### PR TITLE
Minimizing branch actions with icons

### DIFF
--- a/components/graph/git-graph-actions.js
+++ b/components/graph/git-graph-actions.js
@@ -133,6 +133,7 @@ GraphActions.Rebase = function(graph, node) {
 inherits(GraphActions.Rebase, GraphActions.ActionBase);
 GraphActions.Rebase.prototype.text = 'Rebase';
 GraphActions.Rebase.prototype.style = 'rebase';
+GraphActions.Rebase.prototype.icon = 'octicon octicon-repo-forked flip';
 GraphActions.Rebase.prototype.createHoverGraphic = function() {
   var onto = this.graph.currentActionContext();
   if (!onto) return;
@@ -294,6 +295,7 @@ GraphActions.CherryPick = function(graph, node) {
 inherits(GraphActions.CherryPick, GraphActions.ActionBase);
 GraphActions.CherryPick.prototype.text = 'Cherry pick';
 GraphActions.CherryPick.prototype.style = 'cherry-pick';
+GraphActions.CherryPick.prototype.icon = 'octicon octicon-circuit-board';
 GraphActions.CherryPick.prototype.perform = function(callback) {
   var self = this;
   this.server.post('/cherrypick', { path: this.graph.repoPath, name: this.node.sha1 }, function(err) {
@@ -315,6 +317,7 @@ GraphActions.Uncommit = function(graph, node) {
 inherits(GraphActions.Uncommit, GraphActions.ActionBase);
 GraphActions.Uncommit.prototype.text = 'Uncommit';
 GraphActions.Uncommit.prototype.style = 'uncommit';
+GraphActions.Uncommit.prototype.icon = 'octicon octicon-zap';
 GraphActions.Uncommit.prototype.perform = function(callback) {
   var self = this;
   this.server.postPromise('/reset', { path: this.graph.repoPath, to: 'HEAD^', mode: 'mixed' })
@@ -340,6 +343,7 @@ GraphActions.Revert = function(graph, node) {
 inherits(GraphActions.Revert, GraphActions.ActionBase);
 GraphActions.Revert.prototype.text = 'Revert';
 GraphActions.Revert.prototype.style = 'revert';
+GraphActions.Revert.prototype.icon = 'octicon octicon-history';
 GraphActions.Revert.prototype.perform = function(callback) {
   var self = this;
   this.server.postPromise('/revert', { path: this.graph.repoPath, commit: this.node.sha1 })

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -35,7 +35,7 @@
 
         <!-- ko foreach: dropareaGraphActions -->
         <span class="graphAction droparea" data-bind="css: cssClasses, visible: visible, attr: { 'data-ta-action': style, 'data-ta-visible': visible }, event: { mouseover: mouseover, mouseout: mouseout }">
-          <!-- ko if: icon --><span data-bind="css: icon"></span><!-- /ko -->
+          <!-- ko if: icon --><span data-bind="css: icon" class="icon"></span><!-- /ko -->
           <span data-bind="text: text"></span>
           <div class="dropmask" tabIndex="0" role="button" data-bind="dropOver: visible, drop: doPerform, dragEnter: dragEnter, dragLeave: dragLeave, click: doPerform"></div>
           <!-- ko component: performProgressBar --><!-- /ko -->

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -73,8 +73,10 @@
       color: #fff;
       cursor: pointer;
       opacity: 1;
-      transition: opacity 0.2s;
-      -webkit-transition: opacity 0.2s;
+      transition: all 0.5s ease 0.2s;
+      -webkit-transition: all 0.5s ease 0.2s;
+      transition-property: opacity, max-width;
+      -webkit-transition-property: opacity, max-width;
       margin-right: 2.5px;
       margin-left: 2.5px;
       overflow: hidden;
@@ -97,10 +99,10 @@
         margin-right: 6px;
       }
       &.droparea {
-        width: 30px;
+        max-width: 30px;
         padding-left: 7px;
         &:hover {
-          width: auto;
+          max-width: 400px;
         }
       }
       &.dimmed {

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -79,8 +79,20 @@
       margin-left: 2.5px;
       overflow: hidden;
       .icon {
-        &.octicon-git-merge {
+        &.flip {
+          -webkit-transform:rotate(-180deg);
+          -moz-transform:rotate(-180deg);
+          -o-transform:rotate(-180deg);
+          transform:rotate(-180deg);
+        }
+        &.octicon-git-merge,&.octicon-repo-forked, &.octicon-zap {
           margin-left: 3px;
+        }
+        &.octicon-history {
+          margin-left: 2px;
+        }
+        &.glyphicon-remove,&.octicon-circuit-board {
+          margin-left: 1px;
         }
         margin-right: 6px;
       }

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -77,6 +77,20 @@
       -webkit-transition: opacity 0.2s;
       margin-right: 2.5px;
       margin-left: 2.5px;
+      overflow: hidden;
+      .icon {
+        &.octicon-git-merge {
+          margin-left: 3px;
+        }
+        margin-right: 6px;
+      }
+      &.droparea {
+        width: 30px;
+        padding-left: 7px;
+        &:hover {
+          width: auto;
+        }
+      }
       &.dimmed {
         opacity: 0.5;
       }
@@ -93,6 +107,7 @@
         background: rgba(65, 222, 60, 0.9);
       }
       &.move {
+        width: auto;
         background: rgba(0, 0, 0, 0.1);
       }
       &.merge {


### PR DESCRIPTION
One of the problems I see is that ungit can grow horizontally too long when there are many branches, tags or remotes.  So this PR is to add icons to every git actions and expand on mouse over.

Some of the icon choices are questionable but if anybody have better license free icons or svg imgs, please let me know.

(FYI, I'm going wait at least a day before merging my PRs so people can comment on it.)

related: #650

[cherrypick, uncommit, revert]
<img width="519" alt="screen shot 2015-11-25 at 5 09 44 pm" src="https://cloud.githubusercontent.com/assets/5281068/11412888/60069682-9397-11e5-98e5-5c7e95c6d8b2.png">

[push, rebase]
<img width="452" alt="screen shot 2015-11-25 at 5 09 25 pm" src="https://cloud.githubusercontent.com/assets/5281068/11412892/682d4f7c-9397-11e5-8a27-4b6a9555dad7.png">

[merge, push, check out, delete]
<img width="506" alt="screen shot 2015-11-25 at 5 09 13 pm" src="https://cloud.githubusercontent.com/assets/5281068/11412895/6b395eea-9397-11e5-943d-efc70d941041.png">