### PR TITLE
Explicitly notify user when sub commit diff has no changes.

### DIFF
--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -90,7 +90,7 @@ exports.parseGitDiff = function(text) {
         }
       }
     }
-    diff.lines = diff_lines;
+    diff.lines = diff_lines.length > 0 ? diff_lines : [[0, 0, "<There are no changes>"]];
 
     diffs.push(diff);
   }


### PR DESCRIPTION
There are some cases when git shows no changes between files, which are little strange and may need further investigation but below code explicitly handles that case

![screen shot 2014-03-29 at 22 27 50](https://cloud.githubusercontent.com/assets/5281068/2560302/a8a35b82-b7bb-11e3-8d53-1bf767c22d0d.png)
