### PR TITLE
display complete git message body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 - File diff firing increasing number of events longer it survives.
 - Fix missing ungit logo. [#812](https://github.com/FredrikNoren/ungit/issues/812)
 - Fix when stash output is empty [#818](https://github.com/FredrikNoren/ungit/issues/818)
+- Fix missing commit message body if commit was committed with Visual Studio or Visual Studio Code [#826](https://github.com/FredrikNoren/ungit/pull/826)
 
 ## [0.10.3](https://github.com/FredrikNoren/ungit/compare/v0.10.2...v0.10.3)
 

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -52,7 +52,7 @@ CommitViewModel.prototype.setData = function(args) {
   var message = args.message.split('\n');
   this.message(args.message);
   this.title(message[0]);
-  this.body(message.slice(2).join('\n'));
+  this.body(message.slice((message[1] ? 1 : 2)).join('\n'));
   this.authorDate(moment(new Date(args.authorDate)));
   this.authorDateFromNow(this.authorDate().fromNow());
   this.authorName(args.authorName);


### PR DESCRIPTION
some editors like visual studio and visual studio code do not add an extra newline character to separate the message title from the body

e.g.: 
```
title
body
```
instead of
```
title

body
```

before:
![image](https://cloud.githubusercontent.com/assets/4009570/20960954/2acad528-bc63-11e6-91d4-70c4e45ca9ba.png)


after:
![image](https://cloud.githubusercontent.com/assets/4009570/20960961/338f0a4e-bc63-11e6-927d-3b604aade224.png)



<sub>Sadly this commit can not be taken as an example because I have amend it with ungit...</sub>
