### PR TITLE
Fix frontend promise implementation ignoring git error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.24: fix some commands not properly reporting git error [#933](https://github.com/FredrikNoren/ungit/issues/933)
 - 1.1.23: finalize nightmare click test
 - 1.1.22: Add a config setting to allow setting the default diff type. [#929](https://github.com/FredrikNoren/ungit/issues/929)
 - 1.1.21:

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -37,7 +37,6 @@ BranchesViewModel.prototype.checkoutBranch = function(branch) {
   this.fetchingProgressBar.start();
   this.server.postPromise('/checkout', { path: this.repoPath(), name: branch.name })
     .then(function() { self.current(branch.name); })
-    .catch(function() {})
     .finally(function() { self.fetchingProgressBar.stop(); });
 }
 BranchesViewModel.prototype.updateBranches = function() {
@@ -70,8 +69,7 @@ BranchesViewModel.prototype.branchRemove = function(branch) {
     .show()
     .closeThen(function(diag) {
       if (!diag.result()) return;
-      self.server.delPromise('/branches', { name: branch.name, path: self.repoPath() }).then(function(err) {
-        programEvents.dispatch({ event: 'working-tree-changed' });
-      }).catch(function() {});
+      self.server.delPromise('/branches', { name: branch.name, path: self.repoPath() })
+        .then(function() { programEvents.dispatch({ event: 'working-tree-changed' }); });
     });
 }

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -119,7 +119,6 @@ RefViewModel.prototype.remove = function() {
   if (this.isRemote) url = '/remote' + url;
 
   return this.server.delPromise(url, { path: this.graph.repoPath(), remote: this.isRemote ? this.remote : null, name: this.refName })
-    .catch(function() {})
     .then(function() {
       self.node().removeRef(self);
       self.graph.refsByRefName[self.name] = undefined;

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -72,7 +72,7 @@ PathViewModel.prototype.updateStatus = function() {
 }
 PathViewModel.prototype.initRepository = function() {
   var self = this;
-  return this.server.postPromise('/init', { path: this.repoPath() }).catch(function() {})
+  return this.server.postPromise('/init', { path: this.repoPath() })
     .finally(function(res) { self.updateStatus(); });
 }
 PathViewModel.prototype.onProgramEvent = function(event) {
@@ -91,8 +91,7 @@ PathViewModel.prototype.cloneRepository = function() {
 
   return this.server.postPromise('/clone', { path: this.repoPath(), url: this.cloneUrl(), destinationDir: dest }).then(function(res) {
       navigation.browseTo('repository?path=' + encodeURIComponent(res.path));
-    }).catch(function() {})
-    .finally(function() { self.cloningProgressBar.stop() })
+    }).finally(function() { self.cloningProgressBar.stop() })
 }
 PathViewModel.prototype.createDir = function() {
   var self = this;

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -91,8 +91,7 @@ RemotesViewModel.prototype.showAddRemoteDialog = function() {
     .closeThen(function(diag) {
       if(diag.isSubmitted()) {
         return self.server.postPromise('/remotes/' + encodeURIComponent(diag.name()), { path: self.repoPath(), url: diag.url() })
-          .then(function() { self.updateRemotes(); })
-          .catch(function() {});
+          .then(function() { self.updateRemotes(); });
       }
     });
 }

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -243,7 +243,6 @@ StagingViewModel.prototype.commit = function() {
 
   this.server.postPromise('/commit', { path: this.repoPath(), message: commitMessage, files: files, amend: this.amend() })
     .then(function() { self.resetMessages(); })
-    .catch(function() {})
     .finally(function() { self.committingProgressBar.stop(); });
 }
 StagingViewModel.prototype.conflictResolution = function(apiPath, progressBar) {
@@ -252,7 +251,6 @@ StagingViewModel.prototype.conflictResolution = function(apiPath, progressBar) {
   var commitMessage = this.commitMessageTitle();
   if (this.commitMessageBody()) commitMessage += '\n\n' + this.commitMessageBody();
   this.server.postPromise(apiPath, { path: this.repoPath(), message: commitMessage })
-    .catch(function(){})
     .finally(function(err, res) {
       self.resetMessages();
       progressBar.stop();

--- a/components/submodules/submodules.js
+++ b/components/submodules/submodules.js
@@ -59,8 +59,7 @@ SubmodulesViewModel.prototype.showAddSubmoduleDialog = function() {
       self.fetchProgressBar.start();
       self.server.postPromise('/submodules/add', { path: self.repoPath(), submoduleUrl: diag.url(), submodulePath: diag.path() }).then(function() {
           programEvents.dispatch({ event: 'submodule-fetch' });
-        }).catch(function() {})
-        .finally(function() { self.fetchProgressBar.stop(); });
+        }).finally(function() { self.fetchProgressBar.stop(); });
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
Fix: #933

This is a mistake carrying over from front end promisify effort.  previously, we were doing, API call -> check for error and log if needed -> handle response.  But with the help of promises, we are now doing API call -> handle response -> check for error via catch.  Which means catching and ignoring error we've been doing would result in lost error message, (previously "catch and ignore" was implemented to do something that is in effect of "finally" block.  

This left over hangover from pre promise strategy is now removed.


p.s. Huge shout out to @bakkerthehacker for providing detailed reports, images and logs to help discover my mistake.