### PR TITLE
Persist commit messages during conflict resolution and refresh file content correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 - Updated file watch logic to closely follow git commands in another process [#283](https://github.com/FredrikNoren/ungit/issues/283)
 - Persist commit messages during merge operation [#779](https://github.com/FredrikNoren/ungit/issues/779)
 - Refresh staging.files object for cleaner refresh such as refresh pached line list, diff and etc.
+- Fixed an issue where patching on some key word file names such as "test".
 
 ### Fixed
 - File diff firing increasing number of events longer it survives.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 - Fix for favorites linking in case rootPath is used @sebastianmay [#609](https://github.com/FredrikNoren/ungit/issues/609) and image diffing
 - Limit commit title to 72 characters, the rest is truncated and shown when inspecting the commit
 - Updated file watch logic to closely follow git commands in another process [#283](https://github.com/FredrikNoren/ungit/issues/283)
+- Persist commit messages during merge operation [#779](https://github.com/FredrikNoren/ungit/issues/779)
+- Refresh staging.files object for cleaner refresh such as refresh pached line list, diff and etc.
 
 ### Fixed
 - File diff firing increasing number of events longer it survives.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and
 - Fix for favorites linking in case rootPath is used @sebastianmay [#609](https://github.com/FredrikNoren/ungit/issues/609) and image diffing
 - Limit commit title to 72 characters, the rest is truncated and shown when inspecting the commit
 - Updated file watch logic to closely follow git commands in another process [#283](https://github.com/FredrikNoren/ungit/issues/283)
-- Persist commit messages during merge operation [#779](https://github.com/FredrikNoren/ungit/issues/779)
-- Refresh staging.files object for cleaner refresh such as refresh pached line list, diff and etc.
-- Fixed an issue where patching on some key word file names such as "test".
 
 ### Fixed
 - File diff firing increasing number of events longer it survives.
 - Fix missing ungit logo. [#812](https://github.com/FredrikNoren/ungit/issues/812)
 - Fix when stash output is empty [#818](https://github.com/FredrikNoren/ungit/issues/818)
+- Persist commit messages during merge operation [#779](https://github.com/FredrikNoren/ungit/issues/779)
+- Refresh `staging.files` object for cleaner refresh such as refresh pached line list, diff and etc.
+- Fixed an issue where patching on some key word file names such as "test".
 
 ## [0.10.3](https://github.com/FredrikNoren/ungit/compare/v0.10.2...v0.10.3)
 

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -234,14 +234,13 @@ StagingViewModel.prototype.commit = function() {
   });
   var commitMessage = this.commitMessageTitle();
   if (this.commitMessageBody()) commitMessage += '\n\n' + this.commitMessageBody();
-  this.server.post('/commit', { path: this.repoPath(), message: commitMessage, files: files, amend: this.amend() }, function(err, res) {
-    self.committingProgressBar.stop();
-    if (err) {
-      return;
-    }
-    self.resetMessages();
-    self.files([]);
-  });
+
+  this.server.postPromise('/commit', { path: this.repoPath(), message: commitMessage, files: files, amend: this.amend() })
+    .catch(function() {})
+    .finally(function() {
+      self.committingProgressBar.stop();
+      self.resetMessages();
+    });
 }
 StagingViewModel.prototype.conflictResolution = function(apiPath, progressBar) {
   var self = this;

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -222,6 +222,7 @@ StagingViewModel.prototype.toggleAmend = function() {
 StagingViewModel.prototype.resetMessages = function() {
   this.commitMessageTitle('');
   this.commitMessageBody('');
+  this.filesByPath = {};
   this.amend(false);
 }
 StagingViewModel.prototype.commit = function() {

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -178,8 +178,10 @@ StagingViewModel.prototype.loadStatus = function(status, callback) {
     this.commitMessageBody('Commit messages are not applicable!\n(╯°□°）╯︵ ┻━┻');
   } else if (this.inMerge() || this.inCherry()) {
     var lines = status.commitMessage.split('\n');
-    this.commitMessageTitle(lines[0]);
-    this.commitMessageBody(lines.slice(1).join('\n'));
+    if (!this.commitMessageTitle()) {
+      this.commitMessageTitle(lines[0]);
+      this.commitMessageBody(lines.slice(1).join('\n'));
+    }
   }
   if (callback) callback();
 }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -271,7 +271,7 @@ git.binaryFileContent = (repoPath, filename, version, outPipe) => {
 }
 
 git.diffFile = (repoPath, filename, sha1, ignoreWhiteSpace) => {
-  const newFileDiffArgs = ['diff', '--no-index', isWindows ? 'NUL' : '/dev/null', filename.trim()];
+  const newFileDiffArgs = ['diff', '--no-index', isWindows ? 'NUL' : '/dev/null', '--', filename.trim()];
   return git.revParse(repoPath)
     .then((revParse) => { return revParse.type === 'bare' ? { files: {} } : git.status(repoPath) }) // if bare do not call status
     .then((status) => {
@@ -377,7 +377,7 @@ git.commit = (repoPath, amend, message, files) => {
       if (fileStatus.removed) {
         toRemove.push(file.name.trim());
       } else if (files[v].patchLineList) {
-        diffPatchPromises.push(git(['diff', file.name.trim()], repoPath)
+        diffPatchPromises.push(git(['diff', '--', file.name.trim()], repoPath)
           .then(gitParser.parsePatchDiffResult.bind(null, file.patchLineList))
           .then(git.applyPatchedDiff.bind(null, repoPath)));
       } else {

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -271,7 +271,7 @@ git.binaryFileContent = (repoPath, filename, version, outPipe) => {
 }
 
 git.diffFile = (repoPath, filename, sha1, ignoreWhiteSpace) => {
-  const newFileDiffArgs = ['diff', '--no-index', isWindows ? 'NUL' : '/dev/null', '--', filename.trim()];
+  const newFileDiffArgs = ['diff', '--no-index', isWindows ? 'NUL' : '/dev/null', filename.trim()];
   return git.revParse(repoPath)
     .then((revParse) => { return revParse.type === 'bare' ? { files: {} } : git.status(repoPath) }) // if bare do not call status
     .then((status) => {


### PR DESCRIPTION
1. fixes #779 where commit messages gets disregarded after conflict resolution operations 
2. Fixed issues where stale `FileViewModel` object caused problems such as below:
    - stale file diff
    - persisted patched line selection after patching operations is done.
3. Fixed an issue where patching on some key word file names such as "test"