### PR TITLE
use req.query instead of deprecated req.param in /api/fs/exists

### DIFF
--- a/source/server.js
+++ b/source/server.js
@@ -307,7 +307,7 @@ app.post('/api/userconfig', ensureAuthenticated, function(req, res) {
 
 
 app.get('/api/fs/exists', ensureAuthenticated, function(req, res) {
-  res.json(fs.existsSync(req.param('path')));
+  res.json(fs.existsSync(req.query['path']));
 });
 
 app.get('/api/fs/listDirectories', ensureAuthenticated, function(req, res) {


### PR DESCRIPTION
```
2015-05-27T07:34:02.954Z - info: GET /api/fs/exists?path=P%3A%5Cnotexists
Wed, 27 May 2015 07:34:02 GMT express deprecated req.param(name): Use req.params, req.body, or req.query instead at ungit\source\server.js:310:30
```