### PR TITLE
Fix current working directory bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ results
 
 npm-debug.log
 
+node_modules/
+
 .ungitrc
 
 report/

--- a/bin/ungit
+++ b/bin/ungit
@@ -7,7 +7,7 @@ var path = require('path');
 var child = new (forever.Monitor)(path.join(__dirname, '..', 'source', 'server.js'), {
 	silent: false,
 	minUptime: 2000,
-	cwd: path.join(__dirname, '..'),
+	cwd: path.join(process.cwd(), '..'),
 	options: []
 });
 


### PR DESCRIPTION
The `__dirname` will point to the global node modules' directory.
