### PR TITLE
Log Server Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.0...master)
 ### Added
 - Introduced change log! [#687](https://github.com/FredrikNoren/ungit/issues/687)
+- Improved server and client error logging [#695](https://github.com/FredrikNoren/ungit/pull/695)
 
 ### Fixed
 - Fix crashes due to submodule parsing [#690](https://github.com/FredrikNoren/ungit/issues/690) [#689](https://github.com/FredrikNoren/ungit/issues/689)

--- a/public/source/server.js
+++ b/public/source/server.js
@@ -150,6 +150,7 @@ Server.prototype.query = function(method, path, body, callback) {
       if (error.body) {
         if (error.body.errorCode && error.body.errorCode != 'unknown') errorSummary = error.body.errorCode;
         else if (typeof(error.body.error) == 'string') errorSummary = error.body.error.split('\n')[0];
+        else if (typeof(error.body.message) == 'string') errorSummary = error.body.message;
         else errorSummary = JSON.stringify(error.body.error);
       }
       else errorSummary = error.httpRequest.statusText + ' ' + error.status;
@@ -217,7 +218,11 @@ Server.prototype._onUnhandledBadBackendResponse = function(err, precreatedError)
   else {
     precreatedError.message = 'Backend error: ' + err.errorSummary;
     console.error(err.errorSummary);
-    console.log(precreatedError.stack);
+    var stack = precreatedError.stack;
+    if (err.res.body && err.res.body.stack) {
+      stack += '\nBackend stacktrace:\n' + err.res.body.stack;
+    }
+    console.log(stack);
     Raven.captureException(precreatedError);
     programEvents.dispatch({ event: 'git-crash-error' });
   }

--- a/source/config.js
+++ b/source/config.js
@@ -207,9 +207,3 @@ Object.defineProperty(Error.prototype, 'toJSON', {
   },
   configurable: true
 });
-
-Object.defineProperty(Error.prototype, 'toString', {
-  value: function() {
-    return 'Message: ' + this.message + '\n' + this.stack;
-  }
-});

--- a/source/config.js
+++ b/source/config.js
@@ -194,3 +194,22 @@ if (argv.$0 === 'ungit' && argv._ && argv._.length > 0) {
 module.exports.homedir = homedir;
 
 cleanUpRootPath();
+
+// Errors can not be serialized with JSON.stringify without this fix
+// http://stackoverflow.com/a/18391400
+Object.defineProperty(Error.prototype, 'toJSON', {
+  value: function() {
+    var alt = {};
+    Object.getOwnPropertyNames(this).forEach(function(key) {
+      alt[key] = this[key];
+    }, this);
+    return alt;
+  },
+  configurable: true
+});
+
+Object.defineProperty(Error.prototype, 'toString', {
+  value: function() {
+    return 'Message: ' + this.message + '\n' + this.stack;
+  }
+});

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -111,13 +111,7 @@ exports.registerApi = function(env) {
       }).catch(function(err) {
         res.status(400).json(err);
 
-        if (err instanceof Error) {
-          console.error('Unhandled error: ' + err.message);
-          console.error(err.stack);
-        } else {
-          console.error('Unhandled error');
           console.error(err);
-        }
       });
   }
 

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -110,6 +110,14 @@ exports.registerApi = function(env) {
         res.json(result || {});
       }).catch(function(err) {
         res.status(400).json(err);
+
+        if (err instanceof Error) {
+          console.error('Unhandled error: ' + err.message);
+          console.error(err.stack);
+        } else {
+          console.error('Unhandled error');
+          console.error(err);
+        }
       });
   }
 

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -111,7 +111,13 @@ exports.registerApi = function(env) {
       }).catch(function(err) {
         res.status(400).json(err);
 
-          console.error(err);
+        if (err instanceof Error) {
+           console.error('Unhandled error: ' + err.message);
+           console.error(err.stack);
+         } else {
+           console.error('Unhandled error');
+           console.error(err);
+         }
       });
   }
 

--- a/source/server.js
+++ b/source/server.js
@@ -29,19 +29,6 @@ process.on('uncaughtException', function(err) {
   });
 });
 
-// Errors can not be serialized with JSON.stringify without this fix
-// http://stackoverflow.com/a/18391400
-Object.defineProperty(Error.prototype, 'toJSON', {
-  value: function() {
-    var alt = {};
-    Object.getOwnPropertyNames(this).forEach(function(key) {
-      alt[key] = this[key];
-    }, this);
-    return alt;
-  },
-  configurable: true
-});
-
 winston.remove(winston.transports.Console);
 winston.add(winston.transports.Console, {'timestamp':true});
 if (config.logDirectory)

--- a/source/server.js
+++ b/source/server.js
@@ -29,6 +29,18 @@ process.on('uncaughtException', function(err) {
   });
 });
 
+// Errors can not be serialized with JSON.stringify without this fix
+// http://stackoverflow.com/a/18391400
+Object.defineProperty(Error.prototype, 'toJSON', {
+  value: function() {
+    var alt = {};
+    Object.getOwnPropertyNames(this).forEach(function(key) {
+      alt[key] = this[key];
+    }, this);
+    return alt;
+  },
+  configurable: true
+});
 
 winston.remove(winston.transports.Console);
 winston.add(winston.transports.Console, {'timestamp':true});

--- a/source/server.js
+++ b/source/server.js
@@ -29,6 +29,7 @@ process.on('uncaughtException', function(err) {
   });
 });
 
+
 winston.remove(winston.transports.Console);
 winston.add(winston.transports.Console, {'timestamp':true});
 if (config.logDirectory)


### PR DESCRIPTION
Some recent bugreports (#689, #679) contain client- and serverside logs but they do not contain any useful errors.

The main reasons for this are:
1. [JavaScript `Error`s are not serializable with `JSON.stringify`](http://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify) by default
2. The [`jsonResultOrFailProm`](https://github.com/FredrikNoren/ungit/blob/master/source/git-api.js#L112) does not log anything in case of an error

---

The first commit fixes point 1 by implementing `toJSON` on `Error`.
Before an empty object `{}` would be returned now the response includes all fields of an `Error` object such as `message` and `stack`:
```
{"stack":"Error: Test\n    at exports.parseGitSubmodule (P:\\ungit\\source\\git-parser.js:217:19)\n    at tryCatcher (P:\\ungit\\node_modules\\bluebird\\js\\release\\util.js:11:23)\n    at Promise._settlePromiseFromHandler (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:491:31)\n    at Promise._settlePromise (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:548:18)\n    at Promise._settlePromise0 (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:593:10)\n    at Promise._settlePromises (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:676:18)\n    at Promise._fulfill (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:617:18)\n    at Promise._settlePromise (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:561:21)\n    at Promise._settlePromise0 (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:593:10)\n    at Promise._settlePromises (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:676:18)\n    at Promise._fulfill (P:\\ungit\\node_modules\\bluebird\\js\\release\\promise.js:617:18)\n    at P:\\ungit\\node_modules\\bluebird\\js\\release\\nodeback.js:42:21\n    at fs.js:334:14\n    at P:\\ungit\\node_modules\\npm-registry-client\\node_modules\\graceful-fs\\graceful-fs.js:42:10\n    at FSReqWrap.oncomplete (fs.js:95:15)","message":"Test"}
```
So the errors are visible in the network panel:
![image](https://cloud.githubusercontent.com/assets/4009570/12858302/7126e066-cc4f-11e5-89a4-8996575d3109.png)

---

The second commit logs the information provided by commit 1 in the client console.
![image](https://cloud.githubusercontent.com/assets/4009570/12858307/795c7d22-cc4f-11e5-8773-a1b3dc4b4152.png)

---

The third commit logs errors in the server console and fixes point 2.

```
2016-02-05T20:12:23.945Z - info: GET /api/submodules?path=P%3A%5Cvstup&socketId=3
Unhandled error: Test
ReferenceError: Test
    at exports.parseGitSubmodule (P:\ungit\source\git-parser.js:217:19)
    at tryCatcher (P:\ungit\node_modules\bluebird\js\release\util.js:11:23)
    at Promise._settlePromiseFromHandler (P:\ungit\node_modules\bluebird\js\release\promise.js:491:31)
    at Promise._settlePromise (P:\ungit\node_modules\bluebird\js\release\promise.js:548:18)
    at Promise._settlePromise0 (P:\ungit\node_modules\bluebird\js\release\promise.js:593:10)
    at Promise._settlePromises (P:\ungit\node_modules\bluebird\js\release\promise.js:676:18)
    at Promise._fulfill (P:\ungit\node_modules\bluebird\js\release\promise.js:617:18)
    at Promise._settlePromise (P:\ungit\node_modules\bluebird\js\release\promise.js:561:21)
    at Promise._settlePromise0 (P:\ungit\node_modules\bluebird\js\release\promise.js:593:10)
    at Promise._settlePromises (P:\ungit\node_modules\bluebird\js\release\promise.js:676:18)
    at Promise._fulfill (P:\ungit\node_modules\bluebird\js\release\promise.js:617:18)
    at P:\ungit\node_modules\bluebird\js\release\nodeback.js:42:21
    at fs.js:334:14
    at P:\ungit\node_modules\npm-registry-client\node_modules\graceful-fs\graceful-fs.js:42:10
    at FSReqWrap.oncomplete (fs.js:95:15)
```
