### PR TITLE
fix git submodule parser to support optional keys

### DIFF
--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -218,50 +218,38 @@ exports.parseGitSubmodule = function(text, args) {
     return {};
   }
 
-  var lines = text.trim().split('\n').filter(function(line) {
-    return line;
-  });
-
-  var submodule = {};
+  var submodule;
   var submodules = [];
 
-  var getSubmoduleName = function(line) {
-    submodule.name = line.match(/"(.*?)"/)[1];
-    parser = getPath;
-  };
+  text.trim().split('\n').filter(function(line) {
+    return line;
+  }).forEach(function(line) {
+    if (line.indexOf("[submodule") === 0) {
+      submodule = {};
+      submodules.push(submodule);
+      submodule.name = line.match(/"(.*?)"/)[1];
+    } else {
+      var parts = line.split("=");
+      var key = parts[0].trim();
+      var value = parts.slice(1).join("=").trim();
+      submodule[key] = value;
 
-  var getPath = function(line) {
-    submodule.path = line.substr(line.indexOf("= ") + 1).trim();
-    parser = getUrl;
-  };
+      if (key == "url") {
+        // keep a reference to the raw url
+        var url = submodule.rawUrl = value;
 
-  var getUrl = function(line) {
-    var url = line.substr(line.indexOf("= ") + 1).trim();
+        // When a repo is checkout with ssh or git instead of an url
+        if (url.indexOf('http') != 0) {
+          if (url.indexOf('git:') == 0) { // git
+            url = 'http' + url.substr(url.indexOf(':'));
+          } else { // ssh
+            url = 'http://' + url.substr(url.indexOf('@') + 1).replace(':', '/');
+          }
+        }
 
-    // keep a reference to the raw url
-    submodule.rawUrl = url;
-
-    // When a repo is checkout with ssh or git instead of an url
-    if (url.indexOf('http') != 0) {
-      if (url.indexOf('git:') == 0) { // git
-        url = 'http' + url.substr(url.indexOf(':'));
-      } else { // ssh
-        url = 'http://' + url.substr(url.indexOf('@') + 1).replace(':', '/');
+        submodule.url = url;
       }
     }
-
-    submodule.url = url;
-
-    parser = getSubmoduleName;
-
-    submodules.push(submodule);
-    submodule = {};
-  };
-
-  var parser = getSubmoduleName;
-
-  lines.forEach(function(line) {
-    parser(line);
   });
 
   return submodules;

--- a/test/spec.git-parser.js
+++ b/test/spec.git-parser.js
@@ -30,3 +30,52 @@ describe('git-parse diff on big change', function() {
     });
   });
 });
+
+describe('git-parser submodule', function() {
+  it('should work with empty string', function() {
+    var gitmodules = "";
+    var submodules = gitParser.parseGitSubmodule(gitmodules);
+    expect(submodules).to.be.an('object').and.to.be.empty();
+  });
+  it('should work with name, path and url', function() {
+    var gitmodules = '[submodule "test1"]\npath = /path/to/sub1\nurl = http://example1.com';
+    var submodules = gitParser.parseGitSubmodule(gitmodules);
+    expect(submodules.length).to.be(1);
+    expect(submodules[0].name).to.be('test1');
+    expect(submodules[0].path).to.be('/path/to/sub1');
+    expect(submodules[0].url).to.be('http://example1.com');
+  });
+  it('should work with multiple name, path and url', function() {
+    var gitmodules = [
+      '[submodule "test1"]\npath = /path/to/sub1\nurl = http://example1.com',
+      '[submodule "test2"]\npath = /path/to/sub2\nurl = http://example2.com',
+    ].join('\n');
+    var submodules = gitParser.parseGitSubmodule(gitmodules);
+    expect(submodules.length).to.be(2);
+    expect(submodules[0].name).to.be('test1');
+    expect(submodules[0].path).to.be('/path/to/sub1');
+    expect(submodules[0].url).to.be('http://example1.com');
+    expect(submodules[1].name).to.be('test2');
+    expect(submodules[1].path).to.be('/path/to/sub2');
+    expect(submodules[1].url).to.be('http://example2.com');
+  });
+  it('should work with multiple name, path, url, update, branch, fetchRecurseSubmodules and ignore', function() {
+    var gitmodules = [
+      '[submodule "test1"]\npath = /path/to/sub1\nurl = http://example1.com\nupdate = checkout\nbranch = master\nfetchRecurseSubmodules = true\nignore = all',
+      '[submodule  "test2"]\n\npath   ==/path/to/sub2\nurl= git://example2.com',
+    ].join('\n');
+    var submodules = gitParser.parseGitSubmodule(gitmodules);
+    expect(submodules.length).to.be(2);
+    expect(submodules[0].name).to.be('test1');
+    expect(submodules[0].path).to.be('/path/to/sub1');
+    expect(submodules[0].url).to.be('http://example1.com');
+    expect(submodules[0].update).to.be('checkout');
+    expect(submodules[0].branch).to.be('master');
+    expect(submodules[0].fetchRecurseSubmodules).to.be('true');
+    expect(submodules[0].ignore).to.be('all');
+    expect(submodules[1].name).to.be('test2');
+    expect(submodules[1].path).to.be('=/path/to/sub2');
+    expect(submodules[1].url).to.be('http://example2.com');
+    expect(submodules[1].rawUrl).to.be('git://example2.com');
+  });
+});


### PR DESCRIPTION
This is a more generic parser which does not require keys to be in the correct order.

Also adding some unittests.

---

More information: https://github.com/FredrikNoren/ungit/issues/689#issuecomment-178111189 https://github.com/FredrikNoren/ungit/issues/689#issuecomment-178114940 https://github.com/FredrikNoren/ungit/issues/689#issuecomment-178120923

Fixes #689