### PR TITLE
Colored line addition/subtraction counts

### DIFF
--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -3,8 +3,10 @@
     <div class="head" data-bind="click: fileNameClick" data-ta-clickable="commitDiffFileName">
       <span data-bind="text: fileName"></span>
       <span class="file-stats" data-bind="visible: added() != '-'">
-        (+<span data-bind="text: added"></span> 
-        -<span data-bind="text: removed"></span>)
+        (
+        <span data-bind="text: added"></span> 
+        <span data-bind="text: removed"></span>
+        )
       </span>
     </div>
     <div class="diff" data-bind="visible: showSpecificDiff" data-ta-container="commitLineDiffs">

--- a/components/commitdiff/commitdiff.less
+++ b/components/commitdiff/commitdiff.less
@@ -14,7 +14,14 @@
       color: rgba(255, 255, 255, 0.79);
       word-wrap: break-word;
       .file-stats {
-        color: rgba(201, 255, 132, 0.36);
+        span:nth-of-type(1)::Before{ content: "+" }
+        span:nth-of-type(1){
+          color: #66F27B;
+        }
+        span:nth-of-type(2)::Before{ content: "-" }
+        span:nth-of-type(2){
+          color: #E86756;
+        }
       }
     }
     .diff {


### PR DESCRIPTION
Use css to target the correct span tags that contain the counts for the commit lines.

Added/removed colours are taken from the table row background colors in the diff preview.

![image](https://cloud.githubusercontent.com/assets/791134/3229966/52146110-f09d-11e3-9cd7-e820a376d97c.png)
