### PR TITLE
Fix #335: git version check override

### DIFF
--- a/bin/ungit
+++ b/bin/ungit
@@ -78,7 +78,7 @@ function verifyGitVersion(callback) {
     } else {
       var versionSearch = /.*(\d+[.]\d+[.]\d+).*/.exec(stdout);
       var requiredVersion = '>=1.8.x';
-      if (!versionSearch) {
+      if (!versionSearch || config.gitVersionCheckOverride) {
         console.log('Failed to parse git version number: ', stdout);
         console.log('Note that Ungit requires git version ' + requiredVersion);
         return callback();

--- a/source/config.js
+++ b/source/config.js
@@ -3,7 +3,7 @@ var optimist = require('optimist');
 var path = require('path');
 
 var defaultConfig = {
-  
+
   // The port ungit is exposed on.
   port: 8448,
 
@@ -30,7 +30,7 @@ var defaultConfig = {
 
   // True to enable authentication. Users are defined in the users configuration property.
   authentication: false,
-  
+
   // Map of username/passwords which are granted access.
   users: undefined,
 
@@ -67,7 +67,7 @@ var defaultConfig = {
   // NOTE: This will execute *before* opening the browser window if the
   //        `launchBrowser` option is `true`.
   // Example:
-  //     # Override the browser launch command; use chrome's "app" 
+  //     # Override the browser launch command; use chrome's "app"
   //     #   argument to get a new, chromeless window for that "native feel"
   //     $ ungit --launchBrowser=0 --launchCommand "chrome --app=%U"
   launchCommand: undefined,
@@ -89,7 +89,10 @@ var defaultConfig = {
 
   // Name-object pairs of configurations for plugins. To disable a plugin, use "disabled": true, for example:
   // "pluginConfigs": { "gerrit": { "disabled": true } }
-  pluginConfigs: {}
+  pluginConfigs: {},
+
+  // Git version check override
+  gitVersionCheckOverride: false
 };
 
 function getUserHome() {


### PR DESCRIPTION
Git version check override

use `node ./bin/ungit --gitVersionCheckOverride` to override ungit's internal git version check.

P.S. used Atom.io for this one, I like the customizability of atom.io but it's still very rough around the edges...
