### PR TITLE
Fix checking out remote refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.17: Fix checking out remote refs
 - 1.1.16:
   - clicktests logging correction and using wait for within tests.
   - Refactor filewatch and using normalized test path

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,12 @@ Getting started
 
 To get started developing on Ungit:
 
- 1. Make sure you have [node.js](http://nodejs.org), [npm](https://npmjs.org/), [git](http://git-scm.com/) and [grunt](http://gruntjs.com/) installed.
+ 1. Make sure you have [node.js](http://nodejs.org), [npm](https://npmjs.org/) and [git](http://git-scm.com/) installed.
  2. Clone the repository to a local directory.
  3. Run `npm install` to install dependencies.
- 4. Run `grunt` to build (compile templates, css and js).
+ 4. Run `npm run build` to build (compile templates, css and js).
  5. Type `npm start` to start ungit, or `npm test` to run tests.
- 6. (Optional). Run `grunt watch` to automatically rebuild stuff when you change files.
+ 6. (Optional). Run `npm run watch` to automatically rebuild stuff when you change files.
 
 Run ungit as standalone application
 -----------------------------------

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -133,6 +133,15 @@ RefViewModel.prototype.remove = function() {
     });
 }
 
+RefViewModel.prototype.getLocalRef = function() {
+  return this.graph.getRef(this.getLocalRefFullName(), false);
+}
+RefViewModel.prototype.getLocalRefFullName = function() {
+  if (this.isRemoteBranch) return 'refs/heads/' + this.refName;
+  if (this.isRemoteTag) return 'tag: ' + this.refName;
+  return null;
+}
+
 RefViewModel.prototype.getRemoteRef = function(remote) {
   return this.graph.getRef(this.getRemoteRefFullName(remote), false);
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",
-    "test": "grunt test"
+    "test": "grunt test",
+    "build": "grunt",
+    "watch": "grunt watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously this is what happened when checking out origin/somebranch:

- Checkout somebranch
- Move somebranch to origin/somebranch

Now, the opposite happens:

- Move somebranch to origin/somebranch
- Checkout somebranch

The reason this is better is because the "checkout some branch" step often creates unnecessary conflicts with whatever you have in your working directory, that is only conflicts with wherever the branch previously was (not where the origin is).