### PR TITLE
reporting commit error in the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.15: if a commit fail (e.g., because of a pre-commit hook) the error is reported in the UI
 - 1.1.14: Disable strict mode for startup params and config [#890](https://github.com/FredrikNoren/ungit/issues/890)
 - 1.1.13: Fix startup args bug: [#896](https://github.com/FredrikNoren/ungit/issues/896)
 - 1.1.12:

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -243,7 +243,15 @@ StagingViewModel.prototype.commit = function() {
 
   this.server.postPromise('/commit', { path: this.repoPath(), message: commitMessage, files: files, amend: this.amend() })
     .then(function() { self.resetMessages(); })
-    .catch(function() {})
+    .catch(function(err) {
+      programEvents.dispatch({ event: 'git-error', data: {
+        command: err.res.body.command,
+        error: err.errorSummary,
+        stdout: err.res.body.stdout,
+        stderr: err.res.body.stderr,
+        repoPath: err.res.body.workingDirectory
+      } });
+    })
     .finally(function() { self.committingProgressBar.stop(); });
 }
 StagingViewModel.prototype.conflictResolution = function(apiPath, progressBar) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
It helpful for the error to be reported in the UI vs having to view the error in the console.  Pre-commit hooks are a common source of these type of errors