### PR TITLE
Fixes long commit messages breaking layout: #278

### DIFF
--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -345,6 +345,15 @@ body {
 			}
 			&.hover {
 				z-index: 3;
+
+				.logEntryBox > .panel-body {
+					.title {
+						font-size: 1.3em;
+						overflow:auto;
+						white-space: inherit;
+						display: inline;
+					}
+				}
 			}
 
 			.logEntryBox > .panel-body {
@@ -370,6 +379,11 @@ body {
 
 				.title {
 					font-size: 1.3em;
+					overflow:hidden;
+					white-space: nowrap;
+					text-overflow: ellipsis;
+					width: 340px;
+					display: block;
 				}
 
 				.body {


### PR DESCRIPTION
Pure CSS solution to #278.  

Displays full text on mouse over.  

![sample](https://f.cloud.github.com/assets/5281068/2048067/5edf9bf6-8a38-11e3-8a66-fafb6e4c1a2b.png)
