### PR TITLE
cleanup tests after they finished

### DIFF
--- a/test/spec.git-api.branching.js
+++ b/test/spec.git-api.branching.js
@@ -206,4 +206,8 @@ describe('git-api branching', function () {
 		});
 	});
 
-})
+	after(function(done) {
+		common.post(req, '/testing/cleanup', undefined, done);
+	});
+
+});

--- a/test/spec.git-api.conflict-no-auto-stash.js
+++ b/test/spec.git-api.conflict-no-auto-stash.js
@@ -64,4 +64,8 @@ describe('git-api conflict checkout', function () {
 		});
 	});
 
+	after(function(done) {
+		common.post(req, '/testing/cleanup', undefined, done);
+	});
+
 });

--- a/test/spec.git-api.conflict.js
+++ b/test/spec.git-api.conflict.js
@@ -287,5 +287,8 @@ describe('git-api conflict solve by deleting', function () {
 		common.post(req, '/rebase/continue', { path: testDir }, done);
 	});
 
-});
+	after(function(done) {
+		common.post(req, '/testing/cleanup', undefined, done);
+	});
 
+});

--- a/test/spec.git-api.discardchanges.js
+++ b/test/spec.git-api.discardchanges.js
@@ -135,4 +135,9 @@ describe('git-api discardchanges', function() {
       ], done);
     });
   });*/
-})
+
+  after(function(done) {
+    common.post(req, '/testing/cleanup', undefined, done);
+  });
+
+});

--- a/test/spec.git-api.ignorefile.js
+++ b/test/spec.git-api.ignorefile.js
@@ -22,7 +22,7 @@ describe('git-api: test ignorefile call', function () {
       var testFile = 'test.txt';
 
       // Create .gitignore file prior to append
-      fs.writeFileSync(dir + '.gitignore', 'test git ignore file...');
+      fs.writeFileSync(path.join(dir, '.gitignore'), 'test git ignore file...');
 
       async.series([
 
@@ -32,7 +32,7 @@ describe('git-api: test ignorefile call', function () {
           common.get(req, '/status', { path: dir }, function (err, res) {
             if (err) return done(err);
             expect(Object.keys(res.body.files).toString()).to.be('.gitignore');
-            fs.readFile(dir + '/.gitignore', function (err, data) {
+            fs.readFile(path.join(dir, '.gitignore'), function (err, data) {
               if (data.toString().indexOf(testFile) > 0) {
                 done();
               } else {
@@ -59,7 +59,7 @@ describe('git-api: test ignorefile call', function () {
           common.get(req, '/status', { path: dir }, function (err, res) {
             if (err) return done(err);
             expect(Object.keys(res.body.files).toString()).to.be('.gitignore');
-            fs.readFile(dir + '/.gitignore', function (err, data) {
+            fs.readFile(path.join(dir, '.gitignore'), function (err, data) {
               if (data.toString().indexOf(testFile) > 0) {
                 done();
               } else {
@@ -78,7 +78,7 @@ describe('git-api: test ignorefile call', function () {
       var testFile = 'test.txt';
 
       // Add file to .gitignore
-      fs.appendFileSync(dir + '/.gitignore', testFile);
+      fs.appendFileSync(path.join(dir, '.gitignore'), testFile);
 
       async.series([
 
@@ -103,7 +103,7 @@ describe('git-api: test ignorefile call', function () {
       var testFile = 'test.txt';
 
       // add part of file name to gitignore
-      fs.appendFileSync(dir + '/.gitignore', testFile.split('.')[0]);
+      fs.appendFileSync(path.join(dir, '.gitignore'), testFile.split('.')[0]);
 
       async.series([
 
@@ -113,7 +113,7 @@ describe('git-api: test ignorefile call', function () {
           common.get(req, '/status', { path: dir }, function (err, res) {
             if (err) return done(err);
             expect(Object.keys(res.body.files).toString()).to.be('.gitignore');
-            fs.readFile(dir + '/.gitignore', function (err, data) {
+            fs.readFile(path.join(dir, '.gitignore'), function (err, data) {
               if (data.toString().indexOf(testFile) > 0) {
                 done();
               } else {
@@ -125,4 +125,9 @@ describe('git-api: test ignorefile call', function () {
       ], done);
     });
   });
+
+  after(function(done) {
+    common.post(req, '/testing/cleanup', undefined, done);
+  });
+
 });

--- a/test/spec.git-api.js
+++ b/test/spec.git-api.js
@@ -415,7 +415,8 @@ describe('git-api', function () {
     });
   });
 
-  it('cleaning up test dir should work', function(done) {
+  after(function(done) {
     common.post(req, '/testing/cleanup', undefined, done);
   });
+
 })

--- a/test/spec.git-api.remote.js
+++ b/test/spec.git-api.remote.js
@@ -229,11 +229,8 @@ describe('git-api remote', function () {
 		});
 	});
 
-	it('cleaning up test dir should work', function(done) {
-		req
-			.post(restGit.pathPrefix + '/testing/cleanup')
-			.set('Accept', 'application/json')
-			.expect('Content-Type', /json/)
-			.expect(200, done);
+	after(function(done) {
+		common.post(req, '/testing/cleanup', undefined, done);
 	});
+
 });

--- a/test/spec.git-api.stash.js
+++ b/test/spec.git-api.stash.js
@@ -51,5 +51,9 @@ describe('git-api conflict rebase', function () {
 	it('should be possible to drop stash', function(done) {
 		common.delete(req, '/stashes/0', { path: testDir }, done);
 	});
+	
+	after(function(done) {
+		common.post(req, '/testing/cleanup', undefined, done);
+	});
 
-})
+});


### PR DESCRIPTION
Cleanup the `test-temp-dir*` after the tests are done.

Without this change my temp folder was full of `test-temp-dir*` folders and `test-temp-dir*.gitignore` files.