### PR TITLE
Fix image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The easiest way to use git. On any platform. Anywhere.
 
 Quick intro to ungit: [http://youtu.be/hkBVAi3oKvo](http://youtu.be/hkBVAi3oKvo)
 
-[![Screenshot](/screenshot.png)](http://youtu.be/hkBVAi3oKvo)
+[![Screenshot](screenshot.png)](http://youtu.be/hkBVAi3oKvo)
 
 Installing
 ----------


### PR DESCRIPTION
I'm not sure why, but currently the screenshot in the README for ungit isn't displaying when I view it on the project's home page on GitHub. This fixes that problem for me.
