### PR TITLE
fix invalid path input for autocomplete causing front end crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.25: fix invalid path input for autocomplete causing front end crash [#942](https://github.com/FredrikNoren/ungit/issues/942)
 - 1.1.24: fix some commands not properly reporting git error [#933](https://github.com/FredrikNoren/ungit/issues/933)
 - 1.1.23: finalize nightmare click test
 - 1.1.22: Add a config setting to allow setting the default diff type. [#929](https://github.com/FredrikNoren/ungit/issues/929)

--- a/components/path/path.html
+++ b/components/path/path.html
@@ -60,7 +60,7 @@
   <!-- ko if: status() == 'no-such-path' -->
   <div data-ta-container="invalid-path" data-bind="visible: status() == 'no-such-path'">
     <h2>Invalid path</h2>
-    <p>"<span data-bind="text: path"></span>" doesn&#39;t seem to be a valid path.</p>
+    <p>"<span data-bind="text: repoPath"></span>" doesn&#39;t seem to be a valid path.</p>
     <div class="create-dir">
       <button class="btn btn-primary btn-lg" data-ta-clickable="create-dir" data-bind="click: createDir">Create directory</button>
     </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -62,7 +62,9 @@ ko.bindingHandlers.autocomplete = {
           });
           $(element).autocomplete("search", value);
         }).catch(function(err) {
-          if (err.errorCode !== 'read-dir-failed') throw err;
+          if (!err.errorSummary.startsWith('ENOENT: no such file or directory') && err.errorCode !== 'read-dir-failed') {
+            throw err;
+          }
         });
       } else if (event.keyCode == 39) { // '/'
         $(element).val(value + ungit.config.fileSeparator);


### PR DESCRIPTION
fix: #942

This was error on how we handle autocomplete exceptions when we switched over to promises.

(This probably was the cause of the some of the nightmare tests wasn't able to use [`.type()`](https://github.com/segmentio/nightmare#typeselector-text) API as it triggered autocomplete on some of the invalid paths we have.  Will be fixing those tests later to reflect more realistic click tests.)

@wonson: Thank you for the bug reports!