### PR TITLE
Add whitespace ignore option for file diffs fix: #777

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and
 [Keep a changlelog's changelog standard](http://keepachangelog.com/)
 
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.3...master)
+
 ### Added
 - New configuration option `logLevel` allows you to assign the level of logging you want to see in the servers output console.
 - New configuration option `mergeTool` allows you to assign a custom external merge tool for conflict resolution [783](https://github.com/FredrikNoren/ungit/issues/783)
-
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.3...master)
+- Whitespace ignore option for text diffs [777](https://github.com/FredrikNoren/ungit/issues/777)
 - Fix for favorites linking in case rootPath is used @sebastianmay [#609](https://github.com/FredrikNoren/ungit/issues/609) and image diffing
+
+### Fixed
+- File diff firing increasing number of events longer it survives.
 
 ## [0.10.3](https://github.com/FredrikNoren/ungit/compare/v0.10.2...v0.10.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 
 ### Added
 - New configuration option `logLevel` allows you to assign the level of logging you want to see in the servers output console.
-- New configuration option `mergeTool` allows you to assign a custom external merge tool for conflict resolution [783](https://github.com/FredrikNoren/ungit/issues/783)
-- Whitespace ignore option for text diffs [777](https://github.com/FredrikNoren/ungit/issues/777)
+- New configuration option `mergeTool` allows you to assign a custom external merge tool for conflict resolution [#783](https://github.com/FredrikNoren/ungit/issues/783)
+- Whitespace ignore option for text diffs [#777](https://github.com/FredrikNoren/ungit/issues/777)
 - Fix for favorites linking in case rootPath is used @sebastianmay [#609](https://github.com/FredrikNoren/ungit/issues/609) and image diffing
 - Limit commit title to 72 characters, the rest is truncated and shown when inspecting the commit
 

--- a/clicktests/test.generic.js
+++ b/clicktests/test.generic.js
@@ -102,8 +102,7 @@ suite.test('Test showing commit diff between two commits', function(done) {
 suite.test('Test showing commit side by side diff between two commits', function(done) {
   helpers.click(page, '[data-ta-clickable="commit-sideBySideDiff"]');
   helpers.waitForElementVisible(page, '[data-ta-container="commitLineDiffs"]', function() {
-    setTimeout(function() {                           // let it finish making api call
-      // helpers.click(page, '[data-ta-clickable="node-clickable-0"]'); // De-select again
+    setTimeout(function() {
       done();
     }, 500);
   });
@@ -112,6 +111,15 @@ suite.test('Test showing commit side by side diff between two commits', function
 suite.test('Test wordwrap', function(done) {
   helpers.click(page, '[data-ta-clickable="commit-wordwrap"]');
   helpers.waitForElementVisible(page, '.word-wrap', function() {
+    setTimeout(function() {
+      done();
+    }, 500);
+  });
+});
+
+suite.test('Test wordwrap', function(done) {
+  helpers.click(page, '[data-ta-clickable="commit-whitespace"]');
+  helpers.waitForElementVisible(page, '[data-ta-container="commitLineDiffs"]', function() {
     setTimeout(function() {
       helpers.click(page, '[data-ta-clickable="node-clickable-0"]');
       done();

--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -4,8 +4,8 @@
   </button>
 </div>
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-sideBySideDiff" data-bind="click: textDiffTypeToggle, css: {active: textDiffType() === 'sidebysidediff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: textDiffTypeTitle"></span>
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-sideBySideDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.value() === 'sidebysidediff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
+    <span data-bind="text: textDiffType.text"></span>
   </button>
 </div>
 

--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -1,6 +1,6 @@
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-wordwrap" data-bind="click: wordWrapToggle, css: {active: wordWrap()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: wordWrapTitle"></span>
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-wordwrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
+    <span data-bind="text: wordWrap.text"></span>
   </button>
 </div>
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">

--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -8,6 +8,11 @@
     <span data-bind="text: textDiffType.text"></span>
   </button>
 </div>
+<div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-whitespace" data-bind="click: whiteSpace.toggle, css: {active: !whiteSpace.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Igonore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
+    <span data-bind="text: whiteSpace.text"></span>
+  </button>
+</div>
 
 <div data-bind="foreach: commitLineDiffs" class="commitdiff">
   <div class="file">

--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -1,16 +1,16 @@
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-wordwrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: wordWrap.text"></span>
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-whitespace" data-bind="click: whiteSpace.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Igonore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
+    <span data-bind="text: whiteSpace.text"></span>
   </button>
 </div>
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-sideBySideDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.value() === 'sidebysidediff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-sideBySideDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
     <span data-bind="text: textDiffType.text"></span>
   </button>
 </div>
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-whitespace" data-bind="click: whiteSpace.toggle, css: {active: !whiteSpace.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Igonore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: whiteSpace.text"></span>
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-wordwrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
+    <span data-bind="text: wordWrap.text"></span>
   </button>
 </div>
 

--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -1,17 +1,11 @@
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-wordwrap" data-bind="click: wordWrapChange.bind($data, true), css: {active: wordWrap()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: 'Word Wrap'"></span>
-  </button>
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-nowrap" data-bind="click: wordWrapChange.bind($data, false), css: {active: !wordWrap()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: 'Default'"></span>
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-wordwrap" data-bind="click: wordWrapToggle, css: {active: wordWrap()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
+    <span data-bind="text: wordWrapTitle"></span>
   </button>
 </div>
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-sideBySideDiff" data-bind="click: textDiffTypeChange.bind($data, 'sidebysidediff'), css: {active: textDiffType() === 'sidebysidediff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: 'Side by Side'"></span>
-  </button>
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-defaultDiff" data-bind="click: textDiffTypeChange.bind($data, 'textdiff'), css: {active: textDiffType() === 'textdiff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
-    <span data-bind="text: 'Default'"></span>
+  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-sideBySideDiff" data-bind="click: textDiffTypeToggle, css: {active: textDiffType() === 'sidebysidediff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
+    <span data-bind="text: textDiffTypeTitle"></span>
   </button>
 </div>
 

--- a/components/commitdiff/commitdiff.js
+++ b/components/commitdiff/commitdiff.js
@@ -18,6 +18,7 @@ var CommitDiff = function(args) {
   this.showDiffButtons = ko.observable(!args.textDiffType);
   this.textDiffType = args.textDiffType = args.textDiffType || components.create('textdiff.type');
   this.wordWrap = args.wordWrap = args.wordWrap || components.create('textdiff.wordwrap');
+  this.whiteSpace = args.whiteSpace = args.whiteSpace || components.create('textdiff.whitespace');
 
   args.fileLineDiffs.shift();  // remove first line that has "total"
   this.loadFileLineDiffs(args);

--- a/components/commitdiff/commitdiff.js
+++ b/components/commitdiff/commitdiff.js
@@ -16,11 +16,7 @@ var CommitDiff = function(args) {
 
   // parent components can provide their own buttons (e.g. staging component)
   this.showDiffButtons = ko.observable(!args.textDiffType);
-  this.textDiffTypeTitle = ko.observable("Default");
-  this.textDiffType = args.textDiffType = args.textDiffType || ko.observable('textdiff');
-  this.textDiffType.subscribe(function(value) {
-    self.textDiffTypeTitle(value === textDiff ? "Default" : "Side By Side");
-  });
+  this.textDiffType = args.textDiffType = args.textDiffType || components.create('textdiff.type');
   this.wordWrapTitle = ko.observable("No Word Wrap");
   this.wordWrap = args.wordWrap = args.wordWrap || ko.observable(false);
   this.wordWrap.subscribe(function(value) {
@@ -44,9 +40,6 @@ CommitDiff.prototype.loadFileLineDiffs = function(args) {
   });
 
   this.commitLineDiffs(this.commitLineDiffs().concat(tempCommitLineDiffs));
-}
-CommitDiff.prototype.textDiffTypeToggle = function(type) {
-  this.textDiffType(this.textDiffType() === textDiff ? sideBySideDiff : textDiff);
 }
 CommitDiff.prototype.wordWrapToggle = function(state) {
   this.wordWrap(!this.wordWrap());

--- a/components/commitdiff/commitdiff.js
+++ b/components/commitdiff/commitdiff.js
@@ -17,11 +17,7 @@ var CommitDiff = function(args) {
   // parent components can provide their own buttons (e.g. staging component)
   this.showDiffButtons = ko.observable(!args.textDiffType);
   this.textDiffType = args.textDiffType = args.textDiffType || components.create('textdiff.type');
-  this.wordWrapTitle = ko.observable("No Word Wrap");
-  this.wordWrap = args.wordWrap = args.wordWrap || ko.observable(false);
-  this.wordWrap.subscribe(function(value) {
-    self.wordWrapTitle(value ? "Word Wrap" : "No Word Wrap");
-  });
+  this.wordWrap = args.wordWrap = args.wordWrap || components.create('textdiff.wordwrap');
 
   args.fileLineDiffs.shift();  // remove first line that has "total"
   this.loadFileLineDiffs(args);
@@ -40,7 +36,4 @@ CommitDiff.prototype.loadFileLineDiffs = function(args) {
   });
 
   this.commitLineDiffs(this.commitLineDiffs().concat(tempCommitLineDiffs));
-}
-CommitDiff.prototype.wordWrapToggle = function(state) {
-  this.wordWrap(!this.wordWrap());
 }

--- a/components/commitdiff/commitdiff.js
+++ b/components/commitdiff/commitdiff.js
@@ -2,18 +2,30 @@ var ko = require('knockout');
 var CommitLineDiff = require('./commitlinediff.js').CommitLineDiff;
 var components = require('ungit-components');
 
+var sideBySideDiff = 'sidebysidediff'
+var textDiff = 'textdiff'
+
 components.register('commitDiff', function(args) {
   return new CommitDiff(args);
 });
 
 var CommitDiff = function(args) {
+  var self = this;
   this.commitLineDiffs = ko.observableArray();
   this.sha1 = args.sha1;
 
   // parent components can provide their own buttons (e.g. staging component)
   this.showDiffButtons = ko.observable(!args.textDiffType);
+  this.textDiffTypeTitle = ko.observable("Default");
   this.textDiffType = args.textDiffType = args.textDiffType || ko.observable('textdiff');
+  this.textDiffType.subscribe(function(value) {
+    self.textDiffTypeTitle(value === textDiff ? "Default" : "Side By Side");
+  });
+  this.wordWrapTitle = ko.observable("No Word Wrap");
   this.wordWrap = args.wordWrap = args.wordWrap || ko.observable(false);
+  this.wordWrap.subscribe(function(value) {
+    self.wordWrapTitle(value ? "Word Wrap" : "No Word Wrap");
+  });
 
   args.fileLineDiffs.shift();  // remove first line that has "total"
   this.loadFileLineDiffs(args);
@@ -33,9 +45,9 @@ CommitDiff.prototype.loadFileLineDiffs = function(args) {
 
   this.commitLineDiffs(this.commitLineDiffs().concat(tempCommitLineDiffs));
 }
-CommitDiff.prototype.textDiffTypeChange = function(type) {
-  this.textDiffType(type);
+CommitDiff.prototype.textDiffTypeToggle = function(type) {
+  this.textDiffType(this.textDiffType() === textDiff ? sideBySideDiff : textDiff);
 }
-CommitDiff.prototype.wordWrapChange = function(state) {
-  this.wordWrap(state);
+CommitDiff.prototype.wordWrapToggle = function(state) {
+  this.wordWrap(!this.wordWrap());
 }

--- a/components/commitdiff/commitdiff.js
+++ b/components/commitdiff/commitdiff.js
@@ -2,15 +2,11 @@ var ko = require('knockout');
 var CommitLineDiff = require('./commitlinediff.js').CommitLineDiff;
 var components = require('ungit-components');
 
-var sideBySideDiff = 'sidebysidediff'
-var textDiff = 'textdiff'
-
 components.register('commitDiff', function(args) {
   return new CommitDiff(args);
 });
 
 var CommitDiff = function(args) {
-  var self = this;
   this.commitLineDiffs = ko.observableArray();
   this.sha1 = args.sha1;
 

--- a/components/commitdiff/commitlinediff.js
+++ b/components/commitdiff/commitlinediff.js
@@ -14,6 +14,7 @@ var CommitLineDiff = function(args, fileLineDiff) {
   this.sha1 = args.sha1;
   this.textDiffType = args.textDiffType;
   this.wordWrap = args.wordWrap;
+  this.whiteSpace = args.whiteSpace;
   this.specificDiff = ko.observable(this.getSpecificDiff());
 };
 exports.CommitLineDiff = CommitLineDiff;
@@ -26,6 +27,7 @@ CommitLineDiff.prototype.getSpecificDiff = function() {
     sha1: this.sha1,
     textDiffType: this.textDiffType,
     isShowingDiffs: this.isShowingDiffs,
+    whiteSpace: this.whiteSpace,
     wordWrap: this.wordWrap
   });
 }

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -49,6 +49,11 @@
             <!-- ko component: stashProgressBar --><!-- /ko -->
           </button>
           <div class="btn-group pull-right btn-group-sm">
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-whitespace" data-bind="click: whiteSpace.toggle, css: {active: !whiteSpace.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Igonore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
+              <span data-bind="text: whiteSpace.text"></span>
+            </button>
+          </div>
+          <div class="btn-group pull-right btn-group-sm">
             <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.value() === 'textdiff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
               <span data-bind="text: textDiffType.text"></span>
             </button>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -49,19 +49,13 @@
             <!-- ko component: stashProgressBar --><!-- /ko -->
           </button>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffTypeChange.bind($data, 'textdiff'), css: {active: textDiffType() === 'textdiff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
-              <span data-bind="text: 'Default'"></span>
-            </button>
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-sideBySideDiff" data-bind="click: textDiffTypeChange.bind($data, 'sidebysidediff'), css: {active: textDiffType() === 'sidebysidediff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
-              <span data-bind="text: 'Side by Side'"></span>
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffTypeToggle, css: {active: textDiffType() === 'textdiff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
+              <span data-bind="text: textDiffTypeTitle"></span>
             </button>
           </div>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-nowrap" data-bind="click: wordWrapChange.bind($data, false), css: {active: !wordWrap()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
-              <span data-bind="text: 'Default'"></span>
-            </button>
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-wordwrap" data-bind="click: wordWrapChange.bind($data, true), css: {active: wordWrap}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
-              <span data-bind="text: 'Word Wrap'"></span>
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-nowrap" data-bind="click: wordWrapToggle, css: {active: !wordWrap()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
+              <span data-bind="text: wordWrapTitle"></span>
             </button>
           </div>
         </div>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -54,8 +54,8 @@
             </button>
           </div>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-nowrap" data-bind="click: wordWrapToggle, css: {active: !wordWrap()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
-              <span data-bind="text: wordWrapTitle"></span>
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-nowrap" data-bind="click: wordWrap.toggle, css: {active: !wordWrap.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
+              <span data-bind="text: wordWrap.text"></span>
             </button>
           </div>
         </div>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -49,17 +49,17 @@
             <!-- ko component: stashProgressBar --><!-- /ko -->
           </button>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-whitespace" data-bind="click: whiteSpace.toggle, css: {active: !whiteSpace.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Igonore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-whitespace" data-bind="click: whiteSpace.toggle, css: {active: whiteSpace.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Igonore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
               <span data-bind="text: whiteSpace.text"></span>
             </button>
           </div>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.value() === 'textdiff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
               <span data-bind="text: textDiffType.text"></span>
             </button>
           </div>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-nowrap" data-bind="click: wordWrap.toggle, css: {active: !wordWrap.value()}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-nowrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
               <span data-bind="text: wordWrap.text"></span>
             </button>
           </div>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -49,8 +49,8 @@
             <!-- ko component: stashProgressBar --><!-- /ko -->
           </button>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffTypeToggle, css: {active: textDiffType() === 'textdiff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
-              <span data-bind="text: textDiffTypeTitle"></span>
+            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.value() === 'textdiff'}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
+              <span data-bind="text: textDiffType.text"></span>
             </button>
           </div>
           <div class="btn-group pull-right btn-group-sm">

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -27,6 +27,7 @@ var StagingViewModel = function(server, repoPath) {
   this.commitMessageBody = ko.observable();
   this.wordWrap = components.create("textdiff.wordwrap");
   this.textDiffType = components.create('textdiff.type');
+  this.whiteSpace = components.create('textdiff.whitespace');
   this.inRebase = ko.observable(false);
   this.inMerge = ko.observable(false);
   this.inCherry = ko.observable(false);

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -189,7 +189,7 @@ StagingViewModel.prototype.setFiles = function(files) {
   for(var file in files) {
     var fileViewModel = this.filesByPath[file];
     if (!fileViewModel) {
-      this.filesByPath[file] = fileViewModel = new FileViewModel(self, file)
+      this.filesByPath[file] = fileViewModel = new FileViewModel(self, file);
     } else {
       // this is mainly for patching and it may not fire due to the fact that
       // '/commit' triggers working-tree-changed which triggers throttled refresh

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -28,10 +28,15 @@ var StagingViewModel = function(server, repoPath) {
     self.commitMessageTitleCount(value.length);
   });
   this.commitMessageBody = ko.observable();
-  this.wordWrapTitle = ko.observable("No Wrap");
+  this.wordWrapTitle = ko.observable("No Word Wrap");
   this.wordWrap = ko.observable(false);
   this.wordWrap.subscribe(function(value) {
     self.wordWrapTitle(value ? "Word Wrap" : "No Word Wrap");
+  });
+  this.textDiffTypeTitle = ko.observable("Default");
+  this.textDiffType = ko.observable(textDiff);
+  this.textDiffType.subscribe(function(value) {
+    self.textDiffTypeTitle(value === textDiff ? "Default" : "Side By Side");
   });
   this.inRebase = ko.observable(false);
   this.inMerge = ko.observable(false);
@@ -107,11 +112,6 @@ var StagingViewModel = function(server, repoPath) {
   this.refreshContentThrottled = _.throttle(this.refreshContent.bind(this), 400, { trailing: true });
   this.invalidateFilesDiffsThrottled = _.throttle(this.invalidateFilesDiffs.bind(this), 400, { trailing: true });
   this.refreshContentThrottled();
-  this.textDiffTypeTitle = ko.observable("Default");
-  this.textDiffType = ko.observable(textDiff);
-  this.textDiffType.subscribe(function(value) {
-    self.textDiffTypeTitle(value === textDiff ? "Default" : "Side By Side");
-  });
   if (window.location.search.indexOf('noheader=true') >= 0)
     this.refreshButton = components.create('refreshbutton');
   this.loadAnyway = false;

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -189,7 +189,7 @@ StagingViewModel.prototype.setFiles = function(files) {
   for(var file in files) {
     var fileViewModel = this.filesByPath[file];
     if (!fileViewModel) {
-      this.filesByPath[file] = fileViewModel = new FileViewModel(self, file, self.textDiffType, self.wordWrap);
+      this.filesByPath[file] = fileViewModel = new FileViewModel(self, file)
     } else {
       // this is mainly for patching and it may not fire due to the fact that
       // '/commit' triggers working-tree-changed which triggers throttled refresh
@@ -292,7 +292,7 @@ StagingViewModel.prototype.onAltEnter = function(d, e){
     return true;
 };
 
-var FileViewModel = function(staging, name, textDiffType, wordWrap) {
+var FileViewModel = function(staging, name) {
   var self = this;
   this.staging = staging;
   this.server = staging.server;
@@ -305,9 +305,6 @@ var FileViewModel = function(staging, name, textDiffType, wordWrap) {
   this.renamed = ko.observable(false);
   this.isShowingDiffs = ko.observable(false);
   this.diffProgressBar = components.create('progressBar', { predictionMemoryKey: 'diffs-' + this.staging.repoPath(), temporary: true });
-  this.isShowingDiffs = ko.observable(false);
-  this.textDiffType = textDiffType;
-  this.wordWrap = wordWrap;
   this.additions = ko.observable('');
   this.deletions = ko.observable('');
   this.fileType = ko.observable('text');
@@ -338,12 +335,13 @@ FileViewModel.prototype.getSpecificDiff = function() {
     filename: this.name(),
     repoPath: this.staging.repoPath,
     server: this.server,
-    textDiffType: this.textDiffType,
+    textDiffType: this.staging.textDiffType,
+    whiteSpace: this.staging.whiteSpace,
     isShowingDiffs: this.isShowingDiffs,
     diffProgressBar: this.diffProgressBar,
     patchLineList: this.patchLineList,
     editState: this.editState,
-    wordWrap: this.wordWrap
+    wordWrap: this.staging.wordWrap
   });
 }
 FileViewModel.prototype.setState = function(state) {

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -25,11 +25,7 @@ var StagingViewModel = function(server, repoPath) {
     self.commitMessageTitleCount(value.length);
   });
   this.commitMessageBody = ko.observable();
-  this.wordWrapTitle = ko.observable("No Word Wrap");
-  this.wordWrap = ko.observable(false);
-  this.wordWrap.subscribe(function(value) {
-    self.wordWrapTitle(value ? "Word Wrap" : "No Word Wrap");
-  });
+  this.wordWrap = components.create("textdiff.wordwrap");
   this.textDiffType = components.create('textdiff.type');
   this.inRebase = ko.observable(false);
   this.inMerge = ko.observable(false);
@@ -293,9 +289,6 @@ StagingViewModel.prototype.onAltEnter = function(d, e){
       this.commit();
     }
     return true;
-};
-StagingViewModel.prototype.wordWrapToggle = function() {
-  this.wordWrap(!this.wordWrap());
 };
 
 var FileViewModel = function(staging, name, textDiffType, wordWrap) {

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -9,9 +9,6 @@ var filesToDisplayLimit = filesToDisplayIncrmentBy;
 var muteGraceTimeDuration = 60 * 1000 * 5;
 var mergeTool = ungit.config.mergeTool;
 
-var sideBySideDiff = 'sidebysidediff'
-var textDiff = 'textdiff'
-
 components.register('staging', function(args) {
   return new StagingViewModel(args.server, args.repoPath);
 });
@@ -33,11 +30,7 @@ var StagingViewModel = function(server, repoPath) {
   this.wordWrap.subscribe(function(value) {
     self.wordWrapTitle(value ? "Word Wrap" : "No Word Wrap");
   });
-  this.textDiffTypeTitle = ko.observable("Default");
-  this.textDiffType = ko.observable(textDiff);
-  this.textDiffType.subscribe(function(value) {
-    self.textDiffTypeTitle(value === textDiff ? "Default" : "Side By Side");
-  });
+  this.textDiffType = components.create('textdiff.type');
   this.inRebase = ko.observable(false);
   this.inMerge = ko.observable(false);
   this.inCherry = ko.observable(false);
@@ -97,7 +90,7 @@ var StagingViewModel = function(server, repoPath) {
 
     if (!self.commitMessageTitle() && !self.inRebase()) return "Provide a title";
 
-    if (self.textDiffType() === sideBySideDiff) {
+    if (self.textDiffType.value() === 'sidebysidediff') {
       var patchFiles = self.files().filter(function(file) { return file.editState() === 'patched'; });
       if (patchFiles.length > 0) return "Cannot patch with side by side view."
     }
@@ -288,9 +281,6 @@ StagingViewModel.prototype.toggleAllStages = function() {
   }
 
   self.allStageFlag(!self.allStageFlag());
-}
-StagingViewModel.prototype.textDiffTypeToggle = function() {
-  this.textDiffType(this.textDiffType() === textDiff ? sideBySideDiff : textDiff);
 }
 StagingViewModel.prototype.onEnter = function(d, e){
     if (e.keyCode === 13 && !this.commitValidationError()) {

--- a/components/textdiff/textdiff.html
+++ b/components/textdiff/textdiff.html
@@ -1,7 +1,7 @@
 <!-- ko if: isShowingDiffs -->
 <div>
   <!-- ko if: isParsed -->
-  <div data-bind="template: {nodes: ko.utils.parseHtmlFragment(htmlSrc)}, css: {'word-wrap': wordWrap}"></div>
+  <div data-bind="template: {nodes: ko.utils.parseHtmlFragment(htmlSrc)}, css: {'word-wrap': wordWrap.value}"></div>
   <!-- /ko -->
   <div class="btn-load-more" data-bind="visible: loadMoreCount() > 0">
     <span class="btn btn-warning" data-bind="click: loadMore, text: 'Load ' + loadMoreCount() + ' more lines'"></span>

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -9,9 +9,26 @@ components.register('textdiff', function(args) {
 
 components.register('textdiff.type', function() {
   return new Type();
-})
+});
+
+components.register('textdiff.wordwrap', function() {
+  return new WordWrap();
+});
 
 var loadLimit = 100;
+
+var WordWrap = function() {
+  var self = this;
+
+  this.text = ko.observable("No Wrap");
+  this.value = ko.observable(false);
+  this.value.subscribe(function(value) {
+    self.text(value ? "Word Wrap" : "No Wrap");
+  });
+  this.toggle = function() {
+    self.value(!self.value());
+  }
+}
 
 var Type = function() {
   var self = this;

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -72,12 +72,16 @@ var TextDiffViewModel = function(args) {
   this.diffJson = null;
   this.loadCount = loadLimit;
   this.textDiffType = args.textDiffType;
+  this.whiteSpace = args.whiteSpace;
   this.isShowingDiffs = args.isShowingDiffs;
   this.diffProgressBar = args.diffProgressBar;
   this.editState = args.editState;
   this.wordWrap = args.wordWrap;
 
   this.textDiffType.value.subscribe(function() {
+    self.invalidateDiff();
+  });
+  this.whiteSpace.value.subscribe(function() {
     self.invalidateDiff();
   });
   this.patchLineList = args.patchLineList;
@@ -92,7 +96,8 @@ TextDiffViewModel.prototype.getDiffArguments = function() {
   return {
     file: this.filename,
     path: this.repoPath(),
-    sha1: this.sha1 ? this.sha1 : ''
+    sha1: this.sha1 ? this.sha1 : '',
+    whiteSpace: this.whiteSpace.value()
   };
 }
 

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -55,7 +55,7 @@ var WhiteSpace = function() {
   this.text = ko.observable("Show White Space");
   this.value = ko.observable(true);
   this.value.subscribe(function(value) {
-    self.text(value ? "Show White Space" : "Ignore White Space");
+    self.text(value ? "Showing White Space diff" : "Ignoring White Space diff");
   });
   this.toggle = function() {
     self.value(!self.value());

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -7,7 +7,26 @@ components.register('textdiff', function(args) {
   return new TextDiffViewModel(args);
 });
 
+components.register('textdiff.type', function() {
+  return new Type();
+})
+
 var loadLimit = 100;
+
+var Type = function() {
+  var self = this;
+  var sideBySideDiff = 'sidebysidediff'
+  var textDiff = 'textdiff'
+
+  this.text = ko.observable("Default");
+  this.value = ko.observable(textDiff);
+  this.value.subscribe(function(value) {
+    self.text(value === textDiff ? "Default" : "Side By Side");
+  });
+  this.toggle = function() {
+    self.value(self.value() === textDiff ? sideBySideDiff : textDiff);
+  }
+}
 
 var TextDiffViewModel = function(args) {
   var self = this;
@@ -24,7 +43,7 @@ var TextDiffViewModel = function(args) {
   this.editState = args.editState;
   this.wordWrap = args.wordWrap;
 
-  this.textDiffType.subscribe(function() {
+  this.textDiffType.value.subscribe(function() {
     self.invalidateDiff();
   });
   this.patchLineList = args.patchLineList;
@@ -95,7 +114,7 @@ TextDiffViewModel.prototype.render = function() {
 
   var html;
 
-  if (this.textDiffType() === 'sidebysidediff') {
+  if (this.textDiffType.value() === 'sidebysidediff') {
     html = diff2html.getPrettySideBySideHtmlFromJson(diffJsonCopy);
   } else {
     html = diff2html.getPrettyHtmlFromJson(diffJsonCopy);

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -52,10 +52,10 @@ var Type = function() {
 var WhiteSpace = function() {
   var self = this;
 
-  this.text = ko.observable("Show White Space");
-  this.value = ko.observable(true);
+  this.text = ko.observable("Showing White Space diff");
+  this.value = ko.observable(false);
   this.value.subscribe(function(value) {
-    self.text(value ? "Showing White Space diff" : "Ignoring White Space diff");
+    self.text(value ? "Ignoring White Space diff" : "Showing White Space diff");
   });
   this.toggle = function() {
     self.value(!self.value());

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -117,6 +117,7 @@ TextDiffViewModel.prototype.invalidateDiff = function(callback) {
         }
         return callback ? callback(err) : null;
       }
+      self.isParsed(false);
 
       if (typeof diffs == 'string') {
         self.diffJson = diff2html.getJsonFromDiff(diffs);
@@ -133,7 +134,6 @@ TextDiffViewModel.prototype.invalidateDiff = function(callback) {
 
 TextDiffViewModel.prototype.render = function() {
   if (this.diffJson.length == 0) return; // check if diffs are available (binary files do not support them)
-  this.isParsed(false);
 
   var self = this;
   var diffJsonCopy = JSON.parse(JSON.stringify(this.diffJson)); // make a json copy

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -33,6 +33,7 @@ var WordWrap = function() {
   this.toggle = function() {
     self.value(!self.value());
   }
+  this.isActive = ko.computed(function() { return !!self.value(); });
 }
 
 var Type = function() {
@@ -49,6 +50,9 @@ var Type = function() {
   this.toggle = function() {
     self.value(self.value() === textDiff ? sideBySideDiff : textDiff);
   }
+  this.isActive = ko.computed(function() {
+    return self.value() === 'textdiff';
+  });
 }
 
 var WhiteSpace = function() {
@@ -63,6 +67,7 @@ var WhiteSpace = function() {
   this.toggle = function() {
     self.value(!self.value());
   }
+  this.isActive = ko.computed(function() { return !self.value(); });
 }
 
 var TextDiffViewModel = function(args) {

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -15,6 +15,10 @@ components.register('textdiff.wordwrap', function() {
   return new WordWrap();
 });
 
+components.register('textdiff.whitespace', function() {
+  return new WhiteSpace();
+});
+
 var loadLimit = 100;
 
 var WordWrap = function() {
@@ -42,6 +46,19 @@ var Type = function() {
   });
   this.toggle = function() {
     self.value(self.value() === textDiff ? sideBySideDiff : textDiff);
+  }
+}
+
+var WhiteSpace = function() {
+  var self = this;
+
+  this.text = ko.observable("Show White Space");
+  this.value = ko.observable(true);
+  this.value.subscribe(function(value) {
+    self.text(value ? "Show White Space" : "Ignore White Space");
+  });
+  this.toggle = function() {
+    self.value(!self.value());
   }
 }
 

--- a/source/config.js
+++ b/source/config.js
@@ -133,7 +133,10 @@ const defaultConfig = {
 
   // Specifies a custom git merge tool to use when resolving conflicts. Your git configuration must be set up to use this!
   // A true value will use the default tool while a string value will use the tool of that specified name.
-  mergeTool: false
+  mergeTool: false,
+
+  // ignore white spaces changes in git-diff
+  ignoreWhiteSpace: false
 };
 
 // Works for now but should be moved to bin/ungit
@@ -186,7 +189,8 @@ let argv = yargs
 .describe('autoCheckoutOnBranchCreate', 'Auto checkout the created branch on creation')
 .describe('alwaysLoadActiveBranch', 'Always load with active checkout branch')
 .describe('numberOfNodesPerLoad', 'number of nodes to load for each git.log call')
-.describe('mergeTool', 'the git merge tool to use when resolving conflicts');
+.describe('mergeTool', 'the git merge tool to use when resolving conflicts')
+.describe('ignoreWhiteSpace', 'ignore white spaces changes in git-diff');
 
 // If not triggered by test, then do strict option check
 if (argv.$0.indexOf('mocha') === -1) {

--- a/source/config.js
+++ b/source/config.js
@@ -133,10 +133,7 @@ const defaultConfig = {
 
   // Specifies a custom git merge tool to use when resolving conflicts. Your git configuration must be set up to use this!
   // A true value will use the default tool while a string value will use the tool of that specified name.
-  mergeTool: false,
-
-  // ignore white spaces changes in git-diff
-  ignoreWhiteSpace: false
+  mergeTool: false
 };
 
 // Works for now but should be moved to bin/ungit
@@ -189,8 +186,7 @@ let argv = yargs
 .describe('autoCheckoutOnBranchCreate', 'Auto checkout the created branch on creation')
 .describe('alwaysLoadActiveBranch', 'Always load with active checkout branch')
 .describe('numberOfNodesPerLoad', 'number of nodes to load for each git.log call')
-.describe('mergeTool', 'the git merge tool to use when resolving conflicts')
-.describe('ignoreWhiteSpace', 'ignore white spaces changes in git-diff');
+.describe('mergeTool', 'the git merge tool to use when resolving conflicts');
 
 // If not triggered by test, then do strict option check
 if (argv.$0.indexOf('mocha') === -1) {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -197,7 +197,7 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/diff`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    jsonResultOrFailProm(res, gitPromise.diffFile(req.query.path, req.query.file, req.query.sha1));
+    jsonResultOrFailProm(res, gitPromise.diffFile(req.query.path, req.query.file, req.query.sha1, config.ignoreWhiteSpace));
   });
 
   app.get(`${exports.pathPrefix}/diff/image`, ensureAuthenticated, ensurePathExists, (req, res) => {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -197,8 +197,8 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/diff`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    var whiteSpace = req.query.whiteSpace === "true" ? true : false;
-    jsonResultOrFailProm(res, gitPromise.diffFile(req.query.path, req.query.file, req.query.sha1, whiteSpace));
+    var isIgnoreWhiteSpace = req.query.whiteSpace === "true" ? true : false;
+    jsonResultOrFailProm(res, gitPromise.diffFile(req.query.path, req.query.file, req.query.sha1, isIgnoreWhiteSpace));
   });
 
   app.get(`${exports.pathPrefix}/diff/image`, ensureAuthenticated, ensurePathExists, (req, res) => {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -197,7 +197,8 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/diff`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    jsonResultOrFailProm(res, gitPromise.diffFile(req.query.path, req.query.file, req.query.sha1, config.ignoreWhiteSpace));
+    var whiteSpace = req.query.whiteSpace === "true" ? true : false;
+    jsonResultOrFailProm(res, gitPromise.diffFile(req.query.path, req.query.file, req.query.sha1, whiteSpace));
   });
 
   app.get(`${exports.pathPrefix}/diff/image`, ensureAuthenticated, ensurePathExists, (req, res) => {

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -253,7 +253,7 @@ git.binaryFileContent = (repoPath, filename, version, outPipe) => {
   return git(['show', `${version}:${filename}`], repoPath, null, outPipe);
 }
 
-git.diffFile = (repoPath, filename, sha1) => {
+git.diffFile = (repoPath, filename, sha1, ignoreWhiteSpace) => {
   const newFileDiffArgs = ['diff', '--no-index', isWindows ? 'NUL' : '/dev/null', filename.trim()];
   return git.revParse(repoPath)
     .then((revParse) => { return revParse.type === 'bare' ? { files: {} } : git.status(repoPath) }) // if bare do not call status
@@ -272,9 +272,9 @@ git.diffFile = (repoPath, filename, sha1) => {
         if (file && file.isNew) {
           exec = git(newFileDiffArgs, repoPath, true);
         } else if (sha1) {
-          exec = git(['diff', `${sha1}^`, sha1, "--", filename.trim()], repoPath);
+          exec = git(['diff', ignoreWhiteSpace ? '-w' : '', `${sha1}^`, sha1, "--", filename.trim()], repoPath);
         } else {
-          exec = git(['diff', 'HEAD', '--', filename.trim()], repoPath);
+          exec = git(['diff', ignoreWhiteSpace ? '-w' : '', 'HEAD', '--', filename.trim()], repoPath);
         }
         return exec.catch((err) => {
           // when <rev> is very first commit and 'diff <rev>~1:[file] <rev>:[file]' is performed,


### PR DESCRIPTION
- add whitespace ignore option for file diffs
- changed diff option buttons to toggle buttons
- Fixed a nasty [bug](https://github.com/FredrikNoren/ungit/pull/791/commits/430c8d8197a41e36c24d8f624e25902c6491dca1) where recycled text diff object continuously add new subscriptions periodically and causing high number of duplicate API calls being made.