### PR TITLE
Adding a "are you sure?" prompt when user try to get diff between commits that is too big

### DIFF
--- a/components/commitdiff/commitlinediff.js
+++ b/components/commitdiff/commitlinediff.js
@@ -1,6 +1,7 @@
 var ko = require('knockout');
 var components = require('ungit-components');
 var inherits = require('util').inherits;
+var programEvents = require('ungit-program-events');
 
 var imageFileExtensions = ['PNG', 'JPG', 'BMP', 'GIF', 'JPEG'];
 
@@ -19,20 +20,41 @@ var CommitLineDiff = function(args) {
 exports.CommitLineDiff = CommitLineDiff;
 
 CommitLineDiff.prototype.fileNameClick = function(data, event) {
+  var self = this;
+
   if (this.showSpecificDiff()) {
     this.showSpecificDiff(false);
   } else {
-    var self = this;
-    if (this.type() == 'textdiff' && !this.specificDiff().diffs()) {
-      this.specificDiff().invalidateDiff(function() {
-        self.showSpecificDiff(true);
-      });      
+    if (this.added() + this.removed() < 100 || this.isLoaded()) {
+      this.showDiff();
     } else {
-      self.showSpecificDiff(true);
+      var checkPrompt = components.create('yesnodialog', { 'title': 'Are you sure?', 'details': 'Diff is too big, are you sure you want to see the diff?'});
+      checkPrompt.closed.add(function() {
+        if (checkPrompt.result()) {
+          self.showDiff();
+        }
+      });
+      programEvents.dispatch({ event: 'request-show-dialog', dialog: checkPrompt });
     }
   }
+  
   event.stopImmediatePropagation();
 };
+
+CommitLineDiff.prototype.showDiff = function() {
+  var self = this;
+  if (!this.isLoaded()) {
+    this.specificDiff().invalidateDiff(function() {
+      self.showSpecificDiff(true);
+    });      
+  } else {
+    self.showSpecificDiff(true);
+  }
+}
+
+CommitLineDiff.prototype.isLoaded = function() {
+  return this.type() === 'textdiff' && this.specificDiff().diffs();
+}
 
 CommitLineDiff.prototype.type = function() {
   if (!this.fileName()) {


### PR DESCRIPTION
Prompt "are you sure?" when user try to get diff between commits that is over 100 lines.

Perhaps a better location for "are you sure?" check is at the textdiff.js and not at the commitlinediff.js but since textdiff.js doesn't have number of lines changed info this is little difficult.  `git status` doesn't provide a number of changed lines which is disappointing.  

(100 is an arbitrary number but it doesn't really make sense to see more then 100 lines of  diffs in tiny window.  50 maybe even a better number.)
