### PR TITLE
Fixes long commit messages breaking layout: #278

### DIFF
--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -624,3 +624,7 @@ body {
 		}
 	}
 }
+
+.popover {
+	color: black;
+}

--- a/public/source/git-graph.js
+++ b/public/source/git-graph.js
@@ -1,6 +1,7 @@
 
 
 var ko = require('knockout');
+var $ = require('../vendor/js/jquery-2.0.0.min');
 var Vector2 = require('../../source/utils/vector2.js');
 var GitNodeViewModel = require('./git-node').GitNodeViewModel;
 var RefViewModel = require('./ref.js').RefViewModel;
@@ -9,6 +10,8 @@ var moment = require('moment');
 var _ = require('lodash');
 var GraphViewModel = require('./graph-graphics/graph').GraphViewModel;
 var EdgeViewModel = require('./graph-graphics/edge').EdgeViewModel;
+require('../vendor/js/bootstrap/tooltip');
+require('../vendor/js/bootstrap/popover');
 
 var GitGraphViewModel = function(repository) {
   var self = this;
@@ -129,6 +132,7 @@ GitGraphViewModel.prototype.setNodesFromLog = function(nodesData) {
     }
   });
   this.setNodes(nodeVMs);
+  $(".title").popover();
 }
 GitGraphViewModel.prototype.getNode = function(sha1) {
   var nodeViewModel = this.nodesById[sha1];

--- a/public/source/git-node.js
+++ b/public/source/git-node.js
@@ -47,6 +47,7 @@ var GitNodeViewModel = function(graph, sha1) {
   this.parents = ko.observable([]);
   this.message = ko.observable();
   this.title = ko.observable();
+  this.fullTitle = ko.observable();
   this.body = ko.observable();
   this.authorDate = ko.observable(0);
   this.authorDateFromNow = ko.observable();
@@ -129,6 +130,7 @@ GitNodeViewModel.prototype.setData = function(args) {
   var message = args.message.split('\n');
   this.message(args.message);
   this.title(this.trimTitle(message[0]));
+  this.fullTitle(message[0]);
   this.body(message.slice(2).join('\n'));
   this.authorDate(moment(args.authorDate));
   this.authorDateFromNow(this.authorDate().fromNow());

--- a/public/templates/repository.html
+++ b/public/templates/repository.html
@@ -45,7 +45,7 @@
 								onerror="this.style.display='none';">
 							<div>
 								<div>
-									<span class="title" data-bind="text: title"></span>
+									<span class="title" data-bind="text: title, attr: { 'data-content': fullTitle }" rel="popover" data-placement="top" data-trigger="hover"></span>
 									<span class="text-muted">by <a data-bind="text: authorName, attr: { href: 'mailto:' + authorEmail() }"></a></span>
 								</div>
 								<div class="body" data-bind="text: body, visible: showBody"></div>


### PR DESCRIPTION
Fixes long commit messages breaking layout.

![screen shot 2013-12-28 at 11 00 45](https://f.cloud.github.com/assets/5281068/1818133/98b14ab6-6fe2-11e3-9fb1-19bca0b9504d.png)
