### PR TITLE
Allow Ungit to functional under sub dir of a git dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 ### Fixed
 - Fix maxConcurrentGitOperations not limiting git processes [#707](https://github.com/FredrikNoren/ungit/issues/707)
 - Fix ".lock" file conflicts in parallelized git operations [#515](https://github.com/FredrikNoren/ungit/issues/515)
+- Allow Ungit to function under sub dir of a git dir [#734](https://github.com/FredrikNoren/ungit/issues/734)
 
 ### Changed
 - Cleaner rebase conflict message display [#708](https://github.com/FredrikNoren/ungit/pull/708)

--- a/clicktests/test.generic.js
+++ b/clicktests/test.generic.js
@@ -6,6 +6,7 @@ var uiInteractions = require('./ui-interactions.js');
 var webpage = require('webpage');
 var page = webpage.create();
 var suite = testsuite.newSuite('generic', page);
+var fs = require('fs');
 
 var environment;
 
@@ -16,9 +17,15 @@ suite.test('Init', function(done) {
   environment.init(function(err) {
     if (err) return done(err);
     testRepoPath = environment.path + '/testrepo';
-    environment.createRepos([
-      { bare: false, path: testRepoPath }
-      ], done);
+    environment.createRepos([ { bare: false, path: testRepoPath } ], function () {
+      // create a sub dir and change working dir to sub dir to prove functionality within subdir
+      testRepoPath += '/asubdir';
+      if (fs.makeDirectory(testRepoPath)) {
+        done();
+      } else {
+        done("failed to make subdir");
+      }
+    });
   });
 });
 

--- a/clicktests/test.generic.js
+++ b/clicktests/test.generic.js
@@ -11,6 +11,7 @@ var fs = require('fs');
 var environment;
 
 var testRepoPath;
+var testRepoPathSubDir;
 
 suite.test('Init', function(done) {
   environment = new Environment(page, { serverStartupOptions: ['--no-disableDiscardWarning'], rootPath: '/deep/root/path/to/app' });
@@ -19,8 +20,8 @@ suite.test('Init', function(done) {
     testRepoPath = environment.path + '/testrepo';
     environment.createRepos([ { bare: false, path: testRepoPath } ], function () {
       // create a sub dir and change working dir to sub dir to prove functionality within subdir
-      testRepoPath += '/asubdir';
-      if (fs.makeDirectory(testRepoPath)) {
+      testRepoPathSubDir = testRepoPath + '/asubdir';
+      if (fs.makeDirectory(testRepoPathSubDir)) {
         done();
       } else {
         done("failed to make subdir");
@@ -30,7 +31,7 @@ suite.test('Init', function(done) {
 });
 
 suite.test('Open repo screen', function(done) {
-  page.open(environment.url + '/#/repository?path=' + encodeURIComponent(testRepoPath), function () {
+  page.open(environment.url + '/#/repository?path=' + encodeURIComponent(testRepoPathSubDir), function () {
     helpers.waitForElementVisible(page, '.graph', function() {
       setTimeout(done, 1000); // Let it finnish loading
     });

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -14,7 +14,7 @@ function BranchesViewModel(server, repoPath) {
   this.repoPath = repoPath;
   this.server = server;
   this.branches = ko.observableArray();
-  this.fetchingProgressBar = components.create('progressBar', { predictionMemoryKey: 'fetching-' + this.repoPath, temporary: true });
+  this.fetchingProgressBar = components.create('progressBar', { predictionMemoryKey: 'fetching-' + this.repoPath(), temporary: true });
   this.current = ko.observable();
   this.fetchLabel = ko.computed(function() {
     if (self.current()) {
@@ -35,7 +35,7 @@ BranchesViewModel.prototype.onProgramEvent = function(event) {
 BranchesViewModel.prototype.checkoutBranch = function(branch) {
   var self = this;
   this.fetchingProgressBar.start();
-  this.server.post('/checkout', { path: this.repoPath, name: branch.name }, function(err) {
+  this.server.post('/checkout', { path: this.repoPath(), name: branch.name }, function(err) {
     if (err) return;
     self.current(branch.name);
     self.fetchingProgressBar.stop();
@@ -44,7 +44,7 @@ BranchesViewModel.prototype.checkoutBranch = function(branch) {
 BranchesViewModel.prototype.updateBranches = function() {
   var self = this;
   this.fetchingProgressBar.start();
-  this.server.get('/branches', { path: this.repoPath }, function(err, branches) {
+  this.server.get('/branches', { path: this.repoPath() }, function(err, branches) {
     if (err) {
       self.current("~error");
       return;
@@ -76,7 +76,7 @@ BranchesViewModel.prototype.branchRemove = function(branch) {
   var diag = components.create('yesnodialog', { title: 'Are you sure?', details: 'This operation cannot be undone with ungit.'});
   diag.closed.add(function() {
     if (diag.result()) {
-      self.server.del('/branches', { name: branch.name, path: self.repoPath }, function(err) {
+      self.server.del('/branches', { name: branch.name, path: self.repoPath() }, function(err) {
         if (!err) {
           programEvents.dispatch({ event: 'working-tree-changed' });
         }

--- a/components/gitErrors/gitErrors.js
+++ b/components/gitErrors/gitErrors.js
@@ -21,7 +21,7 @@ GitErrorsViewModel.prototype.onProgramEvent = function(event) {
   if (event.event == 'git-error') this._handleGitError(event);
 }
 GitErrorsViewModel.prototype._handleGitError = function(event) {
-  if (event.data.repoPath != this.repoPath) return;
+  if (event.data.repoPath != this.repoPath()) return;
   this.gitErrors.push(new GitErrorViewModel(this, this.server, event.data));
 }
 

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -153,7 +153,7 @@ GitNodeViewModel.prototype.showBranchingForm = function() {
 GitNodeViewModel.prototype.createBranch = function() {
   if (!this.canCreateRef()) return;
   var self = this;
-  this.graph.server.postPromise('/branches', { path: this.graph.repoPath, name: this.newBranchName(), startPoint: this.sha1 })
+  this.graph.server.postPromise('/branches', { path: this.graph.repoPath(), name: this.newBranchName(), startPoint: this.sha1 })
     .then(function() {
       var newRef = self.graph.getRef('refs/heads/' + self.newBranchName());
       newRef.node(self);
@@ -166,7 +166,7 @@ GitNodeViewModel.prototype.createBranch = function() {
 GitNodeViewModel.prototype.createTag = function() {
   if (!this.canCreateRef()) return;
   var self = this;
-  this.graph.server.postPromise('/tags', { path: this.graph.repoPath, name: this.newBranchName(), startPoint: this.sha1 })
+  this.graph.server.postPromise('/tags', { path: this.graph.repoPath(), name: this.newBranchName(), startPoint: this.sha1 })
     .then(function() {
       var newRef = self.graph.getRef('tag: refs/tags/' + self.newBranchName());
       newRef.node(self);

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -92,14 +92,14 @@ RefViewModel.prototype.moveTo = function(target, callback) {
 
   if (this.isLocal) {
     if (this.current()) {
-      this.server.post('/reset', { path: this.graph.repoPath, to: target, mode: 'hard' }, callbackWithRefSet);
+      this.server.post('/reset', { path: this.graph.repoPath(), to: target, mode: 'hard' }, callbackWithRefSet);
     } else if (this.isTag) {
-      this.server.post('/tags', { path: this.graph.repoPath, name: this.refName, startPoint: target, force: true }, callbackWithRefSet);
+      this.server.post('/tags', { path: this.graph.repoPath(), name: this.refName, startPoint: target, force: true }, callbackWithRefSet);
     } else {
-      this.server.post('/branches', { path: this.graph.repoPath, name: this.refName, startPoint: target, force: true }, callbackWithRefSet);
+      this.server.post('/branches', { path: this.graph.repoPath(), name: this.refName, startPoint: target, force: true }, callbackWithRefSet);
     }
   } else {
-    var pushReq = { path: this.graph.repoPath, remote: this.remote, refSpec: target, remoteBranch: this.refName };
+    var pushReq = { path: this.graph.repoPath(), remote: this.remote, refSpec: target, remoteBranch: this.refName };
     this.server.post('/push', pushReq, function(err, res) {
         if (err) {
           if (err.errorCode == 'non-fast-forward') {
@@ -122,7 +122,7 @@ RefViewModel.prototype.remove = function(callback) {
   var self = this;
   var url = this.isTag ? '/tags' : '/branches';
   if (this.isRemote) url = '/remote' + url;
-  this.server.del(url, { path: this.graph.repoPath, remote: this.isRemote ? this.remote : null, name: this.refName }, function(err) {
+  this.server.del(url, { path: this.graph.repoPath(), remote: this.isRemote ? this.remote : null, name: this.refName }, function(err) {
     if (!err) {
       self.node().removeRef(self);
       self.graph.refsByRefName[self.name] = undefined;
@@ -157,7 +157,7 @@ RefViewModel.prototype.canBePushed = function(remote) {
 
 RefViewModel.prototype.createRemoteRef = function(callback) {
   var self = this;
-  this.server.post('/push', { path: this.graph.repoPath, remote: this.graph.currentRemote(),
+  this.server.post('/push', { path: this.graph.repoPath(), remote: this.graph.currentRemote(),
       refSpec: this.refName, remoteBranch: this.refName }, function(err) {
         if (!err) {
           var newRef = self.graph.getRef("refs/remotes/" + self.graph.currentRemote() + "/" + self.refName);

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -17,7 +17,7 @@ function GraphViewModel(server, repoPath) {
   this.server = server;
   this.currentRemote = ko.observable();
   this.nodesLoader = components.create('progressBar', {
-    predictionMemoryKey: 'gitgraph-' + self.repoPath,
+    predictionMemoryKey: 'gitgraph-' + self.repoPath(),
     fallbackPredictedTimeMs: 1000,
     temporary: true
   });
@@ -101,7 +101,7 @@ GraphViewModel.prototype.loadNodesFromApi = function(callback) {
   var self = this;
 
   this.nodesLoader.start();
-  this.server.getPromise('/log', { path: this.repoPath, limit: this.maxNNodes })
+  this.server.getPromise('/log', { path: this.repoPath(), limit: this.maxNNodes })
     .then(function(nodes) {
       nodes = self.computeNode(nodes.map(function(logEntry) {
           return self.getNode(logEntry.sha1, logEntry);
@@ -273,7 +273,7 @@ GraphViewModel.prototype.onProgramEvent = function(event) {
 }
 GraphViewModel.prototype.updateBranches = function() {
   var self = this;
-  this.server.get('/checkout', { path: this.repoPath }, function(err, branch) {
+  this.server.get('/checkout', { path: this.repoPath() }, function(err, branch) {
     if (err && err.errorCode == 'not-a-repository') return true;
     if (err) return;
     self.checkedOutBranch(branch);

--- a/components/imagediff/imagediff.js
+++ b/components/imagediff/imagediff.js
@@ -19,10 +19,10 @@ var ImageDiffViewModel = function(args) {
     return 'changed';
   });
   this.oldImageSrc = ko.computed(function() {
-    return '/api/diff/image?path=' + encodeURIComponent(self.repoPath) + '&filename=' + self.filename + '&version=' + (self.sha1 ? self.sha1 + '^': 'HEAD');
+    return '/api/diff/image?path=' + encodeURIComponent(self.repoPath()) + '&filename=' + self.filename + '&version=' + (self.sha1 ? self.sha1 + '^': 'HEAD');
   });
   this.newImageSrc = ko.computed(function() {
-    return '/api/diff/image?path=' + encodeURIComponent(self.repoPath) + '&filename=' + self.filename + '&version=' + (self.sha1 ? self.sha1: 'current');
+    return '/api/diff/image?path=' + encodeURIComponent(self.repoPath()) + '&filename=' + self.filename + '&version=' + (self.sha1 ? self.sha1: 'current');
   });
   this.isShowingDiffs = args.isShowingDiffs;
 }

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -53,6 +53,7 @@ PathViewModel.prototype.updateStatus = function() {
     self.loadingProgressBar.stop();
     if (err) return;
     if (status.type == 'inited' || status.type == 'bare') {
+      self.path = status.gitRootPath ? status.gitRootPath : self.path;
       self.status(status.type);
       if (!self.repository()) {
         self.repository(components.create('repository', { server: self.server, path: self }));

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -52,15 +52,15 @@ PathViewModel.prototype.updateStatus = function() {
   this.server.get('/quickstatus', { path: this.path }, function(err, status){
     self.loadingProgressBar.stop();
     if (err) return;
-    if (status == 'inited' || status == 'bare') {
-      self.status(status);
+    if (status.type == 'inited' || status.type == 'bare') {
+      self.status(status.type);
       if (!self.repository()) {
         self.repository(components.create('repository', { server: self.server, path: self }));
       }
-    } else if (status == 'uninited' || status == 'no-such-path') {
-      self.status(status);
+    } else if (status.type == 'uninited' || status.type == 'no-such-path') {
+      self.status(status.type);
       self.repository(null);
-    } 
+    }
   });
 }
 PathViewModel.prototype.initRepository = function() {

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -71,7 +71,7 @@ PathViewModel.prototype.updateStatus = function() {
 }
 PathViewModel.prototype.initRepository = function() {
   var self = this;
-  this.server.post('/init', { path: this.path() }, function(err, res) {
+  this.server.post('/init', { path: this.repoPath() }, function(err, res) {
     if (err) return;
     self.updateStatus();
   });

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -23,7 +23,7 @@ function RemotesViewModel(server, repoPath) {
     else return 'No remotes specified';
   })
 
-  this.fetchingProgressBar = components.create('progressBar', { predictionMemoryKey: 'fetching-' + this.repoPath, temporary: true });
+  this.fetchingProgressBar = components.create('progressBar', { predictionMemoryKey: 'fetching-' + this.repoPath(), temporary: true });
 
   this.fetchEnabled = ko.computed(function() {
     return self.remotes().length > 0;
@@ -47,8 +47,8 @@ RemotesViewModel.prototype.fetch = function(options) {
 
   this.fetchingProgressBar.start();
   var jobs = [];
-  if (options.tags) jobs.push(function(done) { self.server.get('/remote/tags', { path: self.repoPath, remote: self.currentRemote() }, done); });
-  if (options.nodes) jobs.push(function(done) { self.server.post('/fetch', { path: self.repoPath, remote: self.currentRemote() }, done);  });
+  if (options.tags) jobs.push(function(done) { self.server.get('/remote/tags', { path: self.repoPath(), remote: self.currentRemote() }, done); });
+  if (options.nodes) jobs.push(function(done) { self.server.post('/fetch', { path: self.repoPath(), remote: self.currentRemote() }, done);  });
   async.parallel(jobs, function(err, result) {
     self.fetchingProgressBar.stop();
 
@@ -58,7 +58,7 @@ RemotesViewModel.prototype.fetch = function(options) {
 
 RemotesViewModel.prototype.updateRemotes = function() {
   var self = this;
-  this.server.get('/remotes', { path: this.repoPath }, function(err, remotes) {
+  this.server.get('/remotes', { path: this.repoPath() }, function(err, remotes) {
     if (err && err.errorCode == 'not-a-repository') return true;
     if (err) return;
     remotes = remotes.map(function(remote) {
@@ -85,7 +85,7 @@ RemotesViewModel.prototype.showAddRemoteDialog = function() {
   var diag = components.create('addremotedialog');
   diag.closed.add(function() {
     if (diag.isSubmitted()) {
-      self.server.post('/remotes/' + encodeURIComponent(diag.name()), { path: self.repoPath, url: diag.url() }, function(err, res) {
+      self.server.post('/remotes/' + encodeURIComponent(diag.name()), { path: self.repoPath(), url: diag.url() }, function(err, res) {
         if (err) return;
         self.updateRemotes();
       })
@@ -100,7 +100,7 @@ RemotesViewModel.prototype.remoteRemove = function(remote) {
   diag.closed.add(function() {
     if (diag.result()) {
       self.fetchingProgressBar.start();
-      self.server.del('/remotes/' + remote.name, { path: self.repoPath }, function(err, result) {
+      self.server.del('/remotes/' + remote.name, { path: self.repoPath() }, function(err, result) {
         if (err) {
           console.log(err);
           return;

--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -21,7 +21,8 @@ var RepositoryViewModel = function(server, path) {
   this.stash = this.isBareDir ? {} : components.create('stash', { server: server, repoPath: this.repoPath });
   this.staging = this.isBareDir ? {} : components.create('staging', { server: server, repoPath: this.repoPath });
   this.branches = components.create('branches', { server: server, repoPath: this.repoPath });
-  this.server.watchRepository(this.repoPath);
+  this.repoPath.subscribe(function(value) { self.sever.watchRepository(value); });
+  this.server.watchRepository(this.repoPath());
   this.showLog = self.isBareDir ? ko.observable(true) : self.staging.isStageValid;
   this.isSubmodule = ko.observable(false);
   this.parentModulePath = ko.observable();
@@ -44,21 +45,17 @@ RepositoryViewModel.prototype.onProgramEvent = function(event) {
   if (this.remotes.onProgramEvent) this.remotes.onProgramEvent(event);
   if (this.submodules.onProgramEvent) this.submodules.onProgramEvent(event);
   if (this.branches.onProgramEvent) this.branches.onProgramEvent(event);
+  if (event.event == 'connected') this.server.watchRepository(this.repoPath());
 
   // If we get a reconnect event it's usually because the server crashed and then restarted
   // or something like that, so we need to tell it to start watching the path again
-  if (event.event == 'connected') {
-    this.server.watchRepository(this.repoPath);
-  } else if (event.event == 'request-app-content-refresh') {
-
-  }
 }
 RepositoryViewModel.prototype.updateAnimationFrame = function(deltaT) {
   if (this.graph.updateAnimationFrame) this.graph.updateAnimationFrame(deltaT);
 }
 RepositoryViewModel.prototype.refreshSubmoduleStatus = function() {
   var self = this;
-  this.server.get('/baserepopath', { path: this.repoPath }, function(err, baseRepoPath) {
+  this.server.get('/baserepopath', { path: this.repoPath() }, function(err, baseRepoPath) {
     if (err || !baseRepoPath.path) {
       self.isSubmodule(false);
       return true;
@@ -66,7 +63,7 @@ RepositoryViewModel.prototype.refreshSubmoduleStatus = function() {
 
     self.server.get('/submodules', { path: baseRepoPath.path }, function(err, submodules) {
       if (!err && Array.isArray(submodules)) {
-        var baseName = self.repoPath.replace(/^.*[\\\/]/, '');
+        var baseName = self.repoPath().replace(/^.*[\\\/]/, '');
 
         for (var n = 0; n < submodules.length; n++) {
           if (submodules[n].path === baseName) {

--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -13,7 +13,7 @@ var RepositoryViewModel = function(server, path) {
 
   this.server = server;
   this.isBareDir = path.status() === 'bare';
-  this.repoPath = path.path;
+  this.repoPath = path.repoPath;
   this.gitErrors = components.create('gitErrors', { server: server, repoPath: this.repoPath });
   this.graph = components.create('graph', { server: server, repoPath: this.repoPath });
   this.remotes = components.create('remotes', { server: server, repoPath: this.repoPath });

--- a/components/stash/stash.js
+++ b/components/stash/stash.js
@@ -18,14 +18,14 @@ function StashItemViewModel(stash, data) {
 StashItemViewModel.prototype.pop = function() {
   var self = this;
   this.stashPopProgressBar.start();
-  this.server.del('/stashes/' + this.id, { path: this.stash.repoPath, pop: true }, function(err, res) {
+  this.server.del('/stashes/' + this.id, { path: this.stash.repoPath(), pop: true }, function(err, res) {
     self.stashPopProgressBar.stop();
   });
 }
 StashItemViewModel.prototype.drop = function() {
   var self = this;
   this.stashPopProgressBar.start();
-  this.server.del('/stashes/' + this.id, { path: this.stash.repoPath }, function(err, res) {
+  this.server.del('/stashes/' + this.id, { path: this.stash.repoPath() }, function(err, res) {
     self.stashPopProgressBar.stop();
   });
 }
@@ -51,7 +51,7 @@ StashViewModel.prototype.onProgramEvent = function(event) {
 }
 StashViewModel.prototype.refresh = function() {
   var self = this;
-  this.server.get('/stashes', { path: this.repoPath }, function(err, stashes) {
+  this.server.get('/stashes', { path: this.repoPath() }, function(err, stashes) {
     if (err) {
       if (err.errorCode == 'no-such-path') return true;
       return;

--- a/components/submodules/submodules.js
+++ b/components/submodules/submodules.js
@@ -30,7 +30,7 @@ SubmodulesViewModel.prototype.updateNode = function(parentElement) {
 SubmodulesViewModel.prototype.fetchSubmodules = function(callback) {
   var self = this;
 
-  this.server.get('/submodules', { path: this.repoPath }, function(err, submodules) {
+  this.server.get('/submodules', { path: this.repoPath() }, function(err, submodules) {
     // if returned is not array, don't render submodules module
     if (submodules && Array.isArray(submodules)) {
       self.submodules(submodules);
@@ -53,7 +53,7 @@ SubmodulesViewModel.prototype.updateSubmodules = function() {
   var self = this;
 
   this.updateProgressBar.start();
-  this.server.post('/submodules/update', { path: this.repoPath }, function(err, result) {
+  this.server.post('/submodules/update', { path: this.repoPath() }, function(err, result) {
     self.updateProgressBar.stop();
   });
 }
@@ -64,7 +64,7 @@ SubmodulesViewModel.prototype.showAddSubmoduleDialog = function() {
   diag.closed.add(function() {
     if (diag.isSubmitted()) {
       self.fetchProgressBar.start();
-      self.server.post('/submodules/add', { path: self.repoPath, submoduleUrl: diag.url(), submodulePath: diag.path() }, function(err, result) {
+      self.server.post('/submodules/add', { path: self.repoPath(), submoduleUrl: diag.url(), submodulePath: diag.path() }, function(err, result) {
         if (err) {
           console.log(err);
           return;
@@ -92,7 +92,7 @@ SubmodulesViewModel.prototype.submoduleRemove = function(submodule) {
   diag.closed.add(function() {
     if (diag.result()) {
       self.fetchProgressBar.start();
-      self.server.del('/submodules', { path: self.repoPath, submodulePath: submodule.path, submoduleName: submodule.name }, function(err, result) {
+      self.server.del('/submodules', { path: self.repoPath(), submodulePath: submodule.path, submoduleName: submodule.name }, function(err, result) {
         if (err) {
           console.log(err);
           return;

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -38,7 +38,7 @@ TextDiffViewModel.prototype.updateNode = function(parentElement) {
 TextDiffViewModel.prototype.getDiffArguments = function() {
   return {
     file: this.filename,
-    path: this.repoPath,
+    path: this.repoPath(),
     sha1: this.sha1 ? this.sha1 : ''
   };
 }

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -457,20 +457,7 @@ exports.registerApi = function(env) {
 
   app.get(exports.pathPrefix + '/quickstatus', ensureAuthenticated, function(req, res){
     var task = fs.isExists(req.query.path).then(function(exists) {
-      if (exists) {
-        return gitPromise.revParse(req.query.path, '--is-inside-work-tree')
-          .then(function(isWorkingDir) {
-            var gitRootPath = req.query.path;
-            if (isWorkingDir) {
-              return { type: 'inited', path: gitRootPath };
-            } else {
-              return gitPromise.revParse(req.query.path, '--is-bare-repository')
-                .then(function(isBareDir) { return { type: isBareDir ? 'bare' : 'uninited', path: gitRootPath } });
-            }
-          });
-      } else {
-        return { type: 'no-such-path', path: req.query.path };
-      }
+      return exists ? gitPromise.revParse(req.query.path) : { type: 'no-such-path', path: req.query.path };
     });
     jsonResultOrFailProm(res, task);
   });

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -460,15 +460,16 @@ exports.registerApi = function(env) {
       if (exists) {
         return gitPromise.revParse(req.query.path, '--is-inside-work-tree')
           .then(function(isWorkingDir) {
+            var gitRootPath = req.query.path;
             if (isWorkingDir) {
-              return 'inited';
+              return { type: 'inited', path: gitRootPath };
             } else {
               return gitPromise.revParse(req.query.path, '--is-bare-repository')
-                .then(function(isBareDir) { return isBareDir ? 'bare' : 'uninited'; });
+                .then(function(isBareDir) { return { type: isBareDir ? 'bare' : 'uninited', path: gitRootPath } });
             }
           });
       } else {
-        return 'no-such-path';
+        return { type: 'no-such-path', path: req.query.path };
       }
     });
     jsonResultOrFailProm(res, task);

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -456,9 +456,7 @@ exports.registerApi = function(env) {
   });
 
   app.get(exports.pathPrefix + '/quickstatus', ensureAuthenticated, function(req, res) {
-    const task = fs.isExists(req.query.path).then((exists) => {
-      return exists ? gitPromise.revParse(req.query.path) : { type: 'no-such-path', path: req.query.path };
-    });
+    const task = fs.isExists(req.query.path).then((exists) => exists ? gitPromise.revParse(req.query.path) : { type: 'no-such-path', gitRootPath: req.query.path } )
     jsonResultOrFailProm(res, task);
   });
 

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -455,8 +455,8 @@ exports.registerApi = function(env) {
     jsonResultOrFailProm(res, task);
   });
 
-  app.get(exports.pathPrefix + '/quickstatus', ensureAuthenticated, function(req, res){
-    var task = fs.isExists(req.query.path).then(function(exists) {
+  app.get(exports.pathPrefix + '/quickstatus', ensureAuthenticated, function(req, res) {
+    const task = fs.isExists(req.query.path).then((exists) => {
       return exists ? gitPromise.revParse(req.query.path) : { type: 'no-such-path', path: req.query.path };
     });
     jsonResultOrFailProm(res, task);

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -261,12 +261,9 @@ git.binaryFileContent = function(repoPath, filename, version, outPipe) {
 
 git.diffFile = function(repoPath, filename, sha1) {
   var newFileDiffArgs = ['diff', '--no-index', isWindows ? 'NUL' : '/dev/null', filename.trim()];
-  return git.revParse(repoPath, '--is-bare-repository')
-    .then(function(isBareDir) {
-      if (isBareDir) { // do not call git.status for bare repositories
-        return { files: {} };
-      }
-      return git.status(repoPath);
+  return git.revParse(repoPath)
+    .then(function(revParse) {
+      return revParse.type === 'bare' ? { files: {} } : git.status(repoPath); // if bare do not call status
     }).then(function(status) {
       var file = status.files[filename];
 
@@ -401,12 +398,19 @@ git.commit = function(repoPath, amend, message, files) {
   });
 }
 
-git.revParse = function(repoPath, type) {
-  return git(['rev-parse', type], repoPath)
-    .catch(function(err) {
-      return false;
-    }).then(function(result) {
-      return result.toString().indexOf('true') > -1;
+git.revParse = function(repoPath) {
+  return git(['rev-parse', '--is-inside-work-tree', '--is-bare-repository', '--show-toplevel'], repoPath)
+    .then(function(result) {
+      var resultLines = result.toString().split('\n');
+      var rootPath = resultLines[2] ? resultLines[2] : repoPath;
+      if (resultLines[0].indexOf('true') > -1) {
+        return { type: 'inited', gitRootPath: rootPath };
+      } else if (resultLines[1].indexOf('true') > -1) {
+        return { type: 'bare', gitRootPath: rootPath };
+      }
+      return { type: 'uninited', gitRootPath: rootPath };
+    }).catch(function(err) {
+      return { type: 'uninited', gitRootPath: repoPath };
     });
 }
 

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -400,18 +400,16 @@ git.commit = function(repoPath, amend, message, files) {
 
 git.revParse = function(repoPath) {
   return git(['rev-parse', '--is-inside-work-tree', '--is-bare-repository', '--show-toplevel'], repoPath)
-    .then(function(result) {
-      var resultLines = result.toString().split('\n');
-      var rootPath = resultLines[2] ? resultLines[2] : repoPath;
+    .then((result) => {
+      const resultLines = result.toString().split('\n');
+      const rootPath = resultLines[2] ? resultLines[2] : repoPath;
       if (resultLines[0].indexOf('true') > -1) {
         return { type: 'inited', gitRootPath: rootPath };
       } else if (resultLines[1].indexOf('true') > -1) {
         return { type: 'bare', gitRootPath: rootPath };
       }
       return { type: 'uninited', gitRootPath: rootPath };
-    }).catch(function(err) {
-      return { type: 'uninited', gitRootPath: repoPath };
-    });
+    }).catch((err) => ({ type: 'uninited', gitRootPath: repoPath }));
 }
 
 module.exports = git;

--- a/test/spec.git-api.js
+++ b/test/spec.git-api.js
@@ -26,7 +26,7 @@ describe('git-api', function () {
     common.post(req, '/testing/createtempdir', undefined, function(err, res) {
       if (err) return done(err);
       expect(res.body.path).to.be.ok();
-      testDir = res.body.path;
+      testDir = fs.realpathSync(res.body.path);
       done();
     });
   });
@@ -59,7 +59,7 @@ describe('git-api', function () {
   it('quickstatus should say uninited in uninited directory', function(done) {
     common.get(req, '/quickstatus', { path: testDir }, function(err, res) {
       if (err) return done(err);
-      expect(res.body).to.be('uninited');
+      expect(res.body).to.eql({ type: 'uninited', gitRootPath: testDir });
       done();
     });
   });
@@ -80,7 +80,7 @@ describe('git-api', function () {
   it('quickstatus should say false in non-existing directory', function(done) {
     common.get(req, '/quickstatus', { path: path.join(testDir, 'nowhere') }, function(err, res) {
       if (err) return done(err);
-      expect(res.body).to.be('no-such-path');
+      expect(res.body).to.eql({ type: 'no-such-path', gitRootPath: path.join(testDir, 'nowhere') });
       done();
     });
   });
@@ -96,7 +96,7 @@ describe('git-api', function () {
   it('quickstatus should say inited in inited directory', function(done) {
     common.get(req, '/quickstatus', { path: testDir }, function(err, res) {
       if (err) return done(err);
-      expect(res.body).to.be('inited');
+      expect(res.body).to.eql({ type: 'inited', gitRootPath: testDir });
       done();
     });
   });


### PR DESCRIPTION
Allows operation at a sub dir of git dir.

i.e. if there is a git directory `/tmp/test`, navigating to any sub dir under `/tmp/test` in ungit should be functional as if one is at `/tmp/test`.

I think this will fix #734 but I'm too lazy to test it... :P maybe I will do it over the weekends... :D