### PR TITLE
Catch git spawn exception and better array type test

### DIFF
--- a/source/git.js
+++ b/source/git.js
@@ -79,6 +79,9 @@ var gitQueue = async.queue(function (task, callback) {
   gitProcess.stderr.on('data', function(data) {
     stderr += data.toString();
   });
+  gitProcess.on('error', function (error) {
+      callback(error);
+  });
 
   gitProcess.on('close', function (code) {
     if (config.logGitCommands) winston.info('git result (first 400 bytes): ' + task.commands.join(' ') + '\n' + stderr.slice(0, 400) + '\n' + stdout.slice(0, 400));


### PR DESCRIPTION
This modification is to catch the git spawn exception, and fail gracefully in case of errors (like network problems). Moreover, the test to check for type "Array" was not completely accurate