### PR TITLE
Fix ".lock" file conflicts in parallelized git operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 
 ### Fixed
 - Fix maxConcurrentGitOperations not limiting git processes [#707](https://github.com/FredrikNoren/ungit/issues/707)
+- Fix ".lock" file conflicts in parallelized git operations [#515](https://github.com/FredrikNoren/ungit/issues/515)
 
 ### Changed
 - Cleaner rebase conflict message display [#708](https://github.com/FredrikNoren/ungit/pull/708)

--- a/source/config.js
+++ b/source/config.js
@@ -109,7 +109,10 @@ var defaultConfig = {
   disableDiscardWarning: false,
 
   // Duration of discard warning dialog mute time should it be muted.
-  disableDiscardMuteTime: 60 * 1000 * 5  // 5 mins
+  disableDiscardMuteTime: 60 * 1000 * 5,  // 5 mins
+
+  // Allowed number of retry for git "index.lock" conflict
+  lockConflictRetryCount: 3
 };
 
 // Works for now but should be moved to bin/ungit
@@ -156,7 +159,8 @@ var argv = yargs
 .describe('dev', 'Automatically does stash -> operation -> stash pop when you checkout, reset or cherry pick')
 .describe('fileSeparator', 'OS dependent file separator')
 .describe('disableDiscardWarning', 'disable warning popup at discard')
-.describe('disableDiscardMuteTime', 'duration of discard warning dialog mute time should it be muted');
+.describe('disableDiscardMuteTime', 'duration of discard warning dialog mute time should it be muted')
+.describe('lockConflictRetryCount', 'Allowed number of retry for git "index.lock" conflict');
 
 // If not triggered by test, then do strict option check
 if (argv.$0.indexOf('mocha') === -1) {

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -385,7 +385,7 @@ git.commit = function(repoPath, amend, message, files) {
       }
     }
 
-    var commitPromiseChain = new Promise(function(resolve) { resolve() }) // start with dummy
+    var commitPromiseChain = Promise.resolve()
       .then(function() {
         if (toRemove.length > 0) return git(['update-index', '--remove', '--stdin'], repoPath, null, null, toRemove.join('\n'))
       }).then(function() {

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -83,7 +83,8 @@ var gitExecutorProm = function(args, retryCount) {
   }).catch(function(err) {
     if (retryCount > 0 && err.error && err.error.indexOf("index.lock': File exists") > -1) {
       return new Promise(function(resolve) {
-        setTimeout(resolve, Math.floor(Math.random() * (200) + 500));
+        // sleep random amount between 250 ~ 750 ms
+        setTimeout(resolve, Math.floor(Math.random() * (500) + 250));
       }).then(gitExecutorProm.bind(null, args, retryCount - 1));
     } else {
       throw err;
@@ -109,7 +110,7 @@ var git = function(commands, repoPath, allowError, outPipe, inPipe, timeout) {
   args.timeout = args.timeout || 2 * 60 * 1000; // Default timeout tasks after 2 min
   args.startTime = Date.now();
 
-  return gitExecutorProm(args, 3);
+  return gitExecutorProm(args, config.lockConflictRetryCount);
 }
 
 var getGitError = function(args, stderr, stdout) {

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -387,7 +387,7 @@ git.commit = function(repoPath, amend, message, files) {
 
     var commitPromiseChain = Promise.resolve()
       .then(function() {
-        if (toRemove.length > 0) return git(['update-index', '--remove', '--stdin'], repoPath, null, null, toRemove.join('\n'))
+        if (toRemove.length > 0) return git(['update-index', '--remove', '--stdin'], repoPath, null, null, toRemove.join('\n'));
       }).then(function() {
         if (toAdd.length > 0) return git(['update-index', '--add', '--stdin'], repoPath, null, null, toAdd.join('\n'));
       });


### PR DESCRIPTION
fix: #515 
related: #707 

Currently there are race condition in several git operations we do.  I fixed one obvious bug in /commit but for others it was more complicated due to work space change triggers "stash and pop" operations and etc.  So I just ended up added retry with random backoff time like any other parallelized systems does... 

Although this bug will be very unlikely to be appear again I have kept the fix from #707 as it is good to limit number of git operations.
