### PR TITLE
use monospace on file diffs

### DIFF
--- a/public/less/generic.less
+++ b/public/less/generic.less
@@ -165,6 +165,7 @@ hr {
 	table-layout: fixed;
 	border-radius: 3px;
 	background: rgba(255, 255, 255, 0.1);
+	font-family: @font-family-monospace;
 	.fileDiffLineNumbers {
 		width: 50px;
 		text-align: center;


### PR DESCRIPTION
This way seems easier to read the code.
