### PR TITLE
Fix intermittent test failures

### DIFF
--- a/clicktests/environment.js
+++ b/clicktests/environment.js
@@ -157,6 +157,8 @@ Environment.prototype.changeTestFile = function(filename, callback) {
   this.backgroundAction('POST', this.url + '/api/testing/changefile', { file: filename }, callback);
 }
 Environment.prototype.shutdownServer = function(callback) {
+  this.page.onConsoleMessage = undefined;
+  this.page.onError = undefined;
   this.backgroundAction('POST', this.url + '/api/testing/shutdown', undefined, callback);
 }
 Environment.prototype.createTempFolder = function(callback) {


### PR DESCRIPTION
At least for me, intermittent test failures follows after shutdown operation.  And it is possible that ungit's git fetch operation is lagging behind and result in 'git-error' and result in false negative test run.

This was super annoying to track down and confirm but it seems this fix does it.