### PR TITLE
Continuous delivery

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -38,3 +38,5 @@ build/
 *.dll
 nw.exe
 nw.pak
+
+.npmrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ before_script:
   - git config --global user.name "Test testy"
   - git version
   - grunt -d
+after_script:
+  - grunt travisnpmpublish

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
   - "4.1"
   - "5.3"
   - "6.0"
+branches:
+  only:
+    - master
 env:
   global:
     - CXX=g++-4.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/) and
-[Keep a changlelog's changelog standard](http://keepachangelog.com/)
+This project adheres to [Semantic Versioning](http://semver.org/).
+Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v0.10.3...master)
+- 1.0.0: Introduced Continuous delivery. [#823](https://github.com/FredrikNoren/ungit/issues/823)
+
+## [1.0.0](https://github.com/FredrikNoren/ungit/compare/v0.10.3...v1.0.0)
 
 ### Added
 - Added search by git folder name in the search bar. [#793](https://github.com/FredrikNoren/ungit/issues/793)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Just common sense; do a quick search before posting, someone might already have 
 Pull requests
 =============
 Make sure to include a note in CHANGELOG.md about the change as part of the PR.
-We follow the ["Keep a changelog"](http://keepachangelog.com/) style guide.
-Make sure to include reference's to issues and PR's when relevant in the change log.
+The CHANGELOG format is: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
+For code change PR's: Bump the version in `package.json`. Bump minor version if the change introduces new features, otherwise patch.
 
 Writing plugins
 ===============

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,14 @@ Just common sense; do a quick search before posting, someone might already have 
 
 Pull requests
 =============
-Make sure to include a note in CHANGELOG.md about the change as part of the PR.
-The CHANGELOG format is: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
-For code change PR's: Bump the version in `package.json`. Bump minor version if the change introduces new features, otherwise patch.
+All PRs are automatically published to NPM once merged (see [#823](https://github.com/FredrikNoren/ungit/issues/823)).
+There are two things you have to do for all PRs:
+- Make sure to include a note in CHANGELOG.md about the change as part of the PR.
+- If it's a code change: Bump the version in `package.json`.
+  - Does the change fundamentally change how people use Ungit: Bump the major version.
+  - Does the change introduce new features: Bump the minor version.
+  - Otherwise (bug fixes, tweaks and refactoring): Bump patch version.
+  - If the change doesn't affect the product (e.g. you change the README): No need to bump the version.
 
 Writing plugins
 ===============

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -442,7 +442,7 @@ module.exports = function(grunt) {
   }
   function updatePackageJsonBuildVersion(commitHash) {
     var packageJson = JSON.parse(fs.readFileSync('package.json'));
-    packageJson.version += '-' + commitHash;
+    packageJson.version += '+' + commitHash;
     fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2) + '\n');
   }
   grunt.registerTask('travisnpmpublish', 'Automatically publish to NPM via travis.', function() {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -436,7 +436,7 @@ module.exports = function(grunt) {
   }
 
   function getGitLastCommitHash(callback) {
-    childProcess.exec("git rev-parse --short HEAD", (err, stdout, stderr) => {
+    childProcess.exec("git rev-parse --short HEAD", function(err, stdout, stderr) {
       callback(stdout.trim());
     });
   }
@@ -451,10 +451,10 @@ module.exports = function(grunt) {
       console.log('Skipping travis npm publish');
       return done();
     }
-    getGitLastCommitHash(hash => {
+    getGitLastCommitHash(function(hash) {
       updatePackageJsonBuildVersion(hash);
       fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_authToken=' + process.env.NPM_TOKEN);
-      childProcess.exec("npm publish", () => done());
+      childProcess.exec("npm publish", function() { done(); });
     })
   });
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ environment:
   matrix:
   - nodejs_version: "6.0"
 
+branches:
+  only:
+    - master
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - git config --global user.email "test@testy.com"

--- a/components/app/app.html
+++ b/components/app/app.html
@@ -10,7 +10,11 @@
   </div>
 
   <div class="alert alert-info" data-bind="visible: newVersionAvailable">
-    A new version of ungit (<span data-bind="text: latestVersion"></span>) is <a href="https://github.com/FredrikNoren/ungit">available</a>! Run <code data-bind="text: newVersionInstallCommand"></code> to install. (You are currently running version <span data-bind="text: currentVersion"></span>.)
+    A new version of ungit (<span data-bind="text: latestVersion"></span>) is
+    <a href="https://github.com/FredrikNoren/ungit">available</a>! Run
+    <code data-bind="text: newVersionInstallCommand"></code> to install.
+    See what's new in our
+    <a href="https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md">changelog</a>.
     <button type="button" class="close" data-dismiss="alert">&times;</button>
   </div>
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "0.10.3",
+  "version": "1.0.0",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/source/server.js
+++ b/source/server.js
@@ -269,9 +269,22 @@ app.get('/api/latestversion', (req, res) => {
   sysinfo.getUngitLatestVersion()
     .then((latestVersion) => {
       if (!semver.valid(config.ungitDevVersion)) {
-        res.json({ latestVersion: latestVersion, currentVersion: config.ungitDevVersion, outdated: false });
+        res.json({
+          latestVersion: latestVersion,
+          currentVersion: config.ungitDevVersion,
+          outdated: false
+        });
       } else {
-        res.json({ latestVersion: latestVersion, currentVersion: config.ungitDevVersion, outdated: semver.gt(latestVersion, config.ungitDevVersion) });
+        // We only want to show the "new version" banner if the major/minor version was bumped
+        let latestSansPatch = semver(latestVersion);
+        latestSansPatch.patch = 0;
+        let currentSansPatch = semver(config.ungitDevVersion);
+        currentSansPatch.patch = 0;
+        res.json({
+          latestVersion: latestVersion,
+          currentVersion: config.ungitDevVersion,
+          outdated: semver.gt(latestSansPatch, currentSansPatch)
+        });
       }
     }).catch((err) => {
       res.json({ latestVersion: config.ungitDevVersion, currentVersion: config.ungitDevVersion, outdated: false });


### PR DESCRIPTION
This PR introduces Continuous delivery. Each build on master will be published automatically to npm moving forward. This means that improvements to Ungit will be available to end users at a much earlier time than what we've seen historically.

To make sure end users don't get overwhelmed with "please upgrade" messages only major/minor changes will be advertised in the UI (i.e. patch version will not be advertised).

This PR also bumps the version to 1.0.0 since this a major change in how Ungit is delivered (and I've been looking for an excuse to bump it to 1.0.0 for a while ;) ). Since changes will be automatically delivered moving forward, this change will also release a host of previously unreleased features and fixes on master that were awaiting release.

Fixes #823
Fixes #621