### PR TITLE
Handle revert merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 - Removed deprecated npmconf package [#746](https://github.com/FredrikNoren/ungit/issues/746)
 - More helpful warning messages [#749](https://github.com/FredrikNoren/ungit/pull/749/files)
 - Deleting already deleted remote tag [#748](https://github.com/FredrikNoren/ungit/pull/748)
+- Fix to handle revert merge commit [#757](https://github.com/FredrikNoren/ungit/pull/757)
 
 ### Changed
 - Cleaner rebase conflict message display [#708](https://github.com/FredrikNoren/ungit/pull/708)

--- a/clicktests/test.generic.js
+++ b/clicktests/test.generic.js
@@ -246,6 +246,15 @@ suite.test('Merge', function(done) {
   uiInteractions.refAction(page, 'testbranch', true, 'merge', done);
 });
 
+suite.test('Revert merge', function(done) {
+  helpers.click(page, '[data-ta-clickable="node-clickable-0"]');
+  helpers.waitForElementVisible(page, '[data-ta-action="revert"]', function() {
+    helpers.click(page, '[data-ta-action="revert"]');
+    helpers.waitForElementNotVisible(page, '[data-ta-container="user-error-page"]', function() {
+      done();
+    });
+  });
+});
 
 suite.test('Should be possible to move a branch', function(done) {
   uiInteractions.createBranch(page, 'movebranch', function() {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -226,7 +226,15 @@ exports.registerApi = function(env) {
   });
 
   app.post(exports.pathPrefix + '/revert', ensureAuthenticated, ensurePathExists, function(req, res){
-    jsonResultOrFailProm(res, gitPromise(['revert', req.body.commit], req.body.path))
+    const task = gitPromise(['revert', req.body.commit], req.body.path)
+      .catch(e => {
+        if (e.message.indexOf("is a merge but no -m option was given.") > 0) {
+          return gitPromise(['revert', '-m', 1, req.body.commit], req.body.path)
+        } else {
+          throw e;
+        }
+      });
+    jsonResultOrFailProm(res, task)
       .finally(emitGitDirectoryChanged.bind(null, req.body.path))
       .finally(emitWorkingTreeChanged.bind(null, req.body.path));
   });


### PR DESCRIPTION
fixes: #753 

To be honest, I really don't like this one.  one should be able to choose either 1st parent or 2nd parent but this one is hardcoded to parent1.  which is not ideal.  


I almost want to recommend users to moving the ref point instead of reverting.  How do you guys feel?  

(Upon confirmation I will add tests, and change log edit)

cc: @FredrikNoren @Ajedi32 @campersau 