### PR TITLE
Rebase msg

### DIFF
--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -150,8 +150,8 @@ StagingViewModel.prototype.loadStatus = function(status, callback) {
   this.inRebase(!!status.inRebase);
   this.inMerge(!!status.inMerge);
   if (this.inRebase()) {
-    this.commitMessageTitle('Rebasing...');
-    this.commitMessageBody('');
+    this.commitMessageTitle('Rebase conflict');
+    this.commitMessageBody('Commit messages are not applicable!\n(╯°□°）╯︵ ┻━┻');
   }
 
   if (status.inMerge) {

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -149,6 +149,11 @@ StagingViewModel.prototype.loadStatus = function(status, callback) {
   this.setFiles(status.files);
   this.inRebase(!!status.inRebase);
   this.inMerge(!!status.inMerge);
+  if (this.inRebase()) {
+    this.commitMessageTitle('Rebasing...');
+    this.commitMessageBody('');
+  }
+
   if (status.inMerge) {
     var lines = status.commitMessage.split('\n');
     this.commitMessageTitle(lines[0]);

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -8,6 +8,12 @@
   z-index: 5;
   position: relative;
 
+  .form-control {
+    &:disabled {
+      background-color: rgba(64, 36, 43, 0.75);
+    }
+  }
+
   .arrowDown {
     position: absolute;
     left: (@log-width-small + 45px);


### PR DESCRIPTION
Conflict during rebase white washes commit message boxes as below.  Decided to do more subtle css background coloring for it.  

This only applies to rebase conflicts not merge conflicts.


![screen shot 2016-02-25 at 7 04 37 pm](https://cloud.githubusercontent.com/assets/5281068/13376692/94967078-dd77-11e5-9e8c-d14c29089fa2.png)


<img width="602" alt="screen shot 2016-02-27 at 5 28 03 pm" src="https://cloud.githubusercontent.com/assets/5281068/13376694/9df4f752-dd77-11e5-8f7f-c6d00835e5dd.png">