### PR TITLE
Remove file-stats when added is none numeric

### DIFF
--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -2,7 +2,7 @@
   <div class="file"> 
     <div class="head" data-bind="click: fileNameClick" data-ta-clickable="commitDiffFileName">
       <span data-bind="text: fileName"></span>
-      <span class="file-stats">
+      <span class="file-stats" data-bind="visible: added() != '-'">
         (+<span data-bind="text: added"></span> 
         -<span data-bind="text: removed"></span>)
       </span>


### PR DESCRIPTION
File-stats will show " (+- --) " when binary file change, which is little odd visually to me.  So this fix will remove File-stats and only show file names for diffs between commits when change is not numeric.
