### PR TITLE
Change git pop -> apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.25: Change stash pop operation to stash apply [#919](https://github.com/FredrikNoren/ungit/issues/919)
 - 1.1.24: fix some commands not properly reporting git error [#933](https://github.com/FredrikNoren/ungit/issues/933)
 - 1.1.23: finalize nightmare click test
 - 1.1.22: Add a config setting to allow setting the default diff type. [#929](https://github.com/FredrikNoren/ungit/issues/929)

--- a/components/stash/stash.html
+++ b/components/stash/stash.html
@@ -10,7 +10,7 @@
     </h4>
     <div class="list-group" data-bind="foreach: stashedChanges">
       <div class="list-group-item" data-ta-container="stash-stash">
-        <a href="#" data-bind="click: pop" class="glyphicon glyphicon-pencil glyphicon-circled pull-left" data-ta-clickable="stash-pop" data-toggle="tooltip" title="Pop this stash"></a>
+        <a href="#" data-bind="click: apply" class="glyphicon glyphicon-pencil glyphicon-circled pull-left" data-ta-clickable="stash-apply" data-toggle="tooltip" title="Apply this stash"></a>
         <a href="#" data-bind="click: toggleShowCommitDiffs" data-ta-clickable="stash-diff" data-toggle="tooltip" title="Show stash diff">
           <h4 class="list-group-item-heading" data-bind="text: title"></h4>
           <p class="list-group-item-text" data-bind="text: message"></p>

--- a/components/stash/stash.js
+++ b/components/stash/stash.js
@@ -24,10 +24,10 @@ function StashItemViewModel(stash, data) {
     server: stash.server
   }));
 }
-StashItemViewModel.prototype.pop = function() {
+StashItemViewModel.prototype.apply = function() {
   var self = this;
   this.stashPopProgressBar.start();
-  this.server.delPromise('/stashes/' + this.id, { path: this.stash.repoPath(), pop: true }).finally(function() {
+  this.server.delPromise('/stashes/' + this.id, { path: this.stash.repoPath(), apply: true }).finally(function() {
     self.stashPopProgressBar.stop();
   });
 }

--- a/nmclicktests/spec.stash.js
+++ b/nmclicktests/spec.stash.js
@@ -31,7 +31,7 @@ describe('[STASH]', () => {
   });
 
   it('Should be possible to pop a stash', () => {
-    return environment.nm.click('[data-ta-clickable="stash-pop"]')
+    return environment.nm.click('[data-ta-clickable="stash-apply"]')
       .wait('[data-ta-container="staging-file"]')
   });
 });

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "browserify": "~14.3.0",
     "electron-packager": "~8.6.0",
     "expect.js": "~0.3.1",
-    "extract-zip":"=1.6.0",
+    "extract-zip": "=1.6.0",
     "grunt": "~1.0.1",
     "grunt-babel": "~6.0.0",
     "grunt-contrib-clean": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",
@@ -67,7 +67,7 @@
     "browserify": "~14.3.0",
     "electron-packager": "~8.6.0",
     "expect.js": "~0.3.1",
-    "extract-zip": "=1.6.0",
+    "extract-zip":"=1.6.0",
     "grunt": "~1.0.1",
     "grunt-babel": "~6.0.0",
     "grunt-contrib-clean": "~1.1.0",

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -564,7 +564,7 @@ exports.registerApi = (env) => {
   });
 
   app.delete(`${exports.pathPrefix}/stashes/:id`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const type = req.query.pop === 'true' ? 'pop' : 'drop';
+    const type = req.query.apply === 'true' ? 'apply' : 'drop';
     jsonResultOrFailProm(res, gitPromise(['stash', type, `stash@{${req.params.id}}`], req.query.path))
       .finally(emitGitDirectoryChanged.bind(null, req.query.path))
       .finally(emitWorkingTreeChanged.bind(null, req.query.path));


### PR DESCRIPTION
fix: #919 

Changing default stash application from pop to apply.  

Considering pop is destructive in nature and stash drop operation is available, I think it is more sensible to just change pop to apply.