### PR TITLE
Loosen npm requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "~4.12.0",
     "mkdirp": "~0.5.1",
     "moment": "~2.13.0",
-    "npm": "~3.9.1",
+    "npm": "^3.9.1",
     "npm-registry-client": "~7.1.0",
     "octicons": "~3.5.0",
     "open": "~0.0.5",


### PR DESCRIPTION
If you want to depend on npm, at least let us use the one that ships with node if we can.

Currently, this installs a separate copy of npm just for this package using node 6.3.0