### PR TITLE
Realtime diff change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.8:
+    - Realtime text diff via invalidate diff on directory change
 - 1.1.7:
     - Fix diff flickering issue and optimization [#865](https://github.com/FredrikNoren/ungit/pull/865)
     - Fix credential dialog issue [#864](https://github.com/FredrikNoren/ungit/pull/864)

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -66,6 +66,7 @@ PathViewModel.prototype.updateStatus = function() {
         self.status(status.type);
         self.repository(null);
       }
+      return null;
     }).catch(function(err) { })
     .finally(function() { self.loadingProgressBar.stop() });
 }

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -92,7 +92,7 @@ var TextDiffViewModel = function(args) {
   this.isParsed = ko.observable(false);
 
   programEvents.add(function(event) {
-    if (event.event === "invalidate-diff-and-render") {
+    if (event.event === "invalidate-diff-and-render" || event.event === "working-tree-changed") {
       self.invalidateDiff();
       if (self.isShowingDiffs()) self.render();
     }

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -141,7 +141,7 @@ TextDiffViewModel.prototype.render = function(isInvalidate) {
       return self.getDiffJson();
     }
   }).then(function() {
-    if (self.diffJson.length == 0) return; // check if diffs are available (binary files do not support them)
+    if (!self.diffJson || self.diffJson.length == 0) return; // check if diffs are available (binary files do not support them)
     var lineCount = 0;
 
     if (!self.diffJson[0].isTrimmed) {


### PR DESCRIPTION
Once diff caching means less network traffic but also means we've lost real time text diff change view as file is altered on the background.

Fixed this via simply adding diff invalidation upon directory change event.