### PR TITLE
Update mocha 2.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "grunt-mocha-test": "~0.12.7",
     "grunt-plato": "~1.3.0",
     "grunt-release": "~0.13.0",
-    "mocha": "~2.2.5",
+    "mocha": "~2.3.3",
     "npm": "~3.1.3",
     "phantomjs": "~1.9.17",
     "supertest": "~0.15.0"


### PR DESCRIPTION
Update mocha 2.3.3
Without that, on Windows, some tests failed due to wrong execution order of test cases.