### PR TITLE
Fix commit title word wrap

### DIFF
--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -64,7 +64,7 @@
 
         .title {
           font-size: 1.3em;
-          white-space: break-word;
+          word-wrap: break-word;
           display: block;
         }
 


### PR DESCRIPTION
fixes #344

Note that this does not fix very long titles which would require a specific (max-)height:
![image](https://cloud.githubusercontent.com/assets/4009570/2583402/bdbba6f2-b9d0-11e3-934e-2371172b783e.png)
