### PR TITLE
Fix npm eval fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "grunt-plato": "~1.3.0",
     "grunt-contrib-imagemin": "~0.3.0",
     "grunt-image-embed": "0.3.1",
-    "grunt-browserify": "~2.2.0-beta1",
+    "grunt-browserify": "~3.0.1",
     "phantomjs": "~1.9.7-15",
     "ansi-color": "~0.2.1",
     "grunt-contrib-jshint": "~0.10.0",


### PR DESCRIPTION
I don't know how long travis hold on to the logs but here is the link to the current travis error.

grunt-browserify is upgraded to ~3.0.1 and it works fine for me.  

https://s3.amazonaws.com/archive.travis-ci.org/jobs/34256460/log.txt

[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnotarget[0m No compatible version found: grunt-browserify@'>=2.2.0-beta1 <2.3.0-0'
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnotarget[0m Valid install targets:
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnotarget[0m ["0.1.0","0.1.1","0.1.2","0.1.3","0.2.0","0.2.1","0.2.2","0.2.3","0.2.4","0.2.5","1.0.0","1.0.1","1.0.2","1.0.3","1.0.4","1.0.5","1.1.1","1.2.0","1.2.1","1.2.2","1.2.3","1.2.4","1.2.5","1.2.6","1.2.7","1.2.8","1.2.9","1.2.10","1.2.11","1.2.12","1.3.0","1.3.1","1.3.2","2.0.1","2.0.3","2.0.5","2.0.6","2.0.7","2.0.8","2.1.0","2.1.1","2.1.2","2.1.3","2.1.4","3.0.0"]
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnotarget[0m 
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnotarget[0m This is most likely not a problem with npm itself.
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnotarget[0m In most cases you or one of your dependencies are requesting
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnotarget[0m a package version that doesn't exist.
[0m
[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mSystem[0m Linux 2.6.32-042stab090.5
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mcommand[0m "/home/travis/.nvm/v0.10.31/bin/node" "/home/travis/.nvm/v0.10.31/bin/npm" "install"
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mcwd[0m /home/travis/build/FredrikNoren/ungit
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnode -v[0m v0.10.31
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnpm -v[0m 1.4.23
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mcode[0m ETARGET
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m[35m[0m 
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m[35m[0m Additional logging details can be found in:
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m[35m[0m     /home/travis/build/FredrikNoren/ungit/npm-debug.log
[0m[37m[40mnpm[0m [0m[31m[40mERR![0m [0m[35mnot ok[0m code 0
[0m
[31;1mThe command "eval npm install " failed. Retrying, 3 of 3.[0m
