### PR TITLE
Add option to override ungit version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.0: Added option to ignore ungit version checks [#851](https://github.com/FredrikNoren/ungit/issues/851)
 - 1.0.1: [patch] Fixed gravatar avatar fetch if email have different cases applied. [#847](https://github.com/FredrikNoren/ungit/issues/847)
 - 1.0.0: Introduced Continuous delivery. [#823](https://github.com/FredrikNoren/ungit/issues/823)
 

--- a/components/app/app.js
+++ b/components/app/app.js
@@ -75,7 +75,7 @@ AppViewModel.prototype.shown = function() {
     if (!version) return;
     self.currentVersion(version.currentVersion);
     self.latestVersion(version.latestVersion);
-    self.newVersionAvailable(version.outdated);
+    self.newVersionAvailable(!ungit.config.ungitVersionCheckOverride && version.outdated);
   });
   this.server.get('/gitversion', undefined, function(err, gitversion) {
     if (!gitversion) return;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/source/config.js
+++ b/source/config.js
@@ -107,6 +107,9 @@ const defaultConfig = {
   // Don't show errors when the user is using a bad or undecidable git version
   gitVersionCheckOverride: false,
 
+  // Don't show upgrade message when the user is using an older version of ungit
+  ungitVersionCheckOverride: false,
+
   // Automatically does stash -> operation -> stash pop when you checkout, reset or cherry pick. This makes it
   // possible to perform those actions even when you have a dirty working directory.
   autoStashAndPop: true,
@@ -148,6 +151,7 @@ let argv = yargs
 .alias('o', 'gitVersionCheckOverride')
 .alias('v', 'version')
 .describe('o', 'Ignore git version check and allow ungit to run with possibly lower versions of git')
+.describe('ungitVersionCheckOverride', 'Ignore check for older version of ungit')
 .describe('b', 'Launch a browser window with ungit when the ungit server is started. --no-b or --no-launchBrowser disables this')
 .describe('cliconfigonly', 'Ignore the default configuration points and only use parameters sent on the command line')
 .describe('port', 'The port ungit is exposed on')


### PR DESCRIPTION
This PR adds a config `--ungitVersionCheckOverride` to ignore ungit version checks. It hides the notification message from the client side, and doesn't touch the version check functionality on the server side.

I didn't think this change warranted a new entry in the change log and bumping the patch version, please let me know if you think otherwise.

Fixes https://github.com/FredrikNoren/ungit/issues/851