### PR TITLE
More clever on focus animation

### DIFF
--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -98,12 +98,11 @@ var GitNodeViewModel = function(graph, sha1) {
 module.exports = GitNodeViewModel;
 
 GitNodeViewModel.prototype.getGraphAttr = function() {
-  return [this.cx(), this.cy(), this.r()];
+  return [this.cx(), this.cy()];
 }
 GitNodeViewModel.prototype.setGraphAttr = function(val) {
-  this.element().setAttribute('cx', val[0]);
-  this.element().setAttribute('cy', val[1])
-  this.element().setAttribute('r', val[2]);
+  this.element().setAttribute('x', val[0] - 30);
+  this.element().setAttribute('y', val[1] - 30);
 }
 GitNodeViewModel.prototype.render = function() {
   if (!this.isInited) return;

--- a/components/graph/graph-graphics.html
+++ b/components/graph/graph-graphics.html
@@ -35,10 +35,12 @@
     <!-- /ko -->
 
     <!-- ko foreach: nodes -->
-      <circle data-bind="element: element, attr: { fill: color }, event: { mouseover: nodeMouseover, mouseout: nodeMouseout }, click: toggleSelected" data-ta-clickable="node-clickable" />
-      <!-- ko if: selected -->
-        <circle data-bind="attr: { cx: cx, cy: cy, r: r() - 4 }, click: toggleSelected" stroke="#252833" stroke-width="4" fill="transparent" />
-      <!-- /ko -->
+      <svg data-bind="element: element" >
+        <circle data-bind="attr: { r: r, fill: color }, event: { mouseover: nodeMouseover, mouseout: nodeMouseout }, click: toggleSelected" data-ta-clickable="node-clickable" cx="30" cy="30" />
+        <!-- ko if: selected -->
+          <circle data-bind=" attr: { r: r() - 4 }, click: toggleSelected" stroke="#252833" stroke-width="4" fill="transparent" cx="30" cy="30" />
+        <!-- /ko -->
+      </svg>
     <!-- /ko -->
 
     <!-- ko with: hoverGraphActionGraphic -->


### PR DESCRIPTION
One of the problems of the new animation is that inner hollow black circle that appears on a node on click didn't have the mina.elastic animation.  Commit node had elastic animation but it's front layer highlight graphic didn't.  Which really bothered my ADD and OCD.

But recently had an idea to have a nested SVG and animate entire SVG dom instead of individual circle dom and that seems to be a better solution.