### PR TITLE
Using resolved path for ungit-main  fix: #474

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,7 @@ var semver = require('semver');
 var async = require('async');
 var nodeWebkitBuilds = require('node-webkit-builds');
 var unzip = require('unzip');
+var ungitMain = path.resolve('./public/source/main.js');
 
 module.exports = function(grunt) {
 
@@ -43,7 +44,8 @@ module.exports = function(grunt) {
             './public/source/components.js:ungit-components',
             './public/source/program-events.js:ungit-program-events',
             './public/source/navigation.js:ungit-navigation',
-            './public/source/main.js:ungit-main',
+            ungitMain + ':ungit-main',
+            // './public/source/main.js:ungit-main',
             './source/utils/vector2.js:ungit-vector2',
             './source/address-parser.js:ungit-address-parser',
             'knockout:knockout',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "blueimp-md5": "~1.1.0",
-    "body-parser": "~1.9.3",
+    "body-parser": "~1.10.0",
     "color": "~0.7.3",
     "cookie-parser": "~1.3.3",
     "crossroads": "~0.12.0",


### PR DESCRIPTION
This is going to sound crazy, but here is the fix for #474.

This was working fine and I did reverted recent dependency bump but I was not able to fix it.  I think recent releases at node-browserify have a bug so I was able to fix this via using resolved path.
