### PR TITLE
Remove css font IE fix to fix grunt warning

### DIFF
--- a/public/vendor/less/bootstrap/glyphicons.less
+++ b/public/vendor/less/bootstrap/glyphicons.less
@@ -11,8 +11,7 @@
 @font-face {
   font-family: 'Glyphicons Halflings';
   src: ~"url('@{icon-font-path}@{icon-font-name}.eot')";
-  src: ~"url('@{icon-font-path}@{icon-font-name}.eot?#iefix') format('embedded-opentype')",
-       ~"url('@{icon-font-path}@{icon-font-name}.woff') format('woff')",
+  src: ~"url('@{icon-font-path}@{icon-font-name}.woff') format('woff')",
        ~"url('@{icon-font-path}@{icon-font-name}.ttf') format('truetype')",
        ~"url('@{icon-font-path}@{icon-font-name}.svg#glyphicons-halflingsregular') format('svg')";
 }


### PR DESCRIPTION
Remove css font IE fix to fix grunt warning, as ungit does not support IE below 9