### PR TITLE
Make commitdiff object to persist within git-node rather then compute on fly.  fix:#478

### DIFF
--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -75,11 +75,6 @@ var GitNodeViewModel = function(graph, sha1) {
   this.highlighted = ko.computed(function() {
     return self.nodeIsMousehover() || self.selected();
   });
-  this.commitDiff = ko.computed(function() {
-    if ((self.selected() || self.highlighted()) && self.fileLineDiffs()) return components.create('commitDiff', {
-      fileLineDiffs: self.fileLineDiffs().slice(), sha1: self.sha1, repoPath: self.graph.repoPath, server: self.server });
-    else return null;
-  });
   this.showCommitDiff = ko.computed(function() {
     return self.fileLineDiffs() && self.fileLineDiffs().length > 0;
   });
@@ -156,6 +151,12 @@ GitNodeViewModel.prototype.setData = function(args) {
   this.numberOfRemovedLines(args.fileLineDiffs.length > 0 ? args.fileLineDiffs[0][1] : 0);
   this.fileLineDiffs(args.fileLineDiffs);
   this.isInited = true;
+  this.commitDiff = ko.observable(components.create('commitDiff',
+    { fileLineDiffs: this.fileLineDiffs().slice(),
+      sha1: this.sha1,
+      repoPath: this.graph.repoPath,
+      server: this.server,
+      textDiffType: this.textDiffType }));
 }
 GitNodeViewModel.prototype.updateLastAuthorDateFromNow = function(deltaT) {
   this.lastUpdatedAuthorDateFromNow = this.lastUpdatedAuthorDateFromNow || 0;
@@ -188,7 +189,7 @@ GitNodeViewModel.prototype.updateGoalPosition = function() {
     } else {
       goalPosition.y = 120;
     }
-    
+
     goalPosition.x = 30 + 90 * this.branchOrder;
     this.setRadius(15);
   }
@@ -241,7 +242,7 @@ GitNodeViewModel.prototype.toggleSelected = function() {
   var beforeBelowCR = null;
   if (this.belowNode)
     beforeBelowCR = this.belowNode.logBoxElement().getBoundingClientRect();
-  
+
   var prevSelected  = this.graph.currentActionContext();
   if (!(prevSelected instanceof GitNodeViewModel)) prevSelected = null;
   var prevSelectedCR = null;


### PR DESCRIPTION
with "compute", ko recomputes when a user click on "load 50 more" and creates new commitdiff object within git-node.  There for maxNumberOfFilesShown never gets to be bigger then 50 despite user's request as commitdiff is reinitialized via recompute and default back to 50.
