### PR TITLE
#347: Using escaped carrots for windows on sub commit diff

### DIFF
--- a/source/git.js
+++ b/source/git.js
@@ -12,7 +12,7 @@ var addressParser = require('./address-parser');
 var gitConfigNoColors = '-c color.ui=false';
 var gitConfigNoSlashesInFiles = '-c core.quotepath=false';
 var gitConfigCliPager = '-c core.pager=cat';
-var isWindow = /^win/.test(process.platform);
+var isWindows = /^win/.test(process.platform);
 
 var git = function(command, repoPath, sendToQueue) {
   command = 'git ' + gitConfigNoColors + ' ' + gitConfigNoSlashesInFiles + ' ' + gitConfigCliPager + ' ' + command;
@@ -253,7 +253,7 @@ git.diffFile = function(repoPath, filename, sha1) {
       } else if (sha1 || !file.isNew || fs.lstatSync(filePath).isDirectory()) {
         var gitCommand;
         if (sha1) {
-          gitCommand = 'diff ' + sha1  + (isWindow ? '^^' : '^') + '! -- "' + filename.trim() + '"';
+          gitCommand = 'diff ' + sha1  + (isWindows ? '^^' : '^') + '! -- "' + filename.trim() + '"';
         } else {
           gitCommand = 'diff HEAD -- "' + filename.trim() + '"';
         }


### PR DESCRIPTION
Windows requires escaped carrots for the command when using `^!` short hand.

(as I do not have windows machine I wasn't able to test on it but since @campersau was able to run the command with escaped carrots I believe this will fix the problem.)

Thanks @campersau for the catch!
