### PR TITLE
lockPath feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.3...master)
 - Fix for favorites linking in case rootPath is used @sebastianmay [#609](https://github.com/FredrikNoren/ungit/issues/609) and image diffing
+- Added "lockPath" option [#765](https://github.com/FredrikNoren/ungit/pull/765/files)
 
 ## [0.10.3](https://github.com/FredrikNoren/ungit/compare/v0.10.2...v0.10.3)
 

--- a/bin/ungit
+++ b/bin/ungit
@@ -17,7 +17,7 @@ var child = new (forever.Monitor)(path.join(__dirname, '..', 'src', 'server.js')
   max: config.maxNAutoRestartOnCrash,
   cwd: path.join(process.cwd(), '..'),
   options: process.argv.slice(2),
-  env: { LANG: 'en_US.UTF-8' }
+  env: { LANG: 'en_US.UTF-8', launchDir: process.cwd() }
 });
 
 process.on('exit', function() {
@@ -47,7 +47,7 @@ function launch(callback) {
   var currentUrl = config.urlBase + ':' + config.port + config.rootPath + '/';
   if (config.lockPath) currentUrl += '?noheader=true';
   if (config.forcedLaunchPath === undefined) currentUrl += '#/repository?path=' + encodeURIComponent(process.cwd());
-  else if (config.forcedLaunchPath !== null && config.forcedLaunchPath !== '') currentUrl += '#/repository?path=' + encodeURIComponent(config.forcedLaunchPath);
+  else if (config.forcedLaunchPath !== null || config.forcedLaunchPath !== '') currentUrl += '#/repository?path=' + encodeURIComponent(config.forcedLaunchPath);
   console.log('Browse to ' + currentUrl);
   if (config.launchBrowser && !config.launchCommand) {
     open(currentUrl);

--- a/bin/ungit
+++ b/bin/ungit
@@ -44,9 +44,10 @@ child.on('exit', function (res) {
 });
 
 function launch(callback) {
-  var currentUrl = config.urlBase + ':' + config.port + config.rootPath;
-  if (config.forcedLaunchPath === undefined) currentUrl += '/#/repository?path=' + encodeURIComponent(process.cwd());
-  else if (config.forcedLaunchPath !== null && config.forcedLaunchPath !== '') currentUrl += '/#/repository?path=' + encodeURIComponent(config.forcedLaunchPath);
+  var currentUrl = config.urlBase + ':' + config.port + config.rootPath + '/';
+  if (config.lockPath) currentUrl += '?noheader=true';
+  if (config.forcedLaunchPath === undefined) currentUrl += '#/repository?path=' + encodeURIComponent(process.cwd());
+  else if (config.forcedLaunchPath !== null && config.forcedLaunchPath !== '') currentUrl += '#/repository?path=' + encodeURIComponent(config.forcedLaunchPath);
   console.log('Browse to ' + currentUrl);
   if (config.launchBrowser && !config.launchCommand) {
     open(currentUrl);

--- a/components/header/header.html
+++ b/components/header/header.html
@@ -1,5 +1,5 @@
 
-<div class="navbar navbar-default navbar-fixed-top">
+<div class="navbar navbar-default navbar-fixed-top" data-bind="visible: !lockPath">
 
   <a data-ta-clickable="home-link" class="backlink bootstrap-tooltip" href="#/" data-toggle="tooltip" data-placement="bottom" data-original-title="Navigate to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
     <span class="glyphicon glyphicon-arrow-left glyphicon-circled" data-bind="css: { 'glyph-shown': showBackButton }"></span>
@@ -20,6 +20,22 @@
 
   <div class="arrowUp"></div>
   <div class="version" data-bind="text: currentVersion"></div>
+</div>
+
+<div class="navbar navbar-default navbar-fixed-top" data-bind="visible: lockPath">
+  <div class="form-container">
+    <form class="path-input-form" data-bind="submit: submitPath">
+      <input data-ta-input="navigation-path" type="text" class="form-control input-lg" data-bind="value: path" placeholder="Path of repository">
+    </form>
+  </div>
+
+  <div class="toolbar">
+    <!-- ko component: refreshButton --><!-- /ko -->
+  </div>
+
+  <div class="arrowUp"></div>
+  <div class="version" data-bind="text: currentVersion"></div>
+
 </div>
 
 <div class="navbarPadder"></div>

--- a/components/header/header.js
+++ b/components/header/header.js
@@ -14,6 +14,7 @@ function HeaderViewModel(app) {
   this.showBackButton = ko.observable(false);
   this.path = ko.observable();
   this.currentVersion = ungit.version;
+  this.lockPath = ungit.config.lockPath;
   this.refreshButton = components.create('refreshbutton');
   this.showAddToRepoListButton = ko.computed(function() {
     return self.path() && self.app.repoList().indexOf(self.path()) == -1;

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -12,6 +12,12 @@ components.register('path', function(args) {
 var PathViewModel = function(server, path) {
   var self = this;
   this.server = server;
+
+  if (ungit.config.lockPath && path !== ungit.config.forcedLaunchPath) {
+    path = ungit.config.forcedLaunchPath;
+    navigation.browseTo('repository?path=' + encodeURIComponent(ungit.config.forcedLaunchPath));
+  }
+
   this.repoPath = ko.observable(path);
   this.dirName = this.repoPath().replace('\\', '/')
                    .split('/')

--- a/source/config.js
+++ b/source/config.js
@@ -55,6 +55,9 @@ const defaultConfig = {
   // Instead of launching ungit with the current folder force a different path to be used. Can be set to null to force the home screen.
   forcedLaunchPath: undefined,
 
+  // Lock the path and consequently turn off the repository browser.
+  lockPath: false,
+
   // Closes the server after x ms of inactivity. Mainly used by the clicktesting.
   autoShutdownTimeout: undefined,
 
@@ -156,6 +159,7 @@ let argv = yargs
 .describe('showRebaseAndMergeOnlyOnRefs', 'Set to false to show rebase and merge on drag and drop on all nodes')
 .describe('maxConcurrentGitOperations', 'Maximum number of concurrent git operations')
 .describe('forcedLaunchPath', 'Define path to be used on open. Can be set to null to force the home screen')
+.describe('lockPath', 'Lock the path and consequently turn off the repository browser')
 .describe('autoShutdownTimeout', 'Closes the server after x ms of inactivity. Mainly used by the clicktesting')
 .describe('maxNAutoRestartOnCrash', 'Maximum number of automatic restarts after a crash. Undefined == unlimited')
 .describe('noFFMerge', 'Don\'t fast forward git mergers. See git merge --no-ff documentation')

--- a/source/config.js
+++ b/source/config.js
@@ -55,7 +55,7 @@ const defaultConfig = {
   // Instead of launching ungit with the current folder force a different path to be used. Can be set to null to force the home screen.
   forcedLaunchPath: undefined,
 
-  // Lock the path and consequently turn off the repository browser.
+  // Lock the path to forcedLaunchPath or to the directory from where ungit is launched. Consequently opens the new browser session without header.
   lockPath: false,
 
   // Closes the server after x ms of inactivity. Mainly used by the clicktesting.
@@ -159,7 +159,7 @@ let argv = yargs
 .describe('showRebaseAndMergeOnlyOnRefs', 'Set to false to show rebase and merge on drag and drop on all nodes')
 .describe('maxConcurrentGitOperations', 'Maximum number of concurrent git operations')
 .describe('forcedLaunchPath', 'Define path to be used on open. Can be set to null to force the home screen')
-.describe('lockPath', 'Lock the path and consequently turn off the repository browser')
+.describe('lockPath', 'Lock the path to forcedLaunchPath or to the directory from where ungit is launched. Consequently opens the new browser session without header')
 .describe('autoShutdownTimeout', 'Closes the server after x ms of inactivity. Mainly used by the clicktesting')
 .describe('maxNAutoRestartOnCrash', 'Maximum number of automatic restarts after a crash. Undefined == unlimited')
 .describe('noFFMerge', 'Don\'t fast forward git mergers. See git merge --no-ff documentation')

--- a/source/server.js
+++ b/source/server.js
@@ -36,6 +36,8 @@ if (config.logDirectory)
 const users = config.users;
 config.users = null; // So that we don't send the users to the client
 
+if(config.lockPath && (config.forcedLaunchPath === undefined || config.forcedLaunchPath === '')) config.forcedLaunchPath = process.env.launchDir;
+
 if (config.authentication) {
 
   passport.serializeUser((username, done) => {


### PR DESCRIPTION
Firstly, ungit is awesome! Thank you very much for this and I hope you keep developing it further! :sunglasses: 

Based on the contribution doc, this is an early pull request for a concept work to start a discussion around a feature request with the upstream, and if seen feasible, also to focus more on the implementation side.

As of now, ungit already has an option for `forcedLaunchPath` which makes it possible to bind to a specific repository on launch. It was also a delight to find out that there's a (hidden? :flashlight: ) feature which allows to disable the header repository browser using `noheader=true` request.

I'm proposing to take this one step further with also allowing ungit to be restricted to a single repository during startup. As such, a concept of `lockPath: true/false` is proposed which would bind ungit to the repository specified in the config or startup parameters making it impossible (well, at least not easy :wink: ) for users to browse to another repo.

The current concept is just to show what I had in mind and it certainly has a number of deficiencies.. some that immediately comes to mind:
- does not currently respect `process.cwd()` but relies on `forcedLaunchPath` to specify the repo;
- header can be made visible again and autocomplete of directories remains functional, altough switching to another space is restricted. The `lockPath` should at least disable the autocomplete function in a repo browser;

I guess it makes sense also to touch on the topic, why such a feature is requested? I would like to make it possible to embed ungit to a web IDE and restrict it to the same workspace that the IDE is bound to. A screenshot for viewing pleasure:

![cloud9-ungit](https://cloud.githubusercontent.com/assets/2134238/16405735/947f6504-3d12-11e6-876a-047ace904141.png)

If this kind of use (or abuse?) of ungit is discouraged, please feel free to close the PR.

Cheers! :beers: 
