### PR TITLE
fix too many files dialog

### DIFF
--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -118,7 +118,11 @@ StagingViewModel.prototype.refreshContent = function(callback) {
         err.errorCode == 'no-such-path';
     }
 
-    if (Object.keys(status.files).length > filesToDisplayLimit && !self.loadAnyway && !self.isDiagOpen) {
+    if (Object.keys(status.files).length > filesToDisplayLimit && !self.loadAnyway) {
+      if (self.isDiagOpen) {
+        if (callback) callback();
+        return;
+      }
       self.isDiagOpen = true;
       var diag = components.create('TooManyFilesDialogViewModel', { title: 'Too many unstaged files', details: 'It is recommended to use command line as ungit may be too slow.'});
 
@@ -136,14 +140,6 @@ StagingViewModel.prototype.refreshContent = function(callback) {
     } else {
       self.loadStatus(status, callback);
     }
-    self.inRebase(!!status.inRebase);
-    self.inMerge(!!status.inMerge);
-    if (status.inMerge) {
-      var lines = status.commitMessage.split('\n');
-      self.commitMessageTitle(lines[0]);
-      self.commitMessageBody(lines.slice(1).join('\n'));
-    }
-    if (callback) callback();
   });
 }
 StagingViewModel.prototype.loadStatus = function(status, callback) {


### PR DESCRIPTION
before the dialog was shown but if the refresh event for the staging area was fired while the dialog was open the files would be rendered before the dialog was even closed.

this also removes duplicated code for setting `inRebase`, `inMerge` and `commitMessage*` and also makes sure that the `callback` is only called once it is done.

bug introduced with #549