### PR TITLE
Updated copyright date in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See [CHANGELOG.md](CHANGELOG.md).
 License (MIT)
 -------------
 
-Copyright (C) 2013-2014 Fredrik Norén
+Copyright (C) 2013-2016 Fredrik Norén
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
The copyright date in the _README.md_ file should be updated to 2016.

This change is so small I did not bother changing the _CONTRIBUTING.md_ file. I hope this is OK.