### PR TITLE
#371 Adding commit title counter

### DIFF
--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -9,13 +9,14 @@
     </div>
     <div class="row" data-bind="visible: !showNux()">
       <div class="col-lg-3">
-        <input class="form-control" data-ta-input="staging-commit-title" type="text" placeholder="Title (required)" data-bind="value: commitMessageTitle, valueUpdate: 'afterkeydown', enable: !inRebase()">
+        <input class="form-control" data-ta-input="staging-commit-title" type="text" placeholder="Title (required)" data-bind="value: commitMessageTitle, valueUpdate: 'afterkeydown', enable: !inRebase()"></input>
         <textarea class="form-control" rows="2" placeholder="Body" data-bind="value: commitMessageBody, valueUpdate: 'afterkeydown', enable: !inRebase()"></textarea>
         <div>
           <span class="amend" data-bind="visible: canAmend">
-                          <span class="checkmark" data-bind="css: { checked: amend }">&#10003;</span>
+                  <span class="checkmark" data-bind="css: { checked: amend }">&#10003;</span>
                           <a href="#" data-bind="click: toogleAmend">Amend last commit</a>
                   </span>
+                  <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
         </div>
         
         <button class="btn btn-primary btn-lg" data-ta-clickable="commit" data-bind="click: commit, visible: commitButtonVisible, enable: !commitValidationError()">

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -15,7 +15,11 @@ var StagingViewModel = function(server, repoPath) {
   this.repoPath = repoPath;
   this.filesByPath = {};
   this.files = ko.observable([]);
+  this.commitMessageTitleCount = ko.observable(0);
   this.commitMessageTitle = ko.observable();
+  this.commitMessageTitle.subscribe(function(value) {
+    self.commitMessageTitleCount(value.length);
+  });
   this.commitMessageBody = ko.observable();
   this.inRebase = ko.observable(false);
   this.inMerge = ko.observable(false);

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -142,3 +142,8 @@
 
 @media (min-width: @screen-lg-min) {
 }
+
+.commit-message-title-counter {
+  right: 20px;
+  position: absolute;
+}


### PR DESCRIPTION
I thought about adding color change as number approaches the github's title character limit.  

But that seems like to platform specific so I decided to leave that out.  
