### PR TITLE
[#847] Fix case sensitivity of email address in gravatar hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Use the following format for additions: ` - VERSION: [feature/patch (if applicab
 
 - 1.0.0: Introduced Continuous delivery. [#823](https://github.com/FredrikNoren/ungit/issues/823)
 
+## [1.0.1](https://github.com/FredrikNoren/ungit/compare/v1.0.0...v1.0.1)
+
+### Fixed
+- Fixed gravatar avatar fetch if email have different cases applied. [#847](https://github.com/FredrikNoren/ungit/issues/847)
+
 ## [1.0.0](https://github.com/FredrikNoren/ungit/compare/v0.10.3...v1.0.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.0.1: [patch] Fixed gravatar avatar fetch if email have different cases applied. [#847](https://github.com/FredrikNoren/ungit/issues/847)
 - 1.0.0: Introduced Continuous delivery. [#823](https://github.com/FredrikNoren/ungit/issues/823)
-
-## [1.0.1](https://github.com/FredrikNoren/ungit/compare/v1.0.0...v1.0.1)
-
-### Fixed
-- Fixed gravatar avatar fetch if email have different cases applied. [#847](https://github.com/FredrikNoren/ungit/issues/847)
 
 ## [1.0.0](https://github.com/FredrikNoren/ungit/compare/v0.10.3...v1.0.0)
 

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -31,7 +31,7 @@ function CommitViewModel(gitNode) {
   this.fileLineDiffs = ko.observable();
   this.numberOfAddedLines = ko.observable();
   this.numberOfRemovedLines = ko.observable();
-  this.authorGravatar = ko.computed(function() { return md5(self.authorEmail()); });
+  this.authorGravatar = ko.computed(function() { return md5(self.authorEmail().toLowerCase()); });
 
   this.showCommitDiff = ko.computed(function() {
     return self.fileLineDiffs() && self.fileLineDiffs().length > 0;

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -33,7 +33,7 @@ function CommitViewModel(gitNode) {
   this.numberOfRemovedLines = ko.observable();
   this.authorGravatar = ko.computed(function() {
     var lowerCaseEmail = self.authorEmail();
-    lowerCaseEmail = lowerCaseEmail ? lowerCaseEmail.toLowerCase() : lowerCaseEmail;
+    lowerCaseEmail = lowerCaseEmail ? lowerCaseEmail.toLowerCase().trim() : lowerCaseEmail;
     return md5(lowerCaseEmail);
   });
 

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -33,7 +33,7 @@ function CommitViewModel(gitNode) {
   this.numberOfRemovedLines = ko.observable();
   this.authorGravatar = ko.computed(function() {
     var lowerCaseEmail = self.authorEmail();
-    lowerCaseEmail = lowerCaseEmail ? lowerCaseEmail.toLowerCase().trim() : lowerCaseEmail;
+    lowerCaseEmail = lowerCaseEmail ? lowerCaseEmail.toLowerCase() : lowerCaseEmail;
     return md5(lowerCaseEmail);
   });
 

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -33,7 +33,7 @@ function CommitViewModel(gitNode) {
   this.numberOfRemovedLines = ko.observable();
   this.authorGravatar = ko.computed(function() {
     var lowerCaseEmail = self.authorEmail();
-    lowerCaseEmail = lowerCaseEmail ? lowerCaseEmail.toLowerCase() : lowerCaseEmail;
+    lowerCaseEmail = lowerCaseEmail ? lowerCaseEmail.trim().toLowerCase() : lowerCaseEmail;
     return md5(lowerCaseEmail);
   });
 

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -31,7 +31,11 @@ function CommitViewModel(gitNode) {
   this.fileLineDiffs = ko.observable();
   this.numberOfAddedLines = ko.observable();
   this.numberOfRemovedLines = ko.observable();
-  this.authorGravatar = ko.computed(function() { return md5(self.authorEmail().toLowerCase()); });
+  this.authorGravatar = ko.computed(function() {
+    var lowerCaseEmail = self.authorEmail();
+    lowerCaseEmail = lowerCaseEmail ? lowerCaseEmail.toLowerCase() : lowerCaseEmail;
+    return md5(lowerCaseEmail);
+  });
 
   this.showCommitDiff = ko.computed(function() {
     return self.fileLineDiffs() && self.fileLineDiffs().length > 0;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
- Solve vase sensitivity for gravatar avatars [resolves #847]
> based on https://en.gravatar.com/site/implement/hash/
> Currently, if I write `Neilkalman@gmail.com` or `neilkalman@gmail.com`, I don't get the same result. I made it so that every email is transformed to lowercase so that md5 will work