### PR TITLE
Commit message title limiting to 72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.3...master)
 - Fix for favorites linking in case rootPath is used @sebastianmay [#609](https://github.com/FredrikNoren/ungit/issues/609) and image diffing
+- Limit commit title to 72 characters, the rest is truncated and shown when inspecting the commit
 
 ## [0.10.3](https://github.com/FredrikNoren/ungit/compare/v0.10.2...v0.10.3)
 

--- a/components/commit/commit.html
+++ b/components/commit/commit.html
@@ -11,7 +11,7 @@
           onerror="this.style.display='none';">
         <div>
           <div>
-            <span class="title" data-bind="text: title"></span>
+            <span class="title" data-bind="text: (title().length > 72 ? title().substring(0, 72) + '...' : title)"></span>
             <span class="text-muted">by <a data-bind="text: authorName, attr: { href: 'mailto:' + authorEmail() }"></a></span>
           </div>
           <div class="text-muted nodeSummaryContainer">
@@ -25,6 +25,7 @@
       </div>
       <!-- ko if: selected() || nodeIsMousehover() -->
       <div class="details">
+        <div class="body" data-bind="visible: title().length > 72, text: '...' + title().substring(72)"></div>
         <div class="body" data-bind="text: body"></div>
         <div class="diff-wrapper" data-bind="visible: showCommitDiff, style: diffStyle, click: stopClickPropagation">
           <div class="diff-inner" data-bind="component: commitDiff"></div>


### PR DESCRIPTION
A small improvement concerning commit subjects.

The overwhelming consensus of recommended git commit message formatting is the 50/72 rule ([Exhibit A](http://chris.beams.io/posts/git-commit/), [Exhibit B](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)). Git GUI clients are suggesting the same rules but are not enforcing them.

When browsing certain repos I found that ungit UI breaks down after certain length of the subject line (150+ characters). The idea of this commit is to guide the user to use shorter subject messages by cutting the visible commit subject to 72 characters (being less obtrusive than the suggested 50 limit). The rest of the commit subject is shown as a separate body div when inspecting the commit.

Thoughts? 🙏