### PR TITLE
Add a button to Launch with Cloudify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The easiest way to use git. On any platform. Anywhere.
 Quick intro to ungit: [http://youtu.be/hkBVAi3oKvo](http://youtu.be/hkBVAi3oKvo)
 
 ### Launch and play with your own private instance
-[![Launch with Cloudify](http://rantav.github.io/cloudify-widget-pages/img/gh-button.png)](http://rantav.github.io/cloudify-widget-pages/rethinkdb.html)
+[![Launch with Cloudify](http://rantav.github.io/cloudify-widget-pages/img/gh-button.png)](http://rantav.github.io/cloudify-widget-pages/ungit.html)
 
 ### Screenshots
 


### PR DESCRIPTION
Hi there, in this PR I'm adding a button that lets anyone launch a new live instance of ungit in their browser.  :smile:

When users click on the "Launch with Cloudify" button, they get a dedicated virtual machine that automatically installs ungit for them to play for 20 minutes. 
Under the hood it uses Cloudify to achieve that. 

I work with Gigaspaces, the company behind Cloudify to get community feedback for the new Cloudify product and we chose ungit as one potential use case.

This is a proof of concept, not actual production code, so please don't just merge this PR yet. :wink:
Although just POC, it's functional (and simple at the moment) so feel free to play with it and most importantly - send feedback. 
Ideally, if you like it, I'll make it production ready and if not, I'm very much interested in getting your constructive feedback.

BTW, this isn't yet another PaaS, were not enabling the service on Cloudify's PaaS, we're enabling users to try it out directly from the your site/readme page, it's white-label.
We provide a free trial machine for 20m without any additional cost to users.

Thank you! And looking forward to getting your feedback!
