### PR TITLE
Prompt a message in browserify-component grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -218,7 +218,13 @@ module.exports = function(grunt) {
         bundleExternal: false,
         debug: true
       });
-      b.add('./components/' + component + '/' + component + '.js');
+      var src = './components/' + component + '/' + component + '.js';
+      if (!fs.existsSync(src)) {
+        grunt.log.error(src + ' does not exist. If this component is obsolete, ' +
+          'please remove that directory or perform a clean build.');
+        return;
+      }
+      b.add(src);
       b.external(['ungit-components',
               'ungit-program-events',
               'ungit-navigation',


### PR DESCRIPTION
For browserify-components grunt task, prompt a message if the js is not found in a particular component directory.

This helps people who compile from source to identify a compilation problem, after an old component *.js is deleted, but the directory is left.