### PR TITLE
Better targeted approach to disable body scroll

### DIFF
--- a/components/commitdiff/commitlinediff.js
+++ b/components/commitdiff/commitlinediff.js
@@ -39,7 +39,7 @@ CommitLineDiff.prototype.type = function() {
 };
 
 CommitLineDiff.prototype.diffMouseover = function(data, event) {
-  programEvents.dispatch({ event: 'body-scroll', scroll: false, scrollHeight: event.target.parentElement.parentElement.parentElement.scrollHeight});
+  programEvents.dispatch({ event: 'body-scroll', scroll: false, eventTarget: event.target});
 }
 
 CommitLineDiff.prototype.diffMouseout = function() {

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -44,11 +44,23 @@ var navigation = require('ungit-navigation');
     }
   });
 
+  // Disable or enable scroll for entire body so scroll in diff box will not over flow to body scroll.
   programEvents.add(function(event) {
     if (event.event === 'body-scroll') {
-      // Hide body scroll bar when scroll bar hide is wanted and diffContainer scroll bar is visible
-      var isDiffScrollShowing = event.scrollHeight > 600;
-      if (!event.scroll && isDiffScrollShowing) {
+      if (!event.scroll) {
+        var eventTargetDom = $(event.eventTarget);
+        if (!eventTargetDom.parents('.expanded').length) {
+          // if not expanded, don't disable scroll bar for body
+          return;
+        }
+        
+        var diffHeight = eventTargetDom.parents('.diffContainer').height();
+        if (diffHeight < 600) {
+          // if displayed diff height is less than maximum height, no scroll bar is showing 
+          // and no reason to disable scroll bar for body.
+          return;
+        }
+        
         $('body').css('overflow','hidden');
       } else {
         $('body').css('overflow','auto');


### PR DESCRIPTION
Disable body scroll only when following conditions are met.
- User scroll mouse over to .diffContainer
- diff container is expanded
- diff container scroll height is bigger than maximum height
