### PR TITLE
fix baserepopath for windows

### DIFF
--- a/source/git-api.js
+++ b/source/git-api.js
@@ -498,14 +498,19 @@ exports.registerApi = function(env) {
   app.get(exports.pathPrefix + '/baserepopath', ensureAuthenticated, ensurePathExists, function(req, res){
     var currentPath = path.resolve(path.join(req.query['path'], '..'));
     function isGitDirectory(currentPath) {
-      return fs.existsSync(path.join(currentPath, '.git')) && fs.statSync(path.join(currentPath, '.git')).isDirectory();
+      var gitDirectory = path.join(currentPath, '.git');
+      return fs.existsSync(gitDirectory) && fs.statSync(gitDirectory).isDirectory();
+    }
+    function isRoot(currentPath) {
+      if (os.platform().indexOf('win') == 0) return currentPath.length <= 3;
+      else return currentPath.length <= 1;
     }
 
-    while (currentPath.length > 1 && !isGitDirectory(currentPath)) {
+    while (!isRoot(currentPath) && !isGitDirectory(currentPath)) {
       currentPath = path.resolve(path.join(currentPath, '..'));
     }
 
-    if (currentPath.length > 1) res.json({ path: currentPath });
+    if (isGitDirectory(currentPath)) res.json({ path: currentPath });
     else res.status(404).json({});
   });
 


### PR DESCRIPTION
The `/baserepopath` api resulted in an infinite loop on windows because the length of the root path is 3 and not 1.

The fix in https://github.com/FredrikNoren/ungit/pull/540 didn't work because the `isRoot` function would always return `true` if the path length was ***greater*** than 3 (win) or 1 (other). The change was reverted in https://github.com/FredrikNoren/ungit/pull/551.
 
This fix also checks at the end if `currentPath` is a git directory which allows `subst` git directories on windows to work correctly. (On windows you can create virtual drives which are linked to directories.)

This should now really fix #537, #542

---

~~We could also use [`git rev-parse --show-toplevel`](http://stackoverflow.com/a/957978)~~