### PR TITLE
Distributing rootpath amongst tests

### DIFF
--- a/clicktests/environment.js
+++ b/clicktests/environment.js
@@ -11,7 +11,7 @@ function Environment(page, config) {
   this.page = page;
   this.config = config || {};
   this.config.port = this.config.port || 8449;
-  this.config.rootPath = (typeof this.config.rootPath === 'string') ? this.config.rootPath : '/ungit/12324';
+  this.config.rootPath = (typeof this.config.rootPath === 'string') ? this.config.rootPath : '';
   this.config.serverTimeout = this.config.serverTimeout || 15000;
   this.config.viewportSize = this.config.viewportSize || { width: 2000, height: 2000 };
   this.config.showServerOutput = this.config.showServerOutput || false;

--- a/clicktests/test.generic.js
+++ b/clicktests/test.generic.js
@@ -4,273 +4,262 @@ var testsuite = require('./testsuite');
 var Environment = require('./environment');
 var uiInteractions = require('./ui-interactions.js');
 var webpage = require('webpage');
-
-var rootPaths = [
-  '',
-  '/ungit',
-  '/deep/root/path/to/app'
-];
-  
-rootPaths.forEach(function(rootPath) {
 var page = webpage.create();
-var suite = testsuite.newSuite('generic - rootPath: ' + rootPath, page);
+var suite = testsuite.newSuite('generic', page);
 
 var environment;
 
 var testRepoPath;
 
-  suite.test('Init', function(done) {
-    environment = new Environment(page, { serverStartupOptions: ['--no-disableDiscardWarning'] });
-    environment.init(function(err) {
-      if (err) return done(err);
-      testRepoPath = environment.path + '/testrepo';
-      environment.createRepos([
-        { bare: false, path: testRepoPath }
-        ], done);
+suite.test('Init', function(done) {
+  environment = new Environment(page, { serverStartupOptions: ['--no-disableDiscardWarning'], rootPath: '/deep/root/path/to/app' });
+  environment.init(function(err) {
+    if (err) return done(err);
+    testRepoPath = environment.path + '/testrepo';
+    environment.createRepos([
+      { bare: false, path: testRepoPath }
+      ], done);
+  });
+});
+
+suite.test('Open repo screen', function(done) {
+  page.open(environment.url + '/#/repository?path=' + encodeURIComponent(testRepoPath), function () {
+    helpers.waitForElement(page, '.graph', function() {
+      setTimeout(done, 1000); // Let it finnish loading
     });
   });
-  
-  suite.test('Open repo screen', function(done) {
-    page.open(environment.url + '/#/repository?path=' + encodeURIComponent(testRepoPath), function () {
-      helpers.waitForElement(page, '.graph', function() {
-        setTimeout(done, 1000); // Let it finnish loading
-      });
-    });
+});
+
+suite.test('Check for refresh button', function(done) {
+  helpers.waitForElement(page, '[data-ta-clickable="refresh-button"]', function(err) {
+    helpers.click(page, '[data-ta-clickable="refresh-button"]');
+    setTimeout(function() {
+      done();
+    }, 500);
   });
-  
-  suite.test('Check for refresh button', function(done) {
-    helpers.waitForElement(page, '[data-ta-clickable="refresh-button"]', function(err) {
-      helpers.click(page, '[data-ta-clickable="refresh-button"]');
-      setTimeout(function() {
+});
+
+suite.test('Should be possible to create and commit a file', function(done) {
+  environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
+    if (err) return done(err);
+    uiInteractions.commit(page, 'Init', function() {
+      helpers.waitForElement(page, '[data-ta-container="node"]', function() {
         done();
-      }, 500);
-    });
-  });
-  
-  suite.test('Should be possible to create and commit a file', function(done) {
-    environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
-      if (err) return done(err);
-      uiInteractions.commit(page, 'Init', function() {
-        helpers.waitForElement(page, '[data-ta-container="node"]', function() {
-          done();
-        });
       });
     });
   });
-  
-  suite.test('Should be possible to amend a file', function(done) {
-    environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
-      if (err) return done(err);
-      uiInteractions.amendCommit(page, function() {
-        helpers.waitForElement(page, '[data-ta-container="node"]', function() {
-          done();
-        });
-      });
-    });
-  });
-  
-  suite.test('Should be able to add a new file to .gitignore', function(done) {
-    environment.createTestFile(testRepoPath + '/addMeToIgnore.txt', function(err) {
-      if (err) return done(err);
-      helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
-        // add "addMeToIgnore.txt" to .gitignore
-        helpers.click(page, '[data-ta-clickable="ignore-file"]');
-        // add ".gitignore" to .gitignore
-        //TODO I'm not sure what is the best way to detect page refresh, so currently wait for 1 sec and then click ignore-file.
-        setTimeout(function() {
-          helpers.click(page, '[data-ta-clickable="ignore-file"]');
-          helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
-            done();
-          });
-        }, 1000);
-      });
-    });
-  });
-  
-  suite.test('Test showing commit diff between two commits', function(done) {
-    helpers.click(page, '[data-ta-clickable="node-clickable"]');
-    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-      helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
-      helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-        setTimeout(function() {                           // let it finish making api call
-          helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
-          done();
-        }, 1000);
-      });
-    });
-  });
+});
 
-  suite.test('Test showing commit side by side diff between two commits', function(done) {
-    helpers.click(page, '[data-ta-clickable="node-clickable"]');
-    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-      helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
-      helpers.click(page, '[data-ta-clickable="commit-sideBySideDiff"]');
-      helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
-        setTimeout(function() {                           // let it finish making api call
-          helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
-          done();
-        }, 1000);
+suite.test('Should be possible to amend a file', function(done) {
+  environment.createTestFile(testRepoPath + '/testfile.txt', function(err) {
+    if (err) return done(err);
+    uiInteractions.amendCommit(page, function() {
+      helpers.waitForElement(page, '[data-ta-container="node"]', function() {
+        done();
       });
     });
   });
-  
-  suite.test('Should be possible to discard a created file and ensure patching is not avaliable for new file', function(done) {
-    environment.createTestFile(testRepoPath + '/testfile2.txt', function(err) {
-      if (err) return done(err);
-      helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
-        helpers.click(page, '[data-ta-clickable="show-stage-diffs"]');
-        setTimeout(function() {
-          helpers.waitForNotElement(page, '[data-ta-container="patch-file"]', function() {
-            helpers.click(page, '[data-ta-clickable="discard-file"]');
-            helpers.click(page, '[data-ta-clickable="yes"]');
-            helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
-              done();
-            });
-          });
-        }, 1000);
-      });
-    });
-  });
+});
 
-  suite.test('Should be possible to create a branch', function(done) {
-    uiInteractions.createBranch(page, 'testbranch', done);
-  });
-  
-  
-  suite.test('Should be possible to create and destroy a branch', function(done) {
-    uiInteractions.createBranch(page, 'willbedeleted', function() {
-      helpers.click(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]');
-      helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
-      helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
-        helpers.click(page, '[data-ta-clickable="yes"]');
-        helpers.waitForNotElement(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]', function() {
-          done();
-        });
-      });
-    });
-  });
-  
-  suite.test('Should be possible to create and destroy a tag', function(done) {
-    uiInteractions.createTag(page, 'tagwillbedeleted', function() {
-      helpers.click(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');
-      helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
-      helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
-        helpers.click(page, '[data-ta-clickable="yes"]');
-        helpers.waitForNotElement(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]', function() {
-          done();
-        });
-      });
-    });
-  });
-  
-  suite.test('Commit changes to a file', function(done) {
-  environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
+suite.test('Should be able to add a new file to .gitignore', function(done) {
+  environment.createTestFile(testRepoPath + '/addMeToIgnore.txt', function(err) {
     if (err) return done(err);
     helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
-      helpers.click(page, '[data-ta-input="staging-commit-title"]')
-      helpers.write(page, 'My commit message');
+      // add "addMeToIgnore.txt" to .gitignore
+      helpers.click(page, '[data-ta-clickable="ignore-file"]');
+      // add ".gitignore" to .gitignore
+      //TODO I'm not sure what is the best way to detect page refresh, so currently wait for 1 sec and then click ignore-file.
       setTimeout(function() {
-        helpers.click(page, '[data-ta-clickable="commit"]');
+        helpers.click(page, '[data-ta-clickable="ignore-file"]');
         helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
           done();
-          });
-        }, 100);
-      });
+        });
+      }, 1000);
     });
   });
+});
 
-  suite.test('Show stats for changed file and discard it', function(done) {
-    environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
-      if (err) return done(err);
-      helpers.waitForElement(page, '[data-ta-container="staging-file"] .additions', function(element) {
-        if (element.textContent != '+1') {
-          return done(new Error('file additions do not match: expected: "+1" but was "' + element.textContent + '"'));
-        }
-        helpers.waitForElement(page, '[data-ta-container="staging-file"] .deletions', function(element) {
-          if (element.textContent != '-1') {
-            return done(new Error('file deletions do not match: expected: "-1" but was "' + element.textContent + '"'));
-          }
+suite.test('Test showing commit diff between two commits', function(done) {
+  helpers.click(page, '[data-ta-clickable="node-clickable"]');
+  helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+    helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
+    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+      setTimeout(function() {                           // let it finish making api call
+        helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
+        done();
+      }, 1000);
+    });
+  });
+});
+
+suite.test('Test showing commit side by side diff between two commits', function(done) {
+  helpers.click(page, '[data-ta-clickable="node-clickable"]');
+  helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+    helpers.click(page, '[data-ta-clickable="commitDiffFileName"]');
+    helpers.click(page, '[data-ta-clickable="commit-sideBySideDiff"]');
+    helpers.waitForElement(page, '[data-ta-container="commitLineDiffs"]', function() {
+      setTimeout(function() {                           // let it finish making api call
+        helpers.click(page, '[data-ta-clickable="node-clickable"]'); // De-select again
+        done();
+      }, 1000);
+    });
+  });
+});
+
+suite.test('Should be possible to discard a created file and ensure patching is not avaliable for new file', function(done) {
+  environment.createTestFile(testRepoPath + '/testfile2.txt', function(err) {
+    if (err) return done(err);
+    helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
+      helpers.click(page, '[data-ta-clickable="show-stage-diffs"]');
+      setTimeout(function() {
+        helpers.waitForNotElement(page, '[data-ta-container="patch-file"]', function() {
           helpers.click(page, '[data-ta-clickable="discard-file"]');
           helpers.click(page, '[data-ta-clickable="yes"]');
           helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
             done();
           });
         });
+      }, 1000);
+    });
+  });
+});
+
+suite.test('Should be possible to create a branch', function(done) {
+  uiInteractions.createBranch(page, 'testbranch', done);
+});
+
+
+suite.test('Should be possible to create and destroy a branch', function(done) {
+  uiInteractions.createBranch(page, 'willbedeleted', function() {
+    helpers.click(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]');
+    helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
+    helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
+      helpers.click(page, '[data-ta-clickable="yes"]');
+      helpers.waitForNotElement(page, '[data-ta-clickable="branch"][data-ta-name="willbedeleted"]', function() {
+        done();
       });
     });
   });
-    
-  suite.test('Should be possible to patch a file', function(done) {
-    environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
-      if (err) return done(err);
-      uiInteractions.patch(page, 'Patch', function() {
-        helpers.waitForElement(page, '[data-ta-container="node"]', function() {
+});
+
+suite.test('Should be possible to create and destroy a tag', function(done) {
+  uiInteractions.createTag(page, 'tagwillbedeleted', function() {
+    helpers.click(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');
+    helpers.click(page, '[data-ta-action="delete"][data-ta-visible="true"]');
+    helpers.waitForElement(page, '[data-ta-container="yes-no-dialog"]', function() {
+      helpers.click(page, '[data-ta-clickable="yes"]');
+      helpers.waitForNotElement(page, '[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]', function() {
+        done();
+      });
+    });
+  });
+});
+
+suite.test('Commit changes to a file', function(done) {
+environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
+  if (err) return done(err);
+  helpers.waitForElement(page, '[data-ta-container="staging-file"]', function() {
+    helpers.click(page, '[data-ta-input="staging-commit-title"]')
+    helpers.write(page, 'My commit message');
+    setTimeout(function() {
+      helpers.click(page, '[data-ta-clickable="commit"]');
+      helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
+        done();
+        });
+      }, 100);
+    });
+  });
+});
+
+suite.test('Show stats for changed file and discard it', function(done) {
+  environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
+    if (err) return done(err);
+    helpers.waitForElement(page, '[data-ta-container="staging-file"] .additions', function(element) {
+      if (element.textContent != '+1') {
+        return done(new Error('file additions do not match: expected: "+1" but was "' + element.textContent + '"'));
+      }
+      helpers.waitForElement(page, '[data-ta-container="staging-file"] .deletions', function(element) {
+        if (element.textContent != '-1') {
+          return done(new Error('file deletions do not match: expected: "-1" but was "' + element.textContent + '"'));
+        }
+        helpers.click(page, '[data-ta-clickable="discard-file"]');
+        helpers.click(page, '[data-ta-clickable="yes"]');
+        helpers.waitForNotElement(page, '[data-ta-container="staging-file"]', function() {
           done();
         });
       });
     });
   });
+});
 
-  suite.test('Checkout a branch', function(done) {
-    uiInteractions.checkout(page, 'testbranch', done);
-  });
-  
-  suite.test('Create another commit', function(done) {
-    environment.createTestFile(testRepoPath + '/testy2.txt', function(err) {
-      if (err) return done(err);
-      uiInteractions.commit(page, 'Branch commit', done);
-    });
-  });
-  
-  suite.test('Rebase', function(done) {
-    uiInteractions.refAction(page, 'testbranch', true, 'rebase', done);
-  });
-  
-  suite.test('Checkout master again', function(done) {
-    uiInteractions.checkout(page, 'master', done);
-  });
-  
-  suite.test('Create yet another commit', function(done) {
-    environment.createTestFile(testRepoPath + '/testy3.txt', function(err) {
-      if (err) return done(err);
-      uiInteractions.commit(page, 'Branch commit', done);
-    });
-  });
-  
-  suite.test('Merge', function(done) {
-    uiInteractions.refAction(page, 'testbranch', true, 'merge', done);
-  });
-  
-  
-  suite.test('Should be possible to move a branch', function(done) {
-    uiInteractions.createBranch(page, 'movebranch', function() {
-      uiInteractions.moveRef(page, 'movebranch', 'Init', done);
-    });
-  });
-  
-  suite.test('Should be possible to click refresh button', function(done) {
-    helpers.click(page, 'button.refresh-button');
-    done();
-  });
-  
-  // Shutdown
-  
-  suite.test('Go to home screen', function(done) {
-    helpers.click(page, '[data-ta-clickable="home-link"]');
-    helpers.waitForElement(page, '[data-ta-container="home-page"]', function() {
-      done();
-    });
-  });
-  
-  suite.test('Shutdown server should bring you to connection lost page', function(done) {
-    environment.shutdown(function() {
-      helpers.waitForElement(page, '[data-ta-container="user-error-page"]', function() {
-        page.close();
+suite.test('Should be possible to patch a file', function(done) {
+  environment.changeTestFile(testRepoPath + '/testfile.txt', function(err) {
+    if (err) return done(err);
+    uiInteractions.patch(page, 'Patch', function() {
+      helpers.waitForElement(page, '[data-ta-container="node"]', function() {
         done();
       });
-    }, true);
+    });
   });
-  
-  
-  testsuite.runAllSuits();
-});  
+});
+
+suite.test('Checkout a branch', function(done) {
+  uiInteractions.checkout(page, 'testbranch', done);
+});
+
+suite.test('Create another commit', function(done) {
+  environment.createTestFile(testRepoPath + '/testy2.txt', function(err) {
+    if (err) return done(err);
+    uiInteractions.commit(page, 'Branch commit', done);
+  });
+});
+
+suite.test('Rebase', function(done) {
+  uiInteractions.refAction(page, 'testbranch', true, 'rebase', done);
+});
+
+suite.test('Checkout master again', function(done) {
+  uiInteractions.checkout(page, 'master', done);
+});
+
+suite.test('Create yet another commit', function(done) {
+  environment.createTestFile(testRepoPath + '/testy3.txt', function(err) {
+    if (err) return done(err);
+    uiInteractions.commit(page, 'Branch commit', done);
+  });
+});
+
+suite.test('Merge', function(done) {
+  uiInteractions.refAction(page, 'testbranch', true, 'merge', done);
+});
+
+
+suite.test('Should be possible to move a branch', function(done) {
+  uiInteractions.createBranch(page, 'movebranch', function() {
+    uiInteractions.moveRef(page, 'movebranch', 'Init', done);
+  });
+});
+
+suite.test('Should be possible to click refresh button', function(done) {
+  helpers.click(page, 'button.refresh-button');
+  done();
+});
+
+// Shutdown
+suite.test('Go to home screen', function(done) {
+  helpers.click(page, '[data-ta-clickable="home-link"]');
+  helpers.waitForElement(page, '[data-ta-container="home-page"]', function() {
+    done();
+  });
+});
+
+suite.test('Shutdown server should bring you to connection lost page', function(done) {
+  environment.shutdown(function() {
+    helpers.waitForElement(page, '[data-ta-container="user-error-page"]', function() {
+      page.close();
+      done();
+    });
+  }, true);
+});
+
+testsuite.runAllSuits();

--- a/clicktests/test.remotes.js
+++ b/clicktests/test.remotes.js
@@ -14,7 +14,7 @@ var bareRepoPath;
 var testRepoPath;
 
 suite.test('Init', function(done) {
-  environment = new Environment(page);
+  environment = new Environment(page, {rootPath: '/ungit12234'});
   environment.init(function(err) {
     if (err) return done(err);
     bareRepoPath = environment.path + '/barerepo';


### PR DESCRIPTION
part of #629

Distributing rootpaths amongst other tests to speed up test runtime and reduce unnecessary duplicate tests.  