### PR TITLE
Prevent animation on commit diff view expand

### DIFF
--- a/components/commit/commit.less
+++ b/components/commit/commit.less
@@ -32,6 +32,10 @@
           box-shadow: 5px 5px 0px rgba(0, 0, 0, 0.2);
           padding: 10px;
           padding-top: 0px;
+          position: absolute;
+          background-color: #4A5665;
+          width: 100%;
+          border-radius: 0px 0px 3px 3px;
         }
         .btn-group {
           padding: 2px;
@@ -87,7 +91,7 @@
         margin-top: 10px;
         margin-bottom: 10px;
         background: #4B5766;
-        border-radius: 3px;
+        border-radius: 3px 3px 0px 0px;
       }
     }
   }
@@ -103,4 +107,3 @@
     }
   }
 }
-


### PR DESCRIPTION
On git diff, one of the problem is that nodes are pushed down as git diff is expanded and trigger animation.  Which is fine in most cases but in cases when there are a lot of changes it is rather annoying to see animation happening and inefficient.

This fix is to have git diff view to be overlay over nodes rather then pushing them down to trigger animation.