### PR TITLE
Log improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 [Keep a changlelog's changelog standard](http://keepachangelog.com/)
 
 ### Added
+- New configuration option `logLevel` allows you to assign the level of logging you want to see in the servers output console.
 - New configuration option `mergeTool` allows you to assign a custom external merge tool for conflict resolution [783](https://github.com/FredrikNoren/ungit/issues/783)
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.3...master)

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -207,7 +207,7 @@ GitNodeViewModel.prototype.toggleSelected = function() {
     if ((prevSelectedCR && (prevSelectedCR.top < 0 || prevSelectedCR.top > window.innerHeight)) &&
       afterThisCR.top != beforeThisCR.top) {
       window.scrollBy(0, -(beforeThisCR.top - afterThisCR.top));
-      console.log('Fix')
+      console.log('Fix');
     }
   }
   return false;

--- a/source/config.js
+++ b/source/config.js
@@ -70,6 +70,9 @@ const defaultConfig = {
   // Used for development purposes.
   dev: false,
 
+  // Assigns the log level.
+  logLevel: 'warn',
+
   // Specify a custom command to launch. `%U` will be replaced with the URL
   //  that corresponds with the working git directory.
   //
@@ -165,6 +168,7 @@ let argv = yargs
 .describe('noFFMerge', 'Don\'t fast forward git mergers. See git merge --no-ff documentation')
 .describe('autoFetch', 'Automatically fetch from remote when entering a repository using ungit')
 .describe('dev', 'Used for development purposes')
+.describe('logLevel', 'The logging level, possible values are none, error, warn, info, verbose, debug, and silly.')
 .describe('launchCommand', 'Specify a custom command to launch. `%U` will be replaced with the URL that corresponds with the working git directory.')
 .describe('allowCheckoutNodes', 'Allow checking out nodes (which results in a detached head)')
 .describe('allowedIPs', 'An array of ip addresses that can connect to ungit. All others are denied')

--- a/source/config.js
+++ b/source/config.js
@@ -70,7 +70,8 @@ const defaultConfig = {
   // Used for development purposes.
   dev: false,
 
-  // Assigns the log level.
+  // Assigns the log level. Possible values, in order from quietest to loudest, are
+  // "none", "error", "warn", "info", "verbose", "debug", and "silly"
   logLevel: 'warn',
 
   // Specify a custom command to launch. `%U` will be replaced with the URL

--- a/source/server.js
+++ b/source/server.js
@@ -27,9 +27,15 @@ process.on('uncaughtException', (err) => {
   ], () => process.exit());
 });
 
-
+console.log('Setting log level to ' + config.logLevel);
 winston.remove(winston.transports.Console);
-winston.add(winston.transports.Console, {'timestamp':true});
+winston.add(winston.transports.Console, {
+  level: config.logLevel,
+  timestamp: true,
+  prettyPrint: true,
+  colorize: true,
+  silent: false
+});
 if (config.logDirectory)
   winston.add(winston.transports.File, { filename: path.join(config.logDirectory, 'server.log'), maxsize: 100*1024, maxFiles: 2 });
 

--- a/source/server.js
+++ b/source/server.js
@@ -32,9 +32,7 @@ winston.remove(winston.transports.Console);
 winston.add(winston.transports.Console, {
   level: config.logLevel,
   timestamp: true,
-  prettyPrint: true,
-  colorize: true,
-  silent: false
+  colorize: true
 });
 if (config.logDirectory)
   winston.add(winston.transports.File, { filename: path.join(config.logDirectory, 'server.log'), maxsize: 100*1024, maxFiles: 2 });


### PR DESCRIPTION
This one is kind of random, but I noticed you were using `winston` and it comes with a few features that I thought we would benefit from:

I've added a configuration option `"logLevel"` that allows you to set the level of logging you want to see in the server output console. It is set to `warn` by default, which is actually less logging that it currently does; I figure the majority of users are not developing for ungit and would only care about warning and error messages. You can always set this to `silly` in your local configuration file to get all the logs back.

I've also set `winston` to output log level text using colors.
