### PR TITLE
Moving refresh button out of staging for no header mode

### DIFF
--- a/clicktests/test.all.js
+++ b/clicktests/test.all.js
@@ -5,3 +5,4 @@ require('./test.remotes');
 require('./test.screens');
 require('./test.submodules');
 require('./test.generic');
+require('./test.noheader');

--- a/clicktests/test.generic.js
+++ b/clicktests/test.generic.js
@@ -31,6 +31,15 @@ suite.test('Open repo screen', function(done) {
   });
 });
 
+suite.test('Check for refresh button', function(done) {
+  helpers.waitForElement(page, '[data-ta-clickable="refresh-button"]', function(err) {
+    helpers.click(page, '[data-ta-clickable="refresh-button"]');
+    setTimeout(function() {
+      done();
+    }, 500);
+  });
+});
+
 suite.test('Should be possible to create and commit a file', function(done) {
   environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
     if (err) return done(err);
@@ -156,7 +165,6 @@ suite.test('Commit changes to a file', function(done) {
     });
   });
 });
-
 
 suite.test('Checkout a branch', function(done) {
   uiInteractions.checkout(page, 'testbranch', done);

--- a/clicktests/test.noheader.js
+++ b/clicktests/test.noheader.js
@@ -1,0 +1,47 @@
+
+var helpers = require('./helpers');
+var testsuite = require('./testsuite');
+var Environment = require('./environment');
+var webpage = require('webpage');
+
+var page = webpage.create();
+var suite = testsuite.newSuite('plugins', page);
+
+var environment;
+var testRepoPath;
+
+suite.test('Init', function(done) {
+  environment = new Environment(page);
+  environment.init(function(err) {
+    if (err) return done(err);
+    testRepoPath = environment.path + '/testrepo';
+    environment.createRepos([
+      { bare: false, path: testRepoPath }
+      ], done);
+  });
+});
+
+
+suite.test('Open path screen', function(done) {
+  page.open('', function() { // Reset path, otherwise the next open don't do anything as it's the same uri
+    page.open(environment.url + '/?noheader=true#/repository?path=' + encodeURIComponent(testRepoPath), function () {
+      helpers.waitForElement(page, '[data-ta-container="repository-view"]', function() {
+        helpers.expectNotFindElement(page, '[data-ta-container="remote-error-popup"]');
+        done();
+      });
+    });
+  });
+});
+
+
+suite.test('Check for refresh button', function(done) {
+  helpers.waitForElement(page, '[data-ta-clickable="refresh-button"]', function(err) {
+    helpers.click(page, '[data-ta-clickable="refresh-button"]');
+    setTimeout(function() {
+      done();
+    }, 500);
+  });
+});
+
+
+testsuite.runAllSuits();

--- a/components/refreshButton/refreshButton.html
+++ b/components/refreshButton/refreshButton.html
@@ -1,5 +1,5 @@
 
-<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="click: refresh" data-toggle="tooltip" data-placement="bottom" data-original-title="Refresh changes" data-delay='{"show":"2000", "hide":"0"}'>
+<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="click: refresh" data-toggle="tooltip" data-placement="bottom" data-original-title="Refresh changes" data-delay='{"show":"2000", "hide":"0"}' data-ta-clickable="refresh-button">
   <span class="glyphicon glyphicon-refresh"></span>
   <!-- ko component: refreshingProgressBar --><!-- /ko -->
 </button>

--- a/components/refreshButton/refreshButton.js
+++ b/components/refreshButton/refreshButton.js
@@ -20,5 +20,5 @@ RefreshButton.prototype.refresh = function() {
   return true;
 }
 RefreshButton.prototype.updateNode = function(parentElement) {
-  ko.renderTemplate('refreshbutton', this, {}, parentElement);
+  ko.renderTemplate('refreshButton', this, {}, parentElement);
 }

--- a/components/refreshButton/refreshButton.js
+++ b/components/refreshButton/refreshButton.js
@@ -20,5 +20,5 @@ RefreshButton.prototype.refresh = function() {
   return true;
 }
 RefreshButton.prototype.updateNode = function(parentElement) {
-  ko.renderTemplate('refreshButton', this, {}, parentElement);
+  ko.renderTemplate('refreshbutton', this, {}, parentElement);
 }

--- a/components/refreshButton/refreshButton.less
+++ b/components/refreshButton/refreshButton.less
@@ -1,6 +1,18 @@
 
-.refresh-button {
-  background: rgba(0, 0, 0, 0.1);
-  border: 0px;
-  font-size: 22px;
+.toolbar {
+  .refresh-button {
+    background: rgba(0, 0, 0, 0.1);
+    border: 0px;
+    font-size: 22px;
+  }
+}
+
+.repository-actions {
+  .refresh-button {
+    background: rgba(84, 101, 101, 1);
+    border: 0px;
+    font-size: 20px;
+    height: 34px;
+    padding-top: 3px;
+  }
 }

--- a/components/repository/repository.html
+++ b/components/repository/repository.html
@@ -23,10 +23,13 @@
   <!-- ko if: showLog -->
 
   <div class="repository-actions">
+    <!-- ko if: refreshButton -->
+      <!-- ko component: refreshButton --><!-- /ko -->
+    <!-- /ko -->
     <!-- ko component: remotes --><!-- /ko -->
     <!-- ko component: submodules --><!-- /ko -->
   </div>
-  
+
   <!-- ko component: graph --><!-- /ko -->
 
   <!-- /ko -->

--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -27,6 +27,11 @@ var RepositoryViewModel = function(server, repoPath) {
   this.parentModulePath = ko.observable();
   this.parentModuleLink = ko.observable();
   this.refreshSubmoduleStatus();
+  if (window.location.search.indexOf('noheader=true') >= 0) {
+    this.refreshButton = components.create('refreshButton');
+  } else {
+    this.refreshButton = false;
+  }
 }
 RepositoryViewModel.prototype.updateNode = function(parentElement) {
   ko.renderTemplate('repository', this, {}, parentElement);

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -18,7 +18,6 @@
                   </span>
                   <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
         </div>
-
         <button class="btn btn-primary btn-lg" data-ta-clickable="commit" data-bind="click: commit, visible: commitButtonVisible, enable: !commitValidationError()">
           Commit
           <!-- ko component: committingProgressBar --><!-- /ko -->
@@ -39,7 +38,6 @@
           Abort merge
           <!-- ko component: mergeAbortProgressBar --><!-- /ko -->
         </button>
-        <!-- ko component: refreshButton --><!-- /ko -->
         <span class="validationError" data-bind="text: commitValidationError, visible: commitValidationError"></span>
       </div>
       <div class="col-lg-9 file-area">

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -78,8 +78,6 @@ var StagingViewModel = function(server, repoPath) {
   this.textDiffType = ko.computed(function() {
     return this.textDiffOptions[this.textDiffTypeIndex()];
   }, this);
-  if (window.location.search.indexOf('noheader=true') >= 0)
-    this.refreshButton = components.create('refreshButton');
 }
 StagingViewModel.prototype.updateNode = function(parentElement) {
   ko.renderTemplate('staging', this, {}, parentElement);


### PR DESCRIPTION
Extension of #502.  Moving refresh button out of staging for no header mode so one can refresh even when there are no files in staging.

Regular: 
![screen shot 2015-02-15 at 3 12 11 pm](https://cloud.githubusercontent.com/assets/5281068/6205508/0aeb5738-b525-11e4-9473-84344958b121.png)

No header mode:
![screen shot 2015-02-15 at 3 06 59 pm](https://cloud.githubusercontent.com/assets/5281068/6205503/e9f740be-b524-11e4-8643-3acccb4547a2.png)
