### PR TITLE
fix credential helper

### DIFF
--- a/source/git-api.js
+++ b/source/git-api.js
@@ -111,7 +111,7 @@ exports.registerApi = function(env) {
 
   function credentialsOption(socketId) {
     var credentialsHelperPath = path.resolve(__dirname, '..', 'bin', 'credentials-helper').replace(/\\/g, '/');
-    return ['-c', 'credential.helper="' + credentialsHelperPath + ' ' + socketId + ' ' + config.port + '"'];
+    return ['-c', 'credential.helper=' + [credentialsHelperPath, socketId, config.port].join(' ')];
   }
 
   app.get(exports.pathPrefix + '/status', ensureAuthenticated, ensurePathExists, function(req, res) {


### PR DESCRIPTION
quotes are not needed when using child_process.spawn

fixes #559