### PR TITLE
Support the use of a URL root path

### DIFF
--- a/bin/ungit
+++ b/bin/ungit
@@ -35,7 +35,7 @@ child.on('exit', function (res) {
 });
 
 function launch(callback) {
-  var currentUrl = config.urlBase + ':' + config.port;
+  var currentUrl = config.urlBase + ':' + config.port + config.rootPath;
   if (config.forcedLaunchPath === undefined) currentUrl += '/#/repository?path=' + encodeURIComponent(process.cwd());
   else if (config.forcedLaunchPath !== null && config.forcedLaunchPath !== '') currentUrl += '/#/repository?path=' + encodeURIComponent(config.forcedLaunchPath);
   console.log('Browse to ' + currentUrl);

--- a/clicktests/environment.js
+++ b/clicktests/environment.js
@@ -11,11 +11,12 @@ function Environment(page, config) {
   this.page = page;
   this.config = config || {};
   this.config.port = this.config.port || 8449;
+  this.config.rootPath = (typeof this.config.rootPath === 'string') ? this.config.rootPath : '/ungit/12324';
   this.config.serverTimeout = this.config.serverTimeout || 15000;
   this.config.viewportSize = this.config.viewportSize || { width: 2000, height: 2000 };
   this.config.showServerOutput = this.config.showServerOutput || false;
   this.config.serverStartupOptions = this.config.serverStartupOptions || [];
-  this.url = 'http://localhost:' + this.config.port;
+  this.url = 'http://localhost:' + this.config.port + this.config.rootPath;
 }
 
 Environment.prototype.init = function(callback) {
@@ -108,6 +109,7 @@ Environment.prototype.startServer = function(callback) {
   var options = ['bin/ungit',
     '--cliconfigonly',
     '--port=' + this.config.port,
+    '--rootPath=' + this.config.rootPath,
     '--no-launchBrowser',
     '--dev',
     '--no-bugtracking',

--- a/clicktests/test.generic.js
+++ b/clicktests/test.generic.js
@@ -5,158 +5,165 @@ var Environment = require('./environment');
 var uiInteractions = require('./ui-interactions.js');
 var webpage = require('webpage');
 
+var rootPaths = [
+  '',
+  '/ungit',
+  '/deep/root/path/to/app'
+];
+  
+rootPaths.forEach(function(rootPath) {
 var page = webpage.create();
-var suite = testsuite.newSuite('generic', page);
+var suite = testsuite.newSuite('generic - rootPath: ' + rootPath, page);
 
 var environment;
 
 var testRepoPath;
 
-suite.test('Init', function(done) {
-  environment = new Environment(page, { serverStartupOptions: ['--no-disableDiscardWarning'] });
-  environment.init(function(err) {
-    if (err) return done(err);
-    testRepoPath = environment.path + '/testrepo';
-    environment.createRepos([
-      { bare: false, path: testRepoPath }
-      ], done);
-  });
-});
-
-suite.test('Open repo screen', function(done) {
-  page.open(environment.url + '/#/repository?path=' + encodeURIComponent(testRepoPath), function () {
-    helpers.waitForElement(page, '.graph', function() {
-      setTimeout(done, 1000); // Let it finnish loading
+  suite.test('Init', function(done) {
+    environment = new Environment(page, { serverStartupOptions: ['--no-disableDiscardWarning'] });
+    environment.init(function(err) {
+      if (err) return done(err);
+      testRepoPath = environment.path + '/testrepo';
+      environment.createRepos([
+        { bare: false, path: testRepoPath }
+        ], done);
     });
   });
-});
-
-suite.test('Check for refresh button', function(done) {
-  helpers.waitForElement(page, '[data-ta-clickable="refresh-button"]', function(err) {
-    helpers.click(page, '[data-ta-clickable="refresh-button"]');
-    setTimeout(function() {
-      done();
-    }, 500);
-  });
-});
-
-suite.test('Should be possible to create and commit a file', function(done) {
-  environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
-    if (err) return done(err);
-    uiInteractions.commit(page, 'Init', function() {
-      helpers.waitForElement(page, '[data-ta-container="node"]', function() {
-        done();
+  
+  suite.test('Open repo screen', function(done) {
+    page.open(environment.url + '/#/repository?path=' + encodeURIComponent(testRepoPath), function () {
+      helpers.waitForElement(page, '.graph', function() {
+        setTimeout(done, 1000); // Let it finnish loading
       });
     });
   });
-});
-
-suite.test('Should be possible to amend a file', function(done) {
-  environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
-    if (err) return done(err);
-    uiInteractions.amendCommit(page, function() {
-      helpers.waitForElement(page, '[data-ta-container="node"]', function() {
-        done();
-      });
-    });
-  });
-});
-
-suite.test('Should be able to add a new file to .gitignore', function(done) {
-  environment.createTestFile(testRepoPath + '/addMeToIgnore.txt', function(err) {
-    if (err) return done(err);
-    helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
-      // add "addMeToIgnore.txt" to .gitignore
-      helpers.click(page, '[data-ta-clickable="ignore-file"]');
-      // add ".gitignore" to .gitignore
-      //TODO I'm not sure what is the best way to detect page refresh, so currently wait for 1 sec and then click ignore-file.
+  
+  suite.test('Check for refresh button', function(done) {
+    helpers.waitForElement(page, '[data-ta-clickable="refresh-button"]', function(err) {
+      helpers.click(page, '[data-ta-clickable="refresh-button"]');
       setTimeout(function() {
-        helpers.click(page, '[data-ta-clickable="ignore-file"]');
-        helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
+        done();
+      }, 500);
+    });
+  });
+  
+  suite.test('Should be possible to create and commit a file', function(done) {
+    environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
+      if (err) return done(err);
+      uiInteractions.commit(page, 'Init', function() {
+        helpers.waitForElement(page, '[data-ta-container="node"]', function() {
           done();
         });
-      }, 1000);
+      });
     });
   });
-});
-
-suite.test('Test showing commit diff between two commits', function(done) {
-  helpers.click(page, '[data-ta-clickable="node-clickable"]');
-  helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-    helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
-    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-      setTimeout(function() {                           // let it finish making api call
-        helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
-        done();
-      }, 1000);
+  
+  suite.test('Should be possible to amend a file', function(done) {
+    environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
+      if (err) return done(err);
+      uiInteractions.amendCommit(page, function() {
+        helpers.waitForElement(page, '[data-ta-container="node"]', function() {
+          done();
+        });
+      });
     });
   });
-});
-
-suite.test('Test showing commit side by side diff between two commits', function(done) {
-  helpers.click(page, '[data-ta-clickable="node-clickable"]');
-  helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-    helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
-    helpers.click(page, '[data-ta-clickable="commit-sideBySideDiff"]');
-    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-      setTimeout(function() {                           // let it finish making api call
-        helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
-        done();
-      }, 1000);
-    });
-  });
-});
-
-suite.test('Should be possible to discard a created file and ensure patching is not avaliable for new file', function(done) {
-  environment.createTestFile(testRepoPath + '/testfile2.txt', function(err) {
-    if (err) return done(err);
-    helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
-      helpers.click(page, '[data-ta-clickable="show-stage-diffs"]');
-      setTimeout(function() {
-        helpers.waitForNotElement(page, '[data-ta-container="patch-file"]', function() {
-          helpers.click(page, '[data-ta-clickable="discard-file"]');
-          helpers.click(page, '[data-ta-clickable="yes"]');
+  
+  suite.test('Should be able to add a new file to .gitignore', function(done) {
+    environment.createTestFile(testRepoPath + '/addMeToIgnore.txt', function(err) {
+      if (err) return done(err);
+      helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
+        // add "addMeToIgnore.txt" to .gitignore
+        helpers.click(page, '[data-ta-clickable="ignore-file"]');
+        // add ".gitignore" to .gitignore
+        //TODO I'm not sure what is the best way to detect page refresh, so currently wait for 1 sec and then click ignore-file.
+        setTimeout(function() {
+          helpers.click(page, '[data-ta-clickable="ignore-file"]');
           helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
             done();
           });
+        }, 1000);
+      });
+    });
+  });
+  
+  suite.test('Test showing commit diff between two commits', function(done) {
+    helpers.click(page, '[data-ta-clickable="node-clickable"]');
+    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+      helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
+      helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+        setTimeout(function() {                           // let it finish making api call
+          helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
+          done();
+        }, 1000);
+      });
+    });
+  });
+
+  suite.test('Test showing commit side by side diff between two commits', function(done) {
+    helpers.click(page, '[data-ta-clickable="node-clickable"]');
+    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+      helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
+      helpers.click(page, '[data-ta-clickable="commit-sideBySideDiff"]');
+      helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+        setTimeout(function() {                           // let it finish making api call
+          helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
+          done();
+        }, 1000);
+      });
+    });
+  });
+  
+  suite.test('Should be possible to discard a created file and ensure patching is not avaliable for new file', function(done) {
+    environment.createTestFile(testRepoPath + '/testfile2.txt', function(err) {
+      if (err) return done(err);
+      helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
+        helpers.click(page, '[data-ta-clickable="show-stage-diffs"]');
+        setTimeout(function() {
+          helpers.waitForNotElement(page, '[data-ta-container="patch-file"]', function() {
+            helpers.click(page, '[data-ta-clickable="discard-file"]');
+            helpers.click(page, '[data-ta-clickable="yes"]');
+            helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
+              done();
+            });
+          });
+        }, 1000);
+      });
+    });
+  });
+
+  suite.test('Should be possible to create a branch', function(done) {
+    uiInteractions.createBranch(page, 'testbranch', done);
+  });
+  
+  
+  suite.test('Should be possible to create and destroy a branch', function(done) {
+    uiInteractions.createBranch(page, 'willbedeleted', function() {
+      helpers.click(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]');
+      helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
+      helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
+        helpers.click(page, '[data-ta-clickable="yes"]');
+        helpers.waitForNotElement(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]', function() {
+          done();
         });
-      }, 1000);
-    });
-  });
-});
-
-suite.test('Should be possible to create a branch', function(done) {
-  uiInteractions.createBranch(page, 'testbranch', done);
-});
-
-
-suite.test('Should be possible to create and destroy a branch', function(done) {
-  uiInteractions.createBranch(page, 'willbedeleted', function() {
-    helpers.click(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]');
-    helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
-    helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
-      helpers.click(page, '[data-ta-clickable="yes"]');
-      helpers.waitForNotElement(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]', function() {
-        done();
       });
     });
   });
-});
-
-suite.test('Should be possible to create and destroy a tag', function(done) {
-  uiInteractions.createTag(page, 'tagwillbedeleted', function() {
-    helpers.click(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');
-    helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
-    helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
-      helpers.click(page, '[data-ta-clickable="yes"]');
-      helpers.waitForNotElement(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]', function() {
-        done();
+  
+  suite.test('Should be possible to create and destroy a tag', function(done) {
+    uiInteractions.createTag(page, 'tagwillbedeleted', function() {
+      helpers.click(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');
+      helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
+      helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
+        helpers.click(page, '[data-ta-clickable="yes"]');
+        helpers.waitForNotElement(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]', function() {
+          done();
+        });
       });
     });
   });
-});
-
-suite.test('Commit changes to a file', function(done) {
+  
+  suite.test('Commit changes to a file', function(done) {
   environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
     if (err) return done(err);
     helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
@@ -166,103 +173,104 @@ suite.test('Commit changes to a file', function(done) {
         helpers.click(page, '[data-ta-clickable="commit"]');
         helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
           done();
-        });
-      }, 100);
+          });
+        }, 100);
+      });
     });
   });
-});
 
-suite.test('Show stats for changed file and discard it', function(done) {
-  environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
-    if (err) return done(err);
-    helpers.waitForElement(page, '[data-ta-container="staging-file"] .additions', function(element) {
-      if (element.textContent != '+1') {
-        return done(new Error('file additions do not match: expected: "+1" but was "' + element.textContent + '"'));
-      }
-      helpers.waitForElement(page, '[data-ta-container="staging-file"] .deletions', function(element) {
-        if (element.textContent != '-1') {
-          return done(new Error('file deletions do not match: expected: "-1" but was "' + element.textContent + '"'));
+  suite.test('Show stats for changed file and discard it', function(done) {
+    environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
+      if (err) return done(err);
+      helpers.waitForElement(page, '[data-ta-container="staging-file"] .additions', function(element) {
+        if (element.textContent != '+1') {
+          return done(new Error('file additions do not match: expected: "+1" but was "' + element.textContent + '"'));
         }
-        helpers.click(page, '[data-ta-clickable="discard-file"]');
-        helpers.click(page, '[data-ta-clickable="yes"]');
-        helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
+        helpers.waitForElement(page, '[data-ta-container="staging-file"] .deletions', function(element) {
+          if (element.textContent != '-1') {
+            return done(new Error('file deletions do not match: expected: "-1" but was "' + element.textContent + '"'));
+          }
+          helpers.click(page, '[data-ta-clickable="discard-file"]');
+          helpers.click(page, '[data-ta-clickable="yes"]');
+          helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
+            done();
+          });
+        });
+      });
+    });
+  });
+    
+  suite.test('Should be possible to patch a file', function(done) {
+    environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
+      if (err) return done(err);
+      uiInteractions.patch(page, 'Patch', function() {
+        helpers.waitForElement(page, '[data-ta-container="node"]', function() {
           done();
         });
       });
     });
   });
-});
 
-suite.test('Should be possible to patch a file', function(done) {
-  environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
-    if (err) return done(err);
-    uiInteractions.patch(page, 'Patch', function() {
-      helpers.waitForElement(page, '[data-ta-container="node"]', function() {
-        done();
-      });
+  suite.test('Checkout a branch', function(done) {
+    uiInteractions.checkout(page, 'testbranch', done);
+  });
+  
+  suite.test('Create another commit', function(done) {
+    environment.createTestFile(testRepoPath + '/testy2.txt', function(err) {
+      if (err) return done(err);
+      uiInteractions.commit(page, 'Branch commit', done);
     });
   });
-});
-
-suite.test('Checkout a branch', function(done) {
-  uiInteractions.checkout(page, 'testbranch', done);
-});
-
-suite.test('Create another commit', function(done) {
-  environment.createTestFile(testRepoPath + '/testy2.txt', function(err) {
-    if (err) return done(err);
-    uiInteractions.commit(page, 'Branch commit', done);
+  
+  suite.test('Rebase', function(done) {
+    uiInteractions.refAction(page, 'testbranch', true, 'rebase', done);
   });
-});
-
-suite.test('Rebase', function(done) {
-  uiInteractions.refAction(page, 'testbranch', true, 'rebase', done);
-});
-
-suite.test('Checkout master again', function(done) {
-  uiInteractions.checkout(page, 'master', done);
-});
-
-suite.test('Create yet another commit', function(done) {
-  environment.createTestFile(testRepoPath + '/testy3.txt', function(err) {
-    if (err) return done(err);
-    uiInteractions.commit(page, 'Branch commit', done);
+  
+  suite.test('Checkout master again', function(done) {
+    uiInteractions.checkout(page, 'master', done);
   });
-});
-
-suite.test('Merge', function(done) {
-  uiInteractions.refAction(page, 'testbranch', true, 'merge', done);
-});
-
-
-suite.test('Should be possible to move a branch', function(done) {
-  uiInteractions.createBranch(page, 'movebranch', function() {
-    uiInteractions.moveRef(page, 'movebranch', 'Init', done);
+  
+  suite.test('Create yet another commit', function(done) {
+    environment.createTestFile(testRepoPath + '/testy3.txt', function(err) {
+      if (err) return done(err);
+      uiInteractions.commit(page, 'Branch commit', done);
+    });
   });
-});
-
-suite.test('Should be possible to click refresh button', function(done) {
-  helpers.click(page, 'button.refresh-button');
-  done();
-});
-
-// Shutdown
-
-suite.test('Go to home screen', function(done) {
-  helpers.click(page, '[data-ta-clickable="home-link"]');
-  helpers.waitForElement(page, '[data-ta-container="home-page"]', function() {
+  
+  suite.test('Merge', function(done) {
+    uiInteractions.refAction(page, 'testbranch', true, 'merge', done);
+  });
+  
+  
+  suite.test('Should be possible to move a branch', function(done) {
+    uiInteractions.createBranch(page, 'movebranch', function() {
+      uiInteractions.moveRef(page, 'movebranch', 'Init', done);
+    });
+  });
+  
+  suite.test('Should be possible to click refresh button', function(done) {
+    helpers.click(page, 'button.refresh-button');
     done();
   });
-});
-
-suite.test('Shutdown server should bring you to connection lost page', function(done) {
-  environment.shutdown(function() {
-    helpers.waitForElement(page, '[data-ta-container="user-error-page"]', function() {
+  
+  // Shutdown
+  
+  suite.test('Go to home screen', function(done) {
+    helpers.click(page, '[data-ta-clickable="home-link"]');
+    helpers.waitForElement(page, '[data-ta-container="home-page"]', function() {
       done();
-      page.close();
     });
-  }, true);
-});
-
-
-testsuite.runAllSuits();
+  });
+  
+  suite.test('Shutdown server should bring you to connection lost page', function(done) {
+    environment.shutdown(function() {
+      helpers.waitForElement(page, '[data-ta-container="user-error-page"]', function() {
+        page.close();
+        done();
+      });
+    }, true);
+  });
+  
+  
+  testsuite.runAllSuits();
+});  

--- a/components/header/header.html
+++ b/components/header/header.html
@@ -1,7 +1,7 @@
 
 <div class="navbar navbar-default navbar-fixed-top">
 
-  <a data-ta-clickable="home-link" class="backlink bootstrap-tooltip" href="/#/" data-toggle="tooltip" data-placement="bottom" data-original-title="Navigate to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
+  <a data-ta-clickable="home-link" class="backlink bootstrap-tooltip" href="#/" data-toggle="tooltip" data-placement="bottom" data-original-title="Navigate to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
     <span class="glyphicon glyphicon-arrow-left glyphicon-circled" data-bind="css: { 'glyph-shown': showBackButton }"></span>
     <img src="images/logo.png">
   </a>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "semver": "~5.0.1",
     "serve-static": "~1.10.0",
     "signals": "~1.0.0",
-    "socket.io": "~1.3.6",
+    "socket.io": "~1.3.7",
     "superagent": "^0.21.0",
     "temp": "~0.8.3",
     "uuid": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "semver": "~5.0.1",
     "serve-static": "~1.10.0",
     "signals": "~1.0.0",
-    "socket.io": "~0.9.16",
+    "socket.io": "~1.3.6",
     "superagent": "^0.21.0",
     "temp": "~0.8.3",
     "uuid": "~2.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=0 ">
-	<link rel="stylesheet" type="text/css" href="/css/styles.css" />
-	<link rel="shortcut icon" href="/favicon.ico" >
+	<link rel="stylesheet" type="text/css" href="__ROOT_PATH__/css/styles.css" />
+	<link rel="shortcut icon" href="__ROOT_PATH__/favicon.ico" >
 	<title>ungit</title>
 </head>
 <body>
@@ -26,8 +26,8 @@
 <!-- /ko -->
 
 <script type="text/javascript">ungit = {}</script>
-<script type="text/javascript" src="/serverdata.js"></script>
-<script type="text/javascript" src="/js/raven.min.js"></script>
+<script type="text/javascript" src="__ROOT_PATH__/serverdata.js"></script>
+<script type="text/javascript" src="__ROOT_PATH__/js/raven.min.js"></script>
 <script type="text/javascript">
 	console.log('App version: ' + ungit.version);
 	if (ungit.config.bugtracking) {
@@ -48,8 +48,8 @@
 
   }
 </script>
-<script type="text/javascript" src="/socket.io/socket.io.js"></script>
-<script type="text/javascript" src="/js/ungit.js"></script>
+<script type="text/javascript" src="__ROOT_PATH__/socket.io/socket.io.js"></script>
+<script type="text/javascript" src="__ROOT_PATH__/js/ungit.js"></script>
 
 <!-- ungit-plugins-placeholder -->
 

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -70,8 +70,7 @@ ko.bindingHandlers.autocomplete = {
         $(element).val($(element).val() + ungit.config.fileSeparator);
       } else if(event.keyCode == 13){
         event.preventDefault();
-        var url = '/#/repository?path=' + encodeURIComponent($(element).val());
-        window.location = url;
+        navigation.browseTo('repository?path=' + encodeURIComponent($(element).val()));
       }
 
       return true;

--- a/public/source/server.js
+++ b/public/source/server.js
@@ -2,6 +2,7 @@
 var signals = require('signals');
 var programEvents = require('ungit-program-events');
 var _ = require('lodash');
+var rootPath = ungit.config && ungit.config.rootPath || '';
 
 function Server() {
 }
@@ -9,7 +10,9 @@ module.exports = Server;
 
 Server.prototype.initSocket = function() {
   var self = this;
-  this.socket = io.connect();
+  this.socket = io.connect('', {
+    path: rootPath + '/socket.io'
+  });
   this.socket.on('error', function(err) {
     self._isConnected(function(connected) {
       if (connected) throw err;
@@ -74,7 +77,7 @@ Server.prototype._httpJsonRequest = function(request, callback) {
 }
 // Check if the server is still alive
 Server.prototype._isConnected = function(callback) {
-  this._httpJsonRequest({ method: 'GET', url: '/api/ping' }, function(err, res) {
+  this._httpJsonRequest({ method: 'GET', url: rootPath + '/api/ping' }, function(err, res) {
     callback(!err && res);
   });
 }
@@ -108,7 +111,7 @@ Server.prototype.query = function(method, path, body, callback) {
   if (body) body.socketId = this.socketId;
   var request = {
     method: method,
-    url: '/api' + path,
+    url: rootPath + '/api' + path,
   }
   if (method == 'GET' || method == 'DELETE') request.query = body;
   else request.body = body;

--- a/source/config.js
+++ b/source/config.js
@@ -10,7 +10,10 @@ var defaultConfig = {
   port: 8448,
 
   // The base URL ungit will be accessible from.
-  urlBase: "http://localhost",
+  urlBase: 'http://localhost',
+  
+  // The URL root path under which ungit will be accesible.
+  rootPath: '',
 
   // Directory to output log files.
   logDirectory: null,
@@ -126,6 +129,7 @@ var argv = yargs
 .describe('cliconfigonly', 'Ignore the default configuration points and only use parameters sent on the command line')
 .describe('port', 'The port ungit is exposed on')
 .describe('urlBase', 'The base URL ungit will be accessible from')
+.describe('rootPath', 'The root path ungit will be accessible from')
 .describe('logDirectory', 'Directory to output log files')
 .describe('logRESTRequests', 'Write REST requests to the log')
 .describe('logGitCommands', 'Write git commands issued to the log')
@@ -155,6 +159,24 @@ var argv = yargs
 .describe('disableDiscardWarning', 'disable warning popup at discard')
 .describe('disableDiscardMuteTime', 'duration of discard warning dialog mute time should it be muted');
 
+function cleanUpRootPath() {
+  var currentRootPath = module.exports.rootPath;
+
+  if (typeof currentRootPath !== 'string') {
+    currentRootPath = '';
+  } else if (currentRootPath !== '') {
+    // must start with a slash
+    if (currentRootPath.charAt(0) !== '/') {
+      currentRootPath = '/' + currentRootPath;
+    }
+    // can not end with a trailing slash
+    if (currentRootPath.charAt(currentRootPath.length - 1) === '/') {
+      currentRootPath = currentRootPath.substring(0, currentRootPath.length - 1);
+    }
+  }
+  module.exports.rootPath = currentRootPath;
+}
+
 // For testing, $0 is grunt.  For credential-parser test, $0 is node
 // When ungit is started normaly, $0 == ungit, and non-hyphenated options exists, show help and exit.
 if (argv.$0 === 'ungit' && argv._ && argv._.length > 0) {
@@ -166,3 +188,5 @@ if (argv.$0 === 'ungit' && argv._ && argv._.length > 0) {
   module.exports = rc('ungit', argv.default(defaultConfig).argv);
 }
 module.exports.homedir = homedir;
+
+cleanUpRootPath();

--- a/source/ungit-plugin.js
+++ b/source/ungit-plugin.js
@@ -60,7 +60,7 @@ UngitPlugin.prototype.compile = function(callback) {
 
     js.forEach(function(filename) {
       tasks.push(function(callback) {
-        callback(null, '<script type="text/javascript" src="plugins/' + self.name + '/' + filename +'"></script>');
+        callback(null, '<script type="text/javascript" src="' + config.rootPath + '/plugins/' + self.name + '/' + filename +'"></script>');
       });
     });
   }
@@ -81,7 +81,7 @@ UngitPlugin.prototype.compile = function(callback) {
     var css = assureArray(exports.css);
     css.forEach(function(cssSource) {
       tasks.push(function(callback) {
-        callback(null, '<link rel="stylesheet" type="text/css" href="/plugins/' + self.name + '/' + cssSource + '" />');
+        callback(null, '<link rel="stylesheet" type="text/css" href="' + config.rootPath + '/plugins/' + self.name + '/' + cssSource + '" />');
       });
     });
   }


### PR DESCRIPTION
It adds support to run ungit under a specific URL root path like http://host:port/root/path .
This fixes https://github.com/FredrikNoren/ungit/issues/313

On the server side, the basic idea is to add a top level middleware in express that rewrites URLs to remove the root path and then moves forward to other middlewares (that do not need any change).
The socket io version had to be bumped up to better support the root path starting with a slash (http://socket.io/docs/migrating-from-0-9/#configuration-differences)

On the client side, there was quite a few changes to support the concept of a root path.

All the tests are succeeding.