### PR TITLE
Fix with git 2.4.3, non-detached HEAD, causing log messages hidden problem

### DIFF
--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -174,7 +174,7 @@ exports.parseGitLog = function(data) {
     currentCommmit.parents = sha1s.slice(1);
     if (refStartIndex > 0) {
       var refs = row.substring(refStartIndex + 1, row.length - 1);
-      currentCommmit.refs = refs.split(', ');
+      currentCommmit.refs = refs.split(/ -> |, /g);
     }
     commits.push(currentCommmit);
     parser = parseHeaderLine;


### PR DESCRIPTION
From git 2.4.3 release notes
* The "log --decorate" enhancement in Git 2.4 that shows the commit
   at the tip of the current branch e.g. "HEAD -> master", did not
   work with --decorate=full.

This fixes issue #580.