### PR TITLE
Fix cli args; Ignore ~/.ungitrc with syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.11:
+    - Fix cli arguments [#871](https://github.com/FredrikNoren/ungit/pull/871)
+    - Stop if ~/.ungitrc contains syntax error
+    - Removed official support ini format of ~/.ungitrc, because internal API supports only JSON
 - 1.1.10: Fix broken diff out in some cases when diff contains table. [#881](https://github.com/FredrikNoren/ungit/pull/881)
 - 1.1.9: Fix around ubuntu's inability to cache promises. [#877](https://github.com/FredrikNoren/ungit/pull/878)
 - 1.1.8:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This will launch the server and open up a browser with the ui.
 
 Configuring
 ---------
-Put a configuration file called .ungitrc in your home directory (`/home/USERNAME` on \*nix, `C:/Users/USERNAME/` on windows). Can be in either json or ini format. See [source/config.js](source/config.js) for available options.
+Put a configuration file called .ungitrc in your home directory (`/home/USERNAME` on \*nix, `C:/Users/USERNAME/` on windows). Configuration file must be in json format. See [source/config.js](source/config.js) for available options.
 
 You can also override configuration variables at launch by specifying them as command line arguments; `ungit --port=8080`. To disable boolean features use --no: `ungit --no-autoFetch`.
 
@@ -56,8 +56,6 @@ Example of `~/.ungitrc` configuration file to change default port and enable bug
 	"bugtracking": true
 }
 ```
-
-Ungit uses [rc](https://github.com/dominictarr/rc) for configuration, which in turn uses [yargs](https://github.com/yargs/yargs) for command line arguments. See corresponding documentations for more details.
 
 External Merge Tools
 --------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/source/server.js
+++ b/source/server.js
@@ -305,11 +305,14 @@ app.get('/api/gitversion', (req, res) => {
 const userConfigPath = path.join(config.homedir, '.ungitrc');
 const readUserConfig = () => {
   return fs.isExists(userConfigPath).then((hasConfig) => {
-      if (!hasConfig) return {};
-      return fs.readFileAsync(userConfigPath, { encoding: 'utf8' }).then((content) => {
-          return JSON.parse(content.toString());
-        });
-    });
+    if (!hasConfig) return {};
+    return fs.readFileAsync(userConfigPath, { encoding: 'utf8' })
+      .then((content) => { return JSON.parse(content.toString()); })
+      .catch((err) => {
+        winston.error(`Stop at reading ~/.ungitrc because ${err}`);
+        process.exit(0);
+      });
+  });
 }
 const writeUserConfig = (configContent) => {
   return fs.writeFileAsync(userConfigPath, JSON.stringify(configContent, undefined, 2));


### PR DESCRIPTION
fixes: #871
--cliconfigonly works now. Transparent override configs: default -> rc -> argv

Post to /api/userconfig writes in JSON, therefore support ini format can be confusing. 

It would be good if yargs started to support an arbitrary configuration and all of the standard paths as in rc. Then it would be possible to remove the rc dependency