### PR TITLE
Use a the single lodash package to avoid longer dependency paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   "dependencies": {
     "express": "~3.4.0",
     "superagent": "~0.15.4",
-    "lodash.debounce": "~2.2.1",
-    "lodash.find": "~2.2.1",
-    "lodash.throttle": "~2.2.1",
+    "lodash": "~2.2.1",
     "temp": "0.6.0",
     "socket.io": "0.9.16",
     "moment": "~2.3.0",

--- a/public/source/app.js
+++ b/public/source/app.js
@@ -4,7 +4,7 @@ var ko = require('../vendor/js/knockout-2.2.1');
 var dialogs = require('./dialogs');
 var screens = require('./screens');
 var blockable = require('../../source/utils/blockable');
-var throttle = require('lodash.throttle');
+var _ = require('lodash');
 var superagent = require('../vendor/js/superagent');
 
 
@@ -43,11 +43,11 @@ var AppViewModel = function(browseTo) {
 		console.log('Event:', event);
 	});
 
-	this.workingTreeChanged = blockable(throttle(function() {
+	this.workingTreeChanged = blockable(_.throttle(function() {
 		if (self.content() && self.content() instanceof screens.PathViewModel && self.content().repository())
 			self.content().repository().onWorkingTreeChanged();
 	}, 500));
-	this.gitDirectoryChanged = blockable(throttle(function() {
+	this.gitDirectoryChanged = blockable(_.throttle(function() {
 		if (self.content() && self.content() instanceof screens.PathViewModel && self.content().repository())
 			self.content().repository().onGitDirectoryChanged();
 	}, 500));

--- a/public/source/gerrit.js
+++ b/public/source/gerrit.js
@@ -1,7 +1,7 @@
 
 var ko = require('../vendor/js/knockout-2.2.1');
 var ProgressBarViewModel = require('./controls').ProgressBarViewModel;
-var find = require('lodash.find');
+var _ = require('lodash');
 
 
 var GerritIntegrationViewModel = function(repository) {
@@ -46,7 +46,7 @@ GerritIntegrationViewModel.prototype.initCommitHook = function() {
 	});
 }
 GerritIntegrationViewModel.prototype.getChange = function(changeId) {
-	return find(this.changes(), { data: { id: changeId } });
+	return _.find(this.changes(), { data: { id: changeId } });
 }
 GerritIntegrationViewModel.prototype.getChangeIdFromMessage = function(message) {
 	var changeId = message.split('\n').pop().trim();

--- a/public/source/git-graph.js
+++ b/public/source/git-graph.js
@@ -6,8 +6,7 @@ var GitNodeViewModel = require('./git-node').GitNodeViewModel;
 var RefViewModel = require('./ref.js').RefViewModel;
 var ProgressBarViewModel = require('./controls.js').ProgressBarViewModel;
 var moment = require('moment');
-var debounce = require('lodash.debounce');
-var find = require('lodash.find');
+var _ = require('lodash');
 var GraphViewModel = require('./graph-graphics/graph').GraphViewModel;
 var EdgeViewModel = require('./graph-graphics/edge').EdgeViewModel;
 
@@ -39,7 +38,7 @@ var GitGraphViewModel = function(repository) {
 	this.showDropTargets = ko.computed(function() {
 		return !!self.currentActionContext();
 	});
-	this.scrolledToEnd = debounce(function() {
+	this.scrolledToEnd = _.debounce(function() {
 		self.maxNNodes = self.maxNNodes + 25;
 		self.loadNodesFromApi();
 	}, 1000, true);
@@ -158,7 +157,7 @@ GitGraphViewModel.prototype.getEdge = function(nodeAsha1, nodeBsha1) {
 }
 
 GitGraphViewModel.getHEAD = function(nodes) {
-	return find(nodes, function(node) { return find(node.refs(), 'isLocalHEAD'); });
+	return _.find(nodes, function(node) { return _.find(node.refs(), 'isLocalHEAD'); });
 }
 
 GitGraphViewModel.traverseNodeParents = function(node, nodesById, callback) {

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -1,5 +1,5 @@
 
-var debounce = require('lodash.debounce');
+var _ = require('lodash');
 var ko = require('../vendor/js/knockout-2.2.1');
 var $ = require('../vendor/js/jquery-2.0.0.min');
 require('../vendor/js/jquery.dnd_page_scroll');
@@ -226,7 +226,7 @@ ko.bindingHandlers.autocomplete = {
 
             return true;
         };
-        ko.utils.registerEventHandler(element, "keyup", debounce(handleKeyEvent, 100));
+        ko.utils.registerEventHandler(element, "keyup", _.debounce(handleKeyEvent, 100));
     }
 };
 

--- a/public/source/repository.js
+++ b/public/source/repository.js
@@ -6,7 +6,7 @@ var async = require('async');
 var GerritIntegrationViewModel = require('./gerrit').GerritIntegrationViewModel;
 var StagingViewModel = require('./staging').StagingViewModel;
 var dialogs = require('./dialogs');
-var find = require('lodash.find');
+var _ = require('lodash');
 
 var idCounter = 0;
 var newId = function() { return idCounter++; };
@@ -105,7 +105,7 @@ RemotesViewModel.prototype.updateRemotes = function() {
 		self.remotes(remotes);
 		self.repository.graph.hasRemotes(remotes.length != 0);
 		if (!self.currentRemote() && remotes.length > 0) {
-			if (find(remotes, function(r) { return r.name == 'origin' })) // default to origin if it exists
+			if (_.find(remotes, { 'name': 'origin' })) // default to origin if it exists
 				self.currentRemote('origin');
 			else // otherwise take the first one
 				self.currentRemote(remotes[0].name);

--- a/test/spec.git-api.remote.js
+++ b/test/spec.git-api.remote.js
@@ -1,7 +1,7 @@
 
 var expect = require('expect.js');
 var request = require('supertest');
-var find = require('lodash.find');
+var _ = require('lodash');
 var express = require('express');
 var fs = require('fs');
 var path = require('path');
@@ -138,8 +138,8 @@ describe('git-api remote', function () {
 		common.get(req, '/log', { path: testDirLocal2 }, done, function(err, res) {
 			expect(res.body).to.be.a('array');
 			expect(res.body.length).to.be(2);
-			var init = find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
-			var commit2 = find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			var init = _.find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
+			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(init).to.be.ok();
 			expect(commit2).to.be.ok();
 			expect(init.refs).to.contain('HEAD');
@@ -158,8 +158,8 @@ describe('git-api remote', function () {
 		common.get(req, '/log', { path: testDirLocal2 }, done, function(err, res) {
 			expect(res.body).to.be.a('array');
 			expect(res.body.length).to.be(2);
-			var init = find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
-			var commit2 = find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			var init = _.find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
+			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(init).to.be.ok();
 			expect(commit2).to.be.ok();
 			expect(init.refs).to.eql([]);
@@ -186,8 +186,8 @@ describe('git-api remote', function () {
 	it('log in "local2" should show the branch as in sync', function(done) {
 		common.get(req, '/log', { path: testDirLocal2 }, done, function(err, res) {
 			expect(res.body.length).to.be(2);
-			var init = find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
-			var commit2 = find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			var init = _.find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
+			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(init.refs).to.eql([]);
 			expect(commit2.refs).to.contain('HEAD');
 			expect(commit2.refs).to.contain('refs/heads/master');
@@ -214,7 +214,7 @@ describe('git-api remote', function () {
 
 	it('log in "local2" should show the local tag', function(done) {
 		common.get(req, '/log', { path: testDirLocal2 }, done, function(err, res) {
-			var commit2 = find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(commit2.refs).to.contain('tag: refs/tags/v1.0');
 			done();
 		});


### PR DESCRIPTION
Avoids issues brought up in #223
