### PR TITLE
Active branch focused git.log() result.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 
 ### Added
 - Show diffs for stashed changes [#444](https://github.com/FredrikNoren/ungit/issues/444)
+- Active node focused git log result [#420](https://github.com/FredrikNoren/ungit/issues/420)
 
 ### Fixed
 - Missing npm as a normal dependency [#766] (https://github.com/FredrikNoren/ungit/issues/766)

--- a/clicktests/environment.js
+++ b/clicktests/environment.js
@@ -113,6 +113,7 @@ Environment.prototype.startServer = function(callback) {
     '--autoShutdownTimeout=' + this.config.serverTimeout,
     '--maxNAutoRestartOnCrash=0',
     '--no-autoCheckoutOnBranchCreate',
+    '--alwaysLoadActiveBranch',
     '--logGitCommands']
     .concat(this.config.serverStartupOptions);
   var ungitServer = child_process.spawn('node', options);

--- a/clicktests/test.loadAhead.js
+++ b/clicktests/test.loadAhead.js
@@ -74,6 +74,12 @@ suite.test('Open path screen again and should see only 1 commit', function(done)
   });
 });
 
+suite.test('Create a branch during collapsed mode', function(done) {
+  setTimeout(function() {
+    uiInteractions.createBranch(page, 'new-branch', done);
+  }, 500);
+});
+
 suite.test('Load ahead', function(done) {
   helpers.click(page, '[data-ta-container="nodes-skipped"]');
   helpers.waitForElementVisible(page, '[data-ta-clickable="node-clickable-1"]', function() {

--- a/clicktests/test.loadAhead.js
+++ b/clicktests/test.loadAhead.js
@@ -12,11 +12,10 @@ var environment;
 var testRepoPath;
 
 suite.test('Init', function(done) {
-  environment = new Environment(page, { port: 8452, alwaysLoadActiveBranch: true, numberOfNodesPerLoad: 1 });
+  environment = new Environment(page, { port: 8462, serverStartupOptions: ['--numberOfNodesPerLoad=1'] });
   environment.init(function(err) {
     if (err) return done(err);
-    // testRepoPath = environment.path + '/testrepo';
-    testRepoPath = '/tmp/testrepo';
+    testRepoPath = environment.path + '/testrepo';
     environment.createRepos([
       { bare: false, path: testRepoPath }
       ], done);
@@ -67,7 +66,7 @@ suite.test('Should be possible to create and commit a file', function(done) {
 
 suite.test('Open path screen again and should see only 1 commit', function(done) {
   page.open(environment.url + '/#/repository?path=' + encodeURIComponent(testRepoPath), function () {
-    helpers.waitForElementVisible(page, '[data-ta-clickable="load-ahead"]', function() {
+    helpers.waitForElementVisible(page, '[data-ta-container="nodes-skipped"]', function() {
       helpers.waitForElementNotVisible(page, '[data-ta-clickable="node-clickable-1"]', function() {
         done();
       });
@@ -76,10 +75,9 @@ suite.test('Open path screen again and should see only 1 commit', function(done)
 });
 
 suite.test('Load ahead', function(done) {
-
-  helpers.click(page, '[data-ta-clickable="load-ahead"]');
+  helpers.click(page, '[data-ta-container="nodes-skipped"]');
   helpers.waitForElementVisible(page, '[data-ta-clickable="node-clickable-1"]', function() {
-    helpers.waitForElementNotVisible(page, '[data-ta-clickable="load-ahead"]', function() {
+    helpers.waitForElementNotVisible(page, '[data-ta-container="nodes-skipped"]', function() {
       setTimeout(done, 500);
     });
   });

--- a/components/graph/graph-graphics.html
+++ b/components/graph/graph-graphics.html
@@ -21,6 +21,9 @@
       <g data-bind="attr: { opacity: commitOpacity }">
         <path data-bind="attr: { d: commitNodeEdge }", stroke="#4A4A4A" stroke-width="8" stroke-dasharray="10, 5" />
         <circle data-bind="attr: { stroke: commitNodeColor }" cx="610" cy="35" r="30" data-bind="attr: { stroke: '#4A4A4A' }"  stroke-dasharray="10, 7" stroke-width="10" fill="transparent"/>
+        <!-- ko if: skip() > 0 -->
+          <circle data-bind="attr: { fill: commitNodeColor }, click: loadAhead" cx="610" cy="35" r="15" />
+        <!-- /ko -->
       </g>
     <!-- /ko -->
 

--- a/components/graph/graph-graphics.html
+++ b/components/graph/graph-graphics.html
@@ -18,11 +18,11 @@
   </defs>
   <g>
     <!-- ko if: commitNodeEdge -->
-      <g data-bind="attr: { opacity: commitOpacity }">
+      <g data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}">
         <path data-bind="attr: { d: commitNodeEdge }", stroke="#4A4A4A" stroke-width="8" stroke-dasharray="10, 5" />
         <circle data-bind="attr: { stroke: commitNodeColor }" cx="610" cy="35" r="30" data-bind="attr: { stroke: '#4A4A4A' }"  stroke-dasharray="10, 7" stroke-width="10" fill="transparent"/>
         <!-- ko if: skip() > 0 -->
-          <circle data-bind="attr: { fill: commitNodeColor }, click: loadAhead" cx="610" cy="35" r="15" />
+          <circle class="loadAhead" data-bind="attr: { fill: commitNodeColor }, click: loadAhead" cx="610" cy="35" r="15" />
         <!-- /ko -->
       </g>
     <!-- /ko -->

--- a/components/graph/graph-graphics.html
+++ b/components/graph/graph-graphics.html
@@ -18,11 +18,11 @@
   </defs>
   <g>
     <!-- ko if: commitNodeEdge -->
-      <g data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}, click: loadAhead">
+      <g data-ta-clickable="load-ahead" data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}, click: loadAhead">
         <path data-bind="attr: { d: commitNodeEdge }", stroke="#4A4A4A" stroke-width="8" stroke-dasharray="10, 5" />
         <circle data-bind="attr: { stroke: commitNodeColor }" cx="610" cy="35" r="30" data-bind="attr: { stroke: '#4A4A4A' }"  stroke-dasharray="10, 7" stroke-width="10" fill="transparent"/>
         <!-- ko if: skip() > 0 -->
-          <circle class="loadAhead" data-ta-clickable="load-ahead" data-bind="attr: { fill: commitNodeColor }" cx="610" cy="35" r="15" />
+          <circle class="loadAhead" data-ta-container="nodes-skipped" data-bind="attr: { fill: commitNodeColor }" cx="610" cy="35" r="15" />
         <!-- /ko -->
       </g>
     <!-- /ko -->

--- a/components/graph/graph-graphics.html
+++ b/components/graph/graph-graphics.html
@@ -18,11 +18,11 @@
   </defs>
   <g>
     <!-- ko if: commitNodeEdge -->
-      <g data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}">
+      <g data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}, click: loadAhead">
         <path data-bind="attr: { d: commitNodeEdge }", stroke="#4A4A4A" stroke-width="8" stroke-dasharray="10, 5" />
         <circle data-bind="attr: { stroke: commitNodeColor }" cx="610" cy="35" r="30" data-bind="attr: { stroke: '#4A4A4A' }"  stroke-dasharray="10, 7" stroke-width="10" fill="transparent"/>
         <!-- ko if: skip() > 0 -->
-          <circle class="loadAhead" data-bind="attr: { fill: commitNodeColor }, click: loadAhead" cx="610" cy="35" r="15" />
+          <circle class="loadAhead" data-ta-clickable="load-ahead" data-bind="attr: { fill: commitNodeColor }" cx="610" cy="35" r="15" />
         <!-- /ko -->
       </g>
     <!-- /ko -->

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -109,7 +109,7 @@ GraphViewModel.prototype.loadNodesFromApi = function(callback) {
   this.nodesLoader.start();
   this.server.getPromise('/log', { path: this.repoPath(), limit: this.limit(), skip: this.skip() })
     .then(function(log) {
-      var nodes = log.nodes;
+      var nodes = log.nodes ? log.nodes : [];
       self.limit(parseInt(log.limit));
       self.skip(parseInt(log.skip));
       nodes = self.computeNode(nodes.map(function(logEntry) {

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -5,6 +5,7 @@ var GitRefViewModel = require('./git-ref');
 var _ = require('lodash');
 var moment = require('moment');
 var EdgeViewModel = require('./edge');
+var numberOfNodesPerLoad = ungit.config.numberOfNodesPerLoad;
 
 components.register('graph', function(args) {
   return new GraphViewModel(args.server, args.repoPath);
@@ -13,7 +14,7 @@ components.register('graph', function(args) {
 function GraphViewModel(server, repoPath) {
   var self = this;
   this.repoPath = repoPath;
-  this.limit = ko.observable(25);
+  this.limit = ko.observable(numberOfNodesPerLoad);
   this.skip = ko.observable(0);
   this.server = server;
   this.currentRemote = ko.observable();
@@ -46,11 +47,11 @@ function GraphViewModel(server, repoPath) {
   this.currentActionContext = ko.observable();
   this.edgesById = {};
   this.scrolledToEnd = _.debounce(function() {
-    self.limit(25 + self.limit());
+    self.limit(numberOfNodesPerLoad + self.limit());
     self.loadNodesFromApi();
   }, 500, true);
   this.loadAhead = _.debounce(function() {
-    this.skip(Math.max(this.skip() - 25, 0))
+    this.skip(Math.max(this.skip() - numberOfNodesPerLoad, 0))
     self.loadNodesFromApi();
   }, 500, true);
   this.dimCommit = ko.observable(false);

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -51,7 +51,8 @@ function GraphViewModel(server, repoPath) {
     self.loadNodesFromApi();
   }, 500, true);
   this.loadAhead = _.debounce(function() {
-    this.skip(Math.max(this.skip() - numberOfNodesPerLoad, 0))
+    if (self.skip() <= 0) return;
+    self.skip(Math.max(self.skip() - numberOfNodesPerLoad, 0));
     self.loadNodesFromApi();
   }, 500, true);
   this.dimCommit = ko.observable(false);

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -49,6 +49,10 @@ function GraphViewModel(server, repoPath) {
     self.limit(25 + self.limit());
     self.loadNodesFromApi();
   }, 500, true);
+  this.loadAhead = _.debounce(function() {
+    this.skip(Math.max(this.skip() - 25, 0))
+    self.loadNodesFromApi();
+  }, 500, true);
   this.dimCommit = ko.observable(false);
   this.commitOpacity = ko.computed(function() { return self.dimCommit() ? 0.1 : 1; });
   this.heighstBranchOrder = 0;

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -8,6 +8,19 @@
 
   .graphLog {
     left: 575px;
+    .loadAhead {
+      cursor: pointer;
+      animation: throb 1s ease alternate infinite;
+    }
+  }
+
+  @keyframes throb {
+    50% {
+      r: 20;
+    }
+    100% {
+      r: 18;
+    }
   }
 
   .nodeContainer {

--- a/source/config.js
+++ b/source/config.js
@@ -123,6 +123,9 @@ const defaultConfig = {
 
   // Always load with active checkout branch
   alwaysLoadActiveBranch: false,
+
+  // number of nodes to load for each git.log call
+  numberOfNodesPerLoad: 25,
 };
 
 // Works for now but should be moved to bin/ungit
@@ -172,7 +175,8 @@ let argv = yargs
 .describe('disableDiscardMuteTime', 'duration of discard warning dialog mute time should it be muted')
 .describe('lockConflictRetryCount', 'Allowed number of retry for git "index.lock" conflict')
 .describe('autoCheckoutOnBranchCreate', 'Auto checkout the created branch on creation')
-.describe('alwaysLoadActiveBranch', 'Always load with active checkout branch');
+.describe('alwaysLoadActiveBranch', 'Always load with active checkout branch')
+.describe('numberOfNodesPerLoad', 'number of nodes to load for each git.log call');
 
 // If not triggered by test, then do strict option check
 if (argv.$0.indexOf('mocha') === -1) {

--- a/source/config.js
+++ b/source/config.js
@@ -120,6 +120,9 @@ const defaultConfig = {
 
   // Auto checkout the created branch on creation
   autoCheckoutOnBranchCreate: false,
+
+  // Always load with active checkout branch
+  alwaysLoadActiveBranch: false,
 };
 
 // Works for now but should be moved to bin/ungit
@@ -168,7 +171,8 @@ let argv = yargs
 .describe('disableDiscardWarning', 'disable warning popup at discard')
 .describe('disableDiscardMuteTime', 'duration of discard warning dialog mute time should it be muted')
 .describe('lockConflictRetryCount', 'Allowed number of retry for git "index.lock" conflict')
-.describe('autoCheckoutOnBranchCreate', 'Auto checkout the created branch on creation');
+.describe('autoCheckoutOnBranchCreate', 'Auto checkout the created branch on creation')
+.describe('alwaysLoadActiveBranch', 'Always load with active checkout branch');
 
 // If not triggered by test, then do strict option check
 if (argv.$0.indexOf('mocha') === -1) {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -246,8 +246,8 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const limit = getNumber(req.query.limit, config.numberOfNodesPerLoad)
-    const skip = getNumber(req.query.skip, 0)
+    const limit = getNumber(req.query.limit, config.numberOfNodesPerLoad || 25);
+    const skip = getNumber(req.query.skip, 0);
     const task = gitPromise.log(req.query.path, limit, skip, 100)
       .catch((err) => {
         if (err.stderr && err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -117,6 +117,15 @@ exports.registerApi = (env) => {
     return ['-c', `credential.helper=${credentialsHelperPath} ${socketId} ${config.port}`];
   }
 
+  const getNumber = (value, nullValue) => {
+    const finalValue = parseInt(value ? value : nullValue);
+    if (finalValue || finalValue === 0) {
+      return finalValue;
+    } else {
+      throw { error: "invalid number"};
+    }
+  }
+
   app.get(`${exports.pathPrefix}/status`, ensureAuthenticated, ensurePathExists, (req, res) => {
     jsonResultOrFailProm(res, gitPromise.status(req.query.path, null));
   });
@@ -237,13 +246,13 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const task = gitPromise.log(req.query.path, req.query.limit)
+    const task = gitPromise.log(req.query.path, getNumber(req.query.limit, 25), getNumber(req.query.skip, 0))
       .catch((err) => {
-        if (err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
+        if (err.stderr && err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
           return [];
         } else if (/fatal: your current branch \'.+\' does not have any commits yet.*/.test(err.stderr)) {
           return [];
-        } else if (err.stderr.indexOf('fatal: Not a git repository') == 0) {
+        } else if (err.stderr && err.stderr.indexOf('fatal: Not a git repository') == 0) {
           return [];
         } else {
           throw err;

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -237,8 +237,7 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const logFunction = config.alwaysLoadActiveBranch ? gitPromise.logWithHead : gitPromise.log
-    const task = logFunction(req.query.path, req.query.limit)
+    const task = gitPromise.log(req.query.path, req.query.limit)
       .catch((err) => {
         if (err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
           return [];

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -238,16 +238,17 @@ exports.registerApi = (env) => {
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
     const limit = req.query.limit ? `--max-count=${req.query.limit}` : '';
-    const task = gitPromise(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', limit], req.query.path)
-      .then(gitParser.parseGitLog).catch((err) => {
-        if (err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0)
+    const task = gitPromise.log(req.query.path, limit)
+      .catch((err) => {
+        if (err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
           return [];
-        else if (/fatal: your current branch \'.+\' does not have any commits yet.*/.test(err.stderr))
+        } else if (/fatal: your current branch \'.+\' does not have any commits yet.*/.test(err.stderr)) {
           return [];
-        else if (err.stderr.indexOf('fatal: Not a git repository') == 0)
+        } else if (err.stderr.indexOf('fatal: Not a git repository') == 0) {
           return [];
-        else
+        } else {
           throw err;
+        }
       });
     jsonResultOrFailProm(res, task);
   });

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -246,9 +246,9 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const limit = getNumber(req.query.limit, 25)
+    const limit = getNumber(req.query.limit, config.numberOfNodesPerLoad)
     const skip = getNumber(req.query.skip, 0)
-    const task = gitPromise.log(req.query.path, limit, skip)
+    const task = gitPromise.log(req.query.path, limit, skip, 100)
       .catch((err) => {
         if (err.stderr && err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
           return { "limit": limit, "skip": skip, "nodes": []};

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -237,7 +237,8 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const task = gitPromise.logWithHead(req.query.path, req.query.limit)
+    const logFunction = config.alwaysLoadActiveBranch ? gitPromise.logWithHead : gitPromise.log
+    const task = logFunction(req.query.path, req.query.limit)
       .catch((err) => {
         if (err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
           return [];

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -237,8 +237,7 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const limit = req.query.limit ? `--max-count=${req.query.limit}` : '';
-    const task = gitPromise.log(req.query.path, limit)
+    const task = gitPromise.logWithHead(req.query.path, req.query.limit)
       .catch((err) => {
         if (err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
           return [];

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -246,14 +246,16 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/log`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const task = gitPromise.log(req.query.path, getNumber(req.query.limit, 25), getNumber(req.query.skip, 0))
+    const limit = getNumber(req.query.limit, 25)
+    const skip = getNumber(req.query.skip, 0)
+    const task = gitPromise.log(req.query.path, limit, skip)
       .catch((err) => {
         if (err.stderr && err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
-          return [];
+          return { "limit": limit, "skip": skip, "nodes": []};
         } else if (/fatal: your current branch \'.+\' does not have any commits yet.*/.test(err.stderr)) {
-          return [];
+          return { "limit": limit, "skip": skip, "nodes": []};
         } else if (err.stderr && err.stderr.indexOf('fatal: Not a git repository') == 0) {
-          return [];
+          return { "limit": limit, "skip": skip, "nodes": []};
         } else {
           throw err;
         }

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -97,7 +97,7 @@ exports.parseGitLog = (data) => {
       const refs = row.substring(refStartIndex + 1, row.length - 1);
       currentCommmit.refs = refs.split(/ -> |, /g);
     }
-    currentCommmit.isHead = !!_.find(currentCommmit.refs, (item) => { return item === 'HEAD' });
+    currentCommmit.isHead = !!_.find(currentCommmit.refs, (item) => { return item.trim() === 'HEAD' });
     commits.isHeadExist = commits.isHeadExist || currentCommmit.isHead;
     commits.push(currentCommmit);
     parser = parseHeaderLine;

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -1,7 +1,7 @@
 const moment = require('moment');
 const fs = require('fs');
 const fileType = require('./utils/file-type.js');
-const _ = require('underscore')
+const _ = require('lodash')
 
 exports.parseGitStatus = (text, args) => {
   const lines = text.split('\n');

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const fs = require('fs');
 const fileType = require('./utils/file-type.js');
+const _ = require('underscore')
 
 exports.parseGitStatus = (text, args) => {
   const lines = text.split('\n');
@@ -96,7 +97,7 @@ exports.parseGitLog = (data) => {
       const refs = row.substring(refStartIndex + 1, row.length - 1);
       currentCommmit.refs = refs.split(/ -> |, /g);
     }
-    currentCommmit.isHead = currentCommmit.refs.includes('HEAD');
+    currentCommmit.isHead = !!_.find(currentCommmit.refs, (item) => { return item === 'HEAD' });
     commits.isHeadExist = commits.isHeadExist || currentCommmit.isHead;
     commits.push(currentCommmit);
     parser = parseHeaderLine;

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -97,6 +97,7 @@ exports.parseGitLog = (data) => {
       currentCommmit.refs = refs.split(/ -> |, /g);
     }
     currentCommmit.isHead = currentCommmit.refs.includes('HEAD');
+    commits.isHeadExist = commits.isHeadExist || currentCommmit.isHead;
     commits.push(currentCommmit);
     parser = parseHeaderLine;
   }

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -96,6 +96,7 @@ exports.parseGitLog = (data) => {
       const refs = row.substring(refStartIndex + 1, row.length - 1);
       currentCommmit.refs = refs.split(/ -> |, /g);
     }
+    currentCommmit.isHead = currentCommmit.refs.includes('HEAD');
     commits.push(currentCommmit);
     parser = parseHeaderLine;
   }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -400,17 +400,21 @@ git.revParse = (repoPath) => {
     }).catch((err) => ({ type: 'uninited', gitRootPath: path.normalize(repoPath) }));
 }
 
-git.log = (path, limit, skip) => {
+git.log = (path, limit, skip, maxSearchIteration) => {
   return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${limit}`, `--skip=${skip}`], path)
     .then(gitParser.parseGitLog)
     .then((log) => {
       log = log ? log : [];
-      if (config.alwaysLoadActiveBranch && !log.isHeadExist) {
-        return git.log(path, config.numberOfNodesPerLoad + limit, config.numberOfNodesPerLoad + skip);
+      if (config.alwaysLoadActiveBranch && !log.isHeadExist && maxSearchIteration) {
+        if (maxSearchIteration - 1) {
+          return git.log(path, config.numberOfNodesPerLoad + limit, config.numberOfNodesPerLoad + skip, maxSearchIteration - 1);
+        } else {
+          return git.log(path, config.numberOfNodesPerLoad, 0, maxSearchIteration - 1);
+        }
       } else {
         return { "limit": limit, "skip": skip, "nodes": log};
       }
-    })
+    });
 }
 
 module.exports = git;

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -403,14 +403,15 @@ git.revParse = (repoPath) => {
 }
 
 git.log = (path, limit, skip) => {
-  return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', limit ? `--max-count=${limit}` : '', skip ? `--skip=${skip}` : ''], path)
+  return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${limit}`, `--skip=${skip}`], path)
+    .then(gitParser.parseGitLog)
     .then((log) => {
       if (config.alwaysLoadActiveBranch && !log.isHeadExist) {
-        return git.log(path, log.length + logSlideSize, skip + logSlideSize);
+        return git.log(path, logSlideSize + limit, logSlideSize + skip);
       } else {
         return log;
       }
-    }).then(gitParser.parseGitLog)
+    })
 }
 
 module.exports = git;

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -409,7 +409,7 @@ git.log = (path, limit, skip) => {
       if (config.alwaysLoadActiveBranch && !log.isHeadExist) {
         return git.log(path, logSlideSize + limit, logSlideSize + skip);
       } else {
-        return log;
+        return { "limit": limit, "skip": skip, "nodes": log};
       }
     })
 }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -406,6 +406,7 @@ git.log = (path, limit, skip) => {
   return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${limit}`, `--skip=${skip}`], path)
     .then(gitParser.parseGitLog)
     .then((log) => {
+      log = log ? log : [];
       if (config.alwaysLoadActiveBranch && !log.isHeadExist) {
         return git.log(path, logSlideSize + limit, logSlideSize + skip);
       } else {

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -402,18 +402,13 @@ git.revParse = (repoPath) => {
 
 git.log = (path, limit) => {
   return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', limit ? `--max-count=${limit}` : ''], path)
-    .then(gitParser.parseGitLog)
-}
-
-git.logWithHead = (path, limit) => {
-  return git.log(path, limit)
     .then((log) => {
-      if (!log.isHeadExist) {
+      if (config.alwaysLoadActiveBranch && !log.isHeadExist) {
         return git.logWithHead(path, log.length + 25);
       } else {
         return log;
       }
-    })
+    }).then(gitParser.parseGitLog)
 }
 
 module.exports = git;

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -401,8 +401,19 @@ git.revParse = (repoPath) => {
 }
 
 git.log = (path, limit) => {
-  return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', limit], path)
+  return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', limit ? `--max-count=${limit}` : ''], path)
     .then(gitParser.parseGitLog)
+}
+
+git.logWithHead = (path, limit) => {
+  return git.log(path, limit)
+    .then((log) => {
+      if (!log.isHeadExist) {
+        return git.logWithHead(path, log.length + 25);
+      } else {
+        return log;
+      }
+    })
 }
 
 module.exports = git;

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -400,4 +400,9 @@ git.revParse = (repoPath) => {
     }).catch((err) => ({ type: 'uninited', gitRootPath: path.normalize(repoPath) }));
 }
 
+git.log = (path, limit) => {
+  return git(['log', '--decorate=full', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', limit], path)
+    .then(gitParser.parseGitLog)
+}
+
 module.exports = git;

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -11,8 +11,6 @@ const fs = require('./utils/fs-async');
 const async = require('async');
 const gitConfigArguments = ['-c', 'color.ui=false', '-c', 'core.quotepath=false', '-c', 'core.pager=cat'];
 
-const logSlideSize = 25; // when checked out ref is not in ref, skip $logSlideSize and redo git.log
-
 const gitQueue = async.queue((args, callback) => {
   if (config.logGitCommands) winston.info(`git executing: ${args.repoPath} ${args.commands.join(' ')}`);
   let rejected = false;
@@ -408,7 +406,7 @@ git.log = (path, limit, skip) => {
     .then((log) => {
       log = log ? log : [];
       if (config.alwaysLoadActiveBranch && !log.isHeadExist) {
-        return git.log(path, logSlideSize + limit, logSlideSize + skip);
+        return git.log(path, config.numberOfNodesPerLoad + limit, config.numberOfNodesPerLoad + skip);
       } else {
         return { "limit": limit, "skip": skip, "nodes": log};
       }

--- a/test/spec.git-api.branching.js
+++ b/test/spec.git-api.branching.js
@@ -110,10 +110,14 @@ describe('git-api branching', function () {
 	it('log should show both branches and all commits', function(done) {
 		common.get(req, '/log', { path: testDir }, function(err, res) {
 			if (err) return done(err);
-			expect(res.body).to.be.a('array');
-			expect(res.body.length).to.be(2);
+      expect(res.body.skip).to.be(0);
+      expect(res.body.limit).to.be(25);
+
+      var nodes = res.body.nodes
+			expect(nodes).to.be.a('array');
+			expect(nodes.length).to.be(2);
 			var objs = {};
-			res.body.forEach(function(obj) {
+			nodes.forEach(function(obj) {
 				obj.refs.sort();
 				objs[obj.refs[0]] = obj;
 			});

--- a/test/spec.git-api.diff.js
+++ b/test/spec.git-api.diff.js
@@ -175,7 +175,7 @@ describe('git-api diff', function () {
 			common.get(req, '/log', { path: testBareDir }, function(err, res) {
 				if (err) return done(err);
 				// find a commit which contains the testFile
-				var commit = res.body.filter(function(commit) { return commit.fileLineDiffs.some(function(lineDiff) { return lineDiff[2] == testFile; }) })[0];
+				var commit = res.body.nodes.filter(function(commit) { return commit.fileLineDiffs.some(function(lineDiff) { return lineDiff[2] == testFile; }) })[0];
 				common.get(req, '/diff', { path: testBareDir, sha1: commit.sha1, file: testFile }, function(err, res) {
 					if (err) return done(err);
 					done();

--- a/test/spec.git-api.js
+++ b/test/spec.git-api.js
@@ -116,8 +116,8 @@ describe('git-api', function () {
   it('log should be empty before first commit', function(done) {
     common.get(req, '/log', { path: testDir }, function(err, res) {
       if (err) return done(err);
-      expect(res.body).to.be.a('array');
-      expect(res.body.length).to.be(0);
+      expect(res.body.nodes).to.be.a('array');
+      expect(res.body.nodes.length).to.be(0);
       done();
     });
   });
@@ -184,11 +184,11 @@ describe('git-api', function () {
   it('log should show latest commit', function(done) {
     common.get(req, '/log', { path: testDir }, function(err, res) {
       if (err) return done(err);
-      expect(res.body).to.be.a('array');
-      expect(res.body.length).to.be(1);
-      expect(res.body[0].message.indexOf(commitMessage)).to.be(0);
-      expect(res.body[0].authorName).to.be(gitConfig['user.name']);
-      expect(res.body[0].authorEmail).to.be(gitConfig['user.email']);
+      expect(res.body.nodes).to.be.a('array');
+      expect(res.body.nodes.length).to.be(1);
+      expect(res.body.nodes[0].message.indexOf(commitMessage)).to.be(0);
+      expect(res.body.nodes[0].authorName).to.be(gitConfig['user.name']);
+      expect(res.body.nodes[0].authorEmail).to.be(gitConfig['user.email']);
       done();
     });
   });
@@ -243,7 +243,7 @@ describe('git-api', function () {
 
   it('amend should not produce additional log-entry', function(done) {
     common.get(req, '/log', { path: testDir }, done, function(err, res) {
-      expect(res.body.length).to.be(1);
+      expect(res.body.nodes.length).to.be(1);
       done();
     });
   });
@@ -328,9 +328,9 @@ describe('git-api', function () {
   it('log should show last commit', function(done) {
     common.get(req, '/log', { path: testDir }, function(err, res) {
       if (err) return done(err);
-      expect(res.body).to.be.a('array');
-      expect(res.body.length).to.be(2);
-      var HEAD = res.body[0];
+      expect(res.body.nodes).to.be.a('array');
+      expect(res.body.nodes.length).to.be(2);
+      var HEAD = res.body.nodes[0];
 
       expect(HEAD.message.indexOf(commitMessage3)).to.be(0);
       expect(HEAD.authorDate).to.be.a('string');
@@ -409,8 +409,8 @@ describe('git-api', function () {
   it('log with limit should only return specified number of items', function(done) {
     common.get(req, '/log', { path: testDir, limit: 1 }, function(err, res) {
       if (err) return done(err);
-      expect(res.body).to.be.a('array');
-      expect(res.body.length).to.be(1);
+      expect(res.body.nodes).to.be.a('array');
+      expect(res.body.nodes.length).to.be(1);
       done();
     });
   });

--- a/test/spec.git-api.remote.js
+++ b/test/spec.git-api.remote.js
@@ -84,9 +84,9 @@ describe('git-api remote', function () {
 	it('log in "local1" should show the init commit', function(done) {
 		common.get(req, '/log', { path: testDirLocal1 }, function(err, res) {
 			if (err) return done(err);
-			expect(res.body).to.be.a('array');
-			expect(res.body.length).to.be(1);
-			var init = res.body[0];
+			expect(res.body.nodes).to.be.a('array');
+			expect(res.body.nodes.length).to.be(1);
+			var init = res.body.nodes[0];
 			expect(init.message.indexOf('Init')).to.be(0);
 			expect(init.refs).to.contain('HEAD');
 			expect(init.refs).to.contain('refs/heads/master');
@@ -105,9 +105,9 @@ describe('git-api remote', function () {
 	it('log in "local2" should show the init commit', function(done) {
 		common.get(req, '/log', { path: testDirLocal2 }, function(err, res) {
 			if (err) return done(err);
-			expect(res.body).to.be.a('array');
-			expect(res.body.length).to.be(1);
-			var init = res.body[0];
+			expect(res.body.nodes).to.be.a('array');
+			expect(res.body.nodes.length).to.be(1);
+			var init = res.body.nodes[0];
 			expect(init.message.indexOf('Init')).to.be(0);
 			expect(init.refs).to.contain('HEAD');
 			expect(init.refs).to.contain('refs/heads/master');
@@ -133,10 +133,10 @@ describe('git-api remote', function () {
 	it('log in "local2" should show the branch as one behind', function(done) {
 		common.get(req, '/log', { path: testDirLocal2 }, function(err, res) {
 			if (err) return done(err);
-			expect(res.body).to.be.a('array');
-			expect(res.body.length).to.be(2);
-			var init = _.find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
-			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			expect(res.body.nodes).to.be.a('array');
+			expect(res.body.nodes.length).to.be(2);
+			var init = _.find(res.body.nodes, function(node) { return node.message.indexOf('Init') == 0; });
+			var commit2 = _.find(res.body.nodes, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(init).to.be.ok();
 			expect(commit2).to.be.ok();
 			expect(init.refs).to.contain('HEAD');
@@ -154,10 +154,10 @@ describe('git-api remote', function () {
 	it('log in "local2" should show the branch as in sync', function(done) {
 		common.get(req, '/log', { path: testDirLocal2 }, function(err, res) {
 			if (err) return done(err);
-			expect(res.body).to.be.a('array');
-			expect(res.body.length).to.be(2);
-			var init = _.find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
-			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			expect(res.body.nodes).to.be.a('array');
+			expect(res.body.nodes.length).to.be(2);
+			var init = _.find(res.body.nodes, function(node) { return node.message.indexOf('Init') == 0; });
+			var commit2 = _.find(res.body.nodes, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(init).to.be.ok();
 			expect(commit2).to.be.ok();
 			expect(init.refs).to.eql([]);
@@ -184,9 +184,9 @@ describe('git-api remote', function () {
 	it('log in "local2" should show the branch as in sync', function(done) {
 		common.get(req, '/log', { path: testDirLocal2 }, function(err, res) {
 			if (err) return done(err);
-			expect(res.body.length).to.be(2);
-			var init = _.find(res.body, function(node) { return node.message.indexOf('Init') == 0; });
-			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			expect(res.body.nodes.length).to.be(2);
+			var init = _.find(res.body.nodes, function(node) { return node.message.indexOf('Init') == 0; });
+			var commit2 = _.find(res.body.nodes, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(init.refs).to.eql([]);
 			expect(commit2.refs).to.contain('HEAD');
 			expect(commit2.refs).to.contain('refs/heads/master');
@@ -215,7 +215,7 @@ describe('git-api remote', function () {
 	it('log in "local2" should show the local tag', function(done) {
 		common.get(req, '/log', { path: testDirLocal2 }, function(err, res) {
 			if (err) return done(err);
-			var commit2 = _.find(res.body, function(node) { return node.message.indexOf('Commit2') == 0; });
+			var commit2 = _.find(res.body.nodes, function(node) { return node.message.indexOf('Commit2') == 0; });
 			expect(commit2.refs).to.contain('tag: refs/tags/v1.0');
 			done();
 		});


### PR DESCRIPTION
fix: #420

~~Currently, what this fix is doing is that if "head" ref is missing from git.log, it will continuously increase git.log result list until it does.  Effectively always loading active git branch on load.
Now, this is not optimal and not my favorite.  I'm planning on writing more optimized solution as it can be bit slow and little barbaric solution as it is...~~


Added two config flags

* numberOfNodesPerLoad: number of nodes to load for each git.log call
* alwaysLoadActiveBranch: Always load with active checkout branch. ()

When `alwaysLoadActiveBranch=true`, terrible name but not sure what I can call it,  ungit will load checked out node on load by skipping previous nodes untill active checked out node is found for `git.log` call.  

I have also added a cheeky little button where you can load skipped nodes.

After more testing we might want to change the default value of `alwaysLoadActiveBranch` to true.

![jrbixycto9](https://cloud.githubusercontent.com/assets/5281068/17652709/985f6bba-6238-11e6-91f0-c03c6a78c539.gif)
