### PR TITLE
Fix textdiff.js whitespace indention

### DIFF
--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -49,11 +49,11 @@ TextDiffViewModel.prototype.invalidateDiff = function(callback) {
         self.newMode(diff.bMode[1]);
 
         newDiffs.push({
-            oldLineNumber: '-',
-            newLineNumber: '-',
-            added: false,
-            removed: false,
-            text: 'Mode changed from ' + self.oldMode() + ' to ' + self.newMode()
+          oldLineNumber: '-',
+          newLineNumber: '-',
+          added: false,
+          removed: false,
+          text: 'Mode changed from ' + self.oldMode() + ' to ' + self.newMode()
         });
       }
     });


### PR DESCRIPTION
introduced in #373

Build error:

```
Running "less:production" (less) task
File public/css/styles.css created.

Running "jshint:web" (jshint) task
Linting components/textdiff/textdiff.js ...ERROR
[L57:C9] W015: Expected '}' to have an indentation at 11 instead at 9.
        });

Warning: Task "jshint:web" failed. Use --force to continue.

Aborted due to warnings.
```
