### PR TITLE
Fix cache value being promise in ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.9: Fix around ubuntu's inability to cache promises. [#877](https://github.com/FredrikNoren/ungit/pull/878)
 - 1.1.8:
     - Realtime text diff via invalidate diff on directory change [#867](https://github.com/FredrikNoren/ungit/pull/867)
     - Promisify `./source/utils/cache.js` [#870](https://github.com/FredrikNoren/ungit/pull/870)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/source/utils/cache.js
+++ b/source/utils/cache.js
@@ -15,8 +15,11 @@ cache.resolveFunc = (key) => {
     .catch({ errorcode: "ENOTFOUND" }, (e) => {
       if (!funcMap[key]) throw e;     // func associated with key is not found, throw not found error
       const result = funcMap[key].func();  // func is found, resolve, set with TTL and return result
-      return cache.setAsync(key, result, funcMap[key].ttl)
-        .then(() => { return result });
+      return (result.then ? result : Bluebird.resolve(result))
+        .then((r) => {
+          return cache.setAsync(key, r, funcMap[key].ttl)
+            .then(() => { return r; })
+        });
     });
 }
 


### PR DESCRIPTION
fix: #877

This was a crazy bug and I would definitely need more investigation to confirm but it seems that then blocks that are created after the promise is resolved doesn't get called within ubuntu.  I think that is against A+ promise spec but it has been awhile since I took a look at that...

But what we were doing is that we would cache the promise object and chain the then from there, however for whatever reason ubuntu couldn't chain then functions when promise is already resolved and cache was useless as we weren't able to extract the value.

This fix is to store hard value if cached function result value is a promise.


This is a fun bug and I'm interested in seeing how the OS diff cause this subtle bug...

