### PR TITLE
Graph z-index fix

### DIFF
--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -234,6 +234,9 @@
     display: inline-block;
   }
 
+  svg {
+    z-index: -99;
+  }
 }
 
 


### PR DESCRIPTION
At least in Chrome, depends on how the ungit is loaded, sometimes svg graph loaded later then stash or staging so it covers certain areas and disallow any proper click events. 

![screen shot 2014-08-05 at 21 51 37](https://cloud.githubusercontent.com/assets/5281068/3822492/af2c63ce-1d26-11e4-9bff-d87a18ed9f92.png)
