### PR TITLE
Alert and confirm when `move` is going back in time

### DIFF
--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -108,16 +108,22 @@ Nightmare.action('ug', {
   'refAction': function(ref, local, action, done) {
     this.click('[data-ta-clickable="branch"][data-ta-name="' + ref + '"][data-ta-local="' + local + '"]')
       .ug.click('[data-ta-action="' + action + '"][data-ta-visible="true"] [role="button"]')
-      .ug.waitForElementNotVisible('[data-ta-action="' + action + '"][data-ta-visible="true"]')
-      .wait(200)
-      .then(done.bind(null, null), done);
+      .visible('[data-ta-clickable="yes"]')
+      .then((isVisible) => {
+        return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
+          .ug.waitForElementNotVisible('[data-ta-action="' + action + '"][data-ta-visible="true"]')
+          .wait(200)
+      }).then(done.bind(null, null), done);
   },
   'moveRef': function(ref, targetNodeCommitTitle, done) {
     this.click('[data-ta-clickable="branch"][data-ta-name="' + ref + '"]')
       .ug.click('[data-ta-node-title="' + targetNodeCommitTitle + '"] [data-ta-action="move"][data-ta-visible="true"] [role="button"]')
-      .ug.waitForElementNotVisible('[data-ta-action="move"][data-ta-visible="true"]')
-      .wait(200)
-      .then(done.bind(null, null), done);
+      .visible('[data-ta-clickable="yes"]')
+      .then((isVisible) => {
+        return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
+          .ug.waitForElementNotVisible('[data-ta-action="move"][data-ta-visible="true"]')
+          .wait(200)
+      }).then(done.bind(null, null), done);
   },
   'createRef': function(name, type, done) {
     console.log(`Creating ${name} as ${type}`);
@@ -157,7 +163,7 @@ const prependLines = (pre, text) => {
 // Environment provides
 class Environment {
   constructor(config) {
-    this.nm = Nightmare({ Promise: Bluebird });
+    this.nm = Nightmare({ Promise: Bluebird, show: true });
     this.config = config || {};
     this.config.rootPath = (typeof this.config.rootPath === 'string') ? this.config.rootPath : '';
     this.config.serverTimeout = this.config.serverTimeout || 15000;

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -163,7 +163,7 @@ const prependLines = (pre, text) => {
 // Environment provides
 class Environment {
   constructor(config) {
-    this.nm = Nightmare({ Promise: Bluebird, show: true });
+    this.nm = Nightmare({ Promise: Bluebird });
     this.config = config || {};
     this.config.rootPath = (typeof this.config.rootPath === 'string') ? this.config.rootPath : '';
     this.config.serverTimeout = this.config.serverTimeout || 15000;


### PR DESCRIPTION
fix: #914 

Going back in time doesn't always means banishing ref within the context of ungit.  However, I did not wanted to do potentially expansive calculations to figure out wether or not branches have common ancestor or potentially other expansive calculations so I relied on timestamp.

I think this is generally a "good enough" solution that fulfills intention of the #914 

But I'm open to criticism