### PR TITLE
fix logging git commands

### DIFF
--- a/source/git.js
+++ b/source/git.js
@@ -52,7 +52,7 @@ GitExecutionTask.prototype.timeout = function(timeout) {
 git.runningTasks = [];
 
 var gitQueue = async.queue(function (task, callback) {
-  if (config.logGitCommands) winston.info('git executing: ' + task.repoPath + ' ' + task.commands);
+  if (config.logGitCommands) winston.info('git executing: ' + task.repoPath + ' ' + task.commands.join(' '));
   git.runningTasks.push(task);
   task.startTime = Date.now();
 
@@ -79,7 +79,7 @@ var gitQueue = async.queue(function (task, callback) {
   });
 
   gitProcess.on('close', function (code) {
-    if (config.logGitCommands) winston.info('git result (first 400 bytes): ' + task.command + '\n' + stderr.slice(0, 400) + '\n' + stdout.slice(0, 400));
+    if (config.logGitCommands) winston.info('git result (first 400 bytes): ' + task.commands.join(' ') + '\n' + stderr.slice(0, 400) + '\n' + stdout.slice(0, 400));
 
     if (code != 0) {
       var err = {};


### PR DESCRIPTION
join the `task.commands` values for logging so it is easier to copy and past them into the command prompt