### PR TITLE
consolidating branch registration logic

### DIFF
--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -161,7 +161,6 @@ GitNodeViewModel.prototype.createBranch = function() {
     .then(function() {
       var newRef = self.graph.getRef('refs/heads/' + self.newBranchName());
       newRef.node(self);
-      self.branchesAndLocalTags.push(newRef);
     }).finally(function() {
       self.branchingFormVisible(false);
       self.newBranchName('');
@@ -175,7 +174,6 @@ GitNodeViewModel.prototype.createTag = function() {
     .then(function() {
       var newRef = self.graph.getRef('tag: refs/tags/' + self.newBranchName());
       newRef.node(self);
-      self.branchesAndLocalTags.push(newRef);
     }).finally(function() {
       self.branchingFormVisible(false);
       self.newBranchName('');
@@ -225,9 +223,9 @@ GitNodeViewModel.prototype.removeRef = function(ref) {
   }
 }
 GitNodeViewModel.prototype.pushRef = function(ref) {
-  if (ref.isRemoteTag) {
+  if (ref.isRemoteTag && this.remoteTags.indexOf(ref) < 0) {
     this.remoteTags.push(ref);
-  } else {
+  } else if(this.branchesAndLocalTags.indexOf(ref) < 0) {
     this.branchesAndLocalTags.push(ref);
   }
 }

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -54,10 +54,10 @@ var RefViewModel = function(fullRefName, graph) {
   this.color = this._colorFromHashOfString(this.name);
 
   this.node.subscribe(function(oldNode) {
-    if (oldNode) oldNode.branchesAndLocalTags.remove(self);
+    if (oldNode) oldNode.removeRef(self);
   }, null, "beforeChange");
   this.node.subscribe(function(newNode) {
-    if (newNode && newNode.isLocalTag) newNode.branchesAndLocalTags.push(self);
+    if (newNode) newNode.pushRef(self);
   });
 };
 module.exports = RefViewModel;
@@ -161,7 +161,6 @@ RefViewModel.prototype.createRemoteRef = function(callback) {
       refSpec: this.refName, remoteBranch: this.refName }, function(err) {
         if (!err) {
           var newRef = self.graph.getRef("refs/remotes/" + self.graph.currentRemote() + "/" + self.refName);
-          self.node().remoteTags.push(newRef);
           newRef.node(self.node());
         }
         callback(err);


### PR DESCRIPTION
One of the cause of #685 is due to manually registering created `git-ref` to `git-node` and it was bit confusing.  

We are now only using the logic that automatically associates git-ref to git-node bi-directionally when git-node is assigned to git-ref and not manually configuring association.
