### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Known issues
 License (MIT)
 -------------
 
-Copyright (C) 2013 Fredrik Norén
+Copyright (C) 2013-2014 Fredrik Norén
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
