### PR TITLE
Fix maxConcurrentGitOperations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.1...master)
 
+### Fixed
+- Fix maxConcurrentGitOperations not limiting git processes [#707](https://github.com/FredrikNoren/ungit/issues/707)
+
 ## [0.10.1](https://github.com/FredrikNoren/ungit/compare/v0.10.0...v0.10.1)
 ### Added
 - Introduced change log! [#687](https://github.com/FredrikNoren/ungit/issues/687)

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -8,7 +8,7 @@ var _ = require('lodash');
 var isWindows = /^win/.test(process.platform);
 var Promise = require('bluebird');
 var fs = require('./utils/fs-async');
-var async = require('async')
+var async = require('async');
 var gitConfigArguments = ['-c', 'color.ui=false', '-c', 'core.quotepath=false', '-c', 'core.pager=cat'];
 
 /**


### PR DESCRIPTION
Somewhere in the move to a promise based git system, ungit stopped using this config option.  

This changes adds the `maxConcurrentGitOperations` option back.  This change is quite important to me as several repositories only work well with `maxConcurrentGitOperations = 1`.  Without it, ungit complains about `index.lock` files