### PR TITLE
Now backdrop disappering when user click "Don't Load" or "Load Anyway"

### DIFF
--- a/components/dialogs/dialogs.js
+++ b/components/dialogs/dialogs.js
@@ -125,8 +125,8 @@ function TooManyFilesDialogViewModel(title, details) {
   this.taDialogName('yes-no-dialog');
   this.result = ko.observable(false);
   this.alternatives([
-    { label: "Don't load", primary: true, taId: 'noLoad', click: function() { self.result(false); self.close(); } },
-    { label: 'Load anyway', primary: false, taId: 'loadAnyway', click: function() { self.result(true); self.close(); } },
+    { label: "Don't load", primary: true, taId: 'noLoad', click: function() { self.result(false); self.close(); self.removeBackdrop(); } },
+    { label: 'Load anyway', primary: false, taId: 'loadAnyway', click: function() { self.result(true); self.close(); self.removeBackdrop(); } },
   ]);
 }
 inherits(TooManyFilesDialogViewModel, PromptDialogViewModel);


### PR DESCRIPTION
Now backdrop disappering when user click "Don't Load" or "Load Anyway" in *TooManyFilesDialogViewModel* modal box.

It was a bug. Page was remaining 'blackdroped' when user click *Don't load* or *Load Anyway*