### PR TITLE
fix branch order for ideological branches

### DIFF
--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -224,7 +224,7 @@ GraphViewModel.prototype.markNodesIdeologicalBranches = function(refs, nodes, no
     if (a.isStash && !b.isStash) return 1;
     if (b.isStash && !a.isStash) return -1;
     if (a.node() && a.node().date && b.node() && b.node().date)
-      return b.node().date - a.node().date;
+      return a.node().date - b.node().date;
     return a.refName < b.refName ? -1 : 1;
   });
   var stamp = GraphViewModel._markIdeologicalStamp++;


### PR DESCRIPTION
fix: #804 

I doubt this will break anything and but I think this should eliminate most of the faulty display issues

before:
<img width="617" alt="screen shot 2016-11-06 at 20 55 04" src="https://cloud.githubusercontent.com/assets/5281068/20046883/a9d02b38-a463-11e6-8282-4e0d8d52e9c5.png">

after:
<img width="691" alt="screen shot 2016-11-06 at 20 54 36" src="https://cloud.githubusercontent.com/assets/5281068/20046881/a8cb4dbc-a463-11e6-8d71-3f5437ca9bb2.png">