### PR TITLE
Serverside error handling improvement

### DIFF
--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -60,7 +60,7 @@ RepositoryViewModel.prototype.updateAnimationFrame = function(deltaT) {
 RepositoryViewModel.prototype.refreshSubmoduleStatus = function() {
   var self = this;
   this.server.get('/baserepopath', { path: this.repoPath }, function(err, baseRepoPath) {
-    if (err) {
+    if (err || !baseRepoPath.path) {
       self.isSubmodule(false);
       return true;
     }

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -414,9 +414,15 @@ exports.registerApi = function(env) {
 
   app.get(exports.pathPrefix + '/baserepopath', ensureAuthenticated, ensurePathExists, function(req, res){
     var currentPath = path.resolve(path.join(req.query.path, '..'));
-    jsonResultOrFailProm(res, gitPromise(['rev-parse', '--show-toplevel'], currentPath).then(function(baseRepoPath) {
-      return { path: path.resolve(baseRepoPath.trim()) };
-    }));
+    jsonResultOrFailProm(res, gitPromise(['rev-parse', '--show-toplevel'], currentPath)
+      .then(function(baseRepoPath) {
+        return { path: path.resolve(baseRepoPath.trim()) };
+      }).catch(function(e) {
+        if (e.errorCode === 'not-a-repository') {
+          return {};
+        }
+        throw e;
+      }));
   });
 
   app.get(exports.pathPrefix + '/submodules', ensureAuthenticated, ensurePathExists, function(req, res){

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -109,15 +109,8 @@ exports.registerApi = function(env) {
     return promise.then(function(result) {
         res.json(result || {});
       }).catch(function(err) {
+        winston.warn('Responding with ERROR: ', JSON.stringify(err));
         res.status(400).json(err);
-
-        if (err instanceof Error) {
-           console.error('Unhandled error: ' + err.message);
-           console.error(err.stack);
-         } else {
-           console.error('Unhandled error');
-           console.error(err);
-         }
       });
   }
 

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -360,7 +360,7 @@ git.commit = function(repoPath, amend, message, files) {
     return git(['commit', (amend ? '--amend' : ''), '--file=-'], repoPath, null, null, message);
   }).catch(function(err) {
     // ignore the case where nothing were added to be committed
-    if (err.stdout.indexOf("Changes not staged for commit") === -1)
+    if (!err.stdout || err.stdout.indexOf("Changes not staged for commit") === -1)
       throw err;
   });
 }


### PR DESCRIPTION
* Properly handling few errors that are not really errors
* More subdued error logging in serverside
  * Not using "Unhandled" as often client side is handling it
  * Not showing stack trace to reduce humane alertness.


cc: @campersau 

```javascript
> Object.defineProperty(Error.prototype, 'toJSON', {
...   value: function() {
.....     var alt = {};
.....     Object.getOwnPropertyNames(this).forEach(function(key) {
.......       alt[key] = this[key];
.......     }, this);
.....     return alt;
.....   },
...   configurable: true
... });
[Error]
> var m = {a: 1, b: 2}
undefined
> var err = new Error('abc');
undefined
> JSON.stringify(m)
'{"a":1,"b":2}'
> JSON.stringify(err)
'{"stack":"Error: abc\\n    at repl:1:11\\n    at REPLServer.defaultEval (repl.js:252:27)\\n    at bound (domain.js:287:14)\\n    at REPLServer.runBound [as eval] (domain.js:300:12)\\n    at REPLServer.<anonymous> (repl.js:417:12)\\n    at emitOne (events.js:95:20)\\n    at REPLServer.emit (events.js:182:7)\\n    at REPLServer.Interface._onLine (readline.js:211:10)\\n    at REPLServer.Interface._line (readline.js:550:8)\\n    at REPLServer.Interface._ttyWrite (readline.js:827:14)","message":"abc"}'
> 

```