### PR TITLE
fix to many file change events from file system watchers

### DIFF
--- a/source/git-api.js
+++ b/source/git-api.js
@@ -38,9 +38,10 @@ exports.registerApi = (env) => {
           const watcherPath = path.join(data.path, ...subFolders);
           const relativPath = subFolders.length > 0 ? path.join(...subFolders) : '';
 
-          const runOnFileWatchEvent = function(event, filename) {
+          const runOnFileWatchEvent = (event, filename) => {
             const filePath = path.join(relativPath, filename);
             if (isFileWatched(filePath, socket.ignore)) {
+              winston.info(`FILE WATCH TRIGGERED: ${filePath}`);
               emitGitDirectoryChanged(data.path);
               emitWorkingTreeChanged(data.path);
             }
@@ -58,9 +59,11 @@ exports.registerApi = (env) => {
 
             if (!isMac && !isWindows) {
               // recursive fs.watch only works on mac and windows
-              socket.watcher.push(watchPath(['.git']));
-              socket.watcher.push(watchPath(['.git', 'refs']));
-              winston.info(`Start watching with .git and .git/refs`);
+              socket.watcher.push(watchPath(['.git', 'HEAD']));
+              socket.watcher.push(watchPath(['.git', 'refs', 'heads']));
+              socket.watcher.push(watchPath(['.git', 'refs', 'remotes']));
+              socket.watcher.push(watchPath(['.git', 'refs', 'tags']));
+              winston.info(`Start watching with .git and .git/refs/[heads|remotes|tags]`);
             }
           }).catch((err) => {
             // Sometimes fs.watch crashes with errors such as ENOSPC (no space available)


### PR DESCRIPTION
fixes #820 

There might be an other bug:
What if `.gitignore` changes? Should we also update the state on the server?
<sub><strike>(currently changes to to `.gitignore` file are ignored because of the `startsWith` check)</strike> also fixed with this PR</sub>