### PR TITLE
Fix git#resolveConflicts() bug

### DIFF
--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -184,7 +184,7 @@ git.resolveConflicts = function(repoPath, files) {
   var toAdd = [];
   var toRemove = [];
   return Promise.all((files || []).map(function(file) {
-    return fs.isExists(file).then(function(isExist) {
+    return fs.isExists(path.join(repoPath, file)).then(function(isExist) {
       if (isExist) {
         toAdd.push(file);
       } else {


### PR DESCRIPTION
`fs.isExists()` wasn't given a full proper path and failed to check for correct file

cc: @FredrikNoren 

(I believe this is the only fix needed for next release for current FredrikNoren/Ungit#master)