### PR TITLE
Link screenshot to intro video

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The easiest way to use git. On any platform. Anywhere.
 
 Quick intro to ungit: [http://youtu.be/hkBVAi3oKvo](http://youtu.be/hkBVAi3oKvo)
 
-<a href="http://youtu.be/hkBVAi3oKvo"><img src="/screenshot.png" /></a>
+[![Screenshot](/screenshot.png)](http://youtu.be/hkBVAi3oKvo)
 
 Installing
 ----------


### PR DESCRIPTION
When I first saw your readme I tried clicking the screenshot to watch the video, and was surprised it took me to a page with the screenshot in isolation. This pull request makes the picture link to your youtube video.

Note: I had to use regular HTML instead of markdown to make it work. I could see how you might not like this, but I thought it was worth it for the user experience.

by the way, I :heart: this project -- very ingenious.
