### PR TITLE
data-ta selector removal in favor of css selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.1.28: **unpublished** please append your changes to here instead of new version.
+  - Refactoring to remove static data-ta tags from tests
+  - `grunt nmclicktest` -> `grunt clicktest`
+  - Stabilize ungit open test of clicktest via using a tag that is guaranteed to be generated
 - 1.1.27: Add alert when moving back in time. [#914](https://github.com/FredrikNoren/ungit/issues/914)
 - 1.1.26:
   - fix invalid path input for autocomplete causing front end crash [#942](https://github.com/FredrikNoren/ungit/issues/942)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
-- 1.1.28: **unpublished** please append your changes to here instead of new version.
+- 1.1.28: **UNPUBLISHED** please append your changes to here instead of new version.
   - Refactoring to remove static data-ta tags from tests
   - `grunt nmclicktest` -> `grunt clicktest`
   - Stabilize ungit open test of clicktest via using a tag that is guaranteed to be generated
+  - Add click test bailout on tes failure
 - 1.1.27: Add alert when moving back in time. [#914](https://github.com/FredrikNoren/ungit/issues/914)
 - 1.1.26:
   - fix invalid path input for autocomplete causing front end crash [#942](https://github.com/FredrikNoren/ungit/issues/942)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,8 @@ module.exports = function(grunt) {
       click: {
         options: {
           reporter: 'spec',
-          timeout: 15000
+          timeout: 15000,
+          bail: true
         },
         src: 'nmclicktests/spec.*.js'
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -435,8 +435,8 @@ module.exports = function(grunt) {
 
   // Run tests without compile (use watcher or manually build)
   grunt.registerTask('unittest', ['mochaTest:unit']);
-  grunt.registerTask('nmclicktest', ['mochaTest:click']);
-  grunt.registerTask('test', ['unittest', 'nmclicktest']);
+  grunt.registerTask('clicktest', ['mochaTest:click']);
+  grunt.registerTask('test', ['unittest', 'clicktest']);
 
   // Builds, and then creates a release (bump patch version, create a commit & tag, publish to npm)
   grunt.registerTask('publish', ['default', 'test', 'release:patch']);

--- a/components/app/app.html
+++ b/components/app/app.html
@@ -3,7 +3,7 @@
 <div class="app-top-margin"></div>
 <div class="app-wrapper">
 
-<div class="container" data-bind="shown: shown" data-ta-container="app">
+<div class="container" data-bind="shown: shown">
   <div class="alert alert-danger" data-bind="visible: gitVersionErrorVisible">
     <span data-bind="text: gitVersionError"></span>
     <button type="button" class="close" data-bind="click: dismissGitVersionError">&times;</button>

--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -1,4 +1,4 @@
-<div class="btn-group">
+<div class="btn-group branch">
   <button type="button" class="btn btn-default btn-main" data-ta-clickable="branch" data-bind="click: updateBranches">
     <span class="octicon octicon-git-branch"></span>
     <span data-bind="text: fetchLabel"></span>

--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -1,13 +1,13 @@
 <div class="btn-group branch">
-  <button type="button" class="btn btn-default btn-main" data-ta-clickable="branch" data-bind="click: updateBranches">
+  <button type="button" class="btn btn-default btn-main" data-bind="click: updateBranches">
     <span class="octicon octicon-git-branch"></span>
     <span data-bind="text: fetchLabel"></span>
     <!-- ko component: fetchingProgressBar --><!-- /ko -->
   </button>
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-ta-clickable="branch-menu">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu pull-right" role="menu" data-ta-container="branches">
+  <ul class="dropdown-menu pull-right" role="menu">
     <!-- ko foreach: branches -->
     <li>
       <a href="#" data-bind="text: name, click: $parent.checkoutBranch.bind($parent), attr: { 'data-ta-clickable': 'checkout' + name }"></a>

--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -1,22 +1,22 @@
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-whitespace" data-bind="click: whiteSpace.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Ignore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
+  <button class="btn btn-default bootstrap-tooltip pull-right commit-whitespace" data-bind="click: whiteSpace.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Ignore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
     <span data-bind="text: whiteSpace.text"></span>
   </button>
 </div>
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-sideBySideDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
+  <button class="btn btn-default bootstrap-tooltip pull-right commit-sideBySideDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
     <span data-bind="text: textDiffType.text"></span>
   </button>
 </div>
 <div class="btn-group btn-group-xs" data-bind="visible: showDiffButtons">
-  <button class="btn btn-default bootstrap-tooltip pull-right" data-ta-clickable="commit-wordwrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
+  <button class="btn btn-default bootstrap-tooltip pull-right commit-wordwrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
     <span data-bind="text: wordWrap.text"></span>
   </button>
 </div>
 
 <div data-bind="foreach: commitLineDiffs" class="commitdiff">
   <div class="file">
-    <div class="head" data-bind="click: fileNameClick" data-ta-clickable="commitDiffFileName">
+    <div class="head commit-diff-filename" data-bind="click: fileNameClick">
       <span data-bind="text: fileName"></span>
       <span class="file-stats" data-bind="visible: added() != '-'">
         (
@@ -25,6 +25,6 @@
         )
       </span>
     </div>
-    <div class="diffContainer" data-bind="component: specificDiff" data-ta-container="commitLineDiffs"></div>
+    <div class="diffContainer commit-line-diffs" data-bind="component: specificDiff"></div>
   </div>
 </div>

--- a/components/crash/crash.html
+++ b/components/crash/crash.html
@@ -1,5 +1,5 @@
 <div class="container" >
-  <div class="panel panel-default crash" data-ta-container="user-error-page">
+  <div class="panel panel-default crash">
     <div class="panel-body">
       <h1>Whooops</h1>
       Unfortunately ungit interrupted its work because: <code data-bind="html: eventcause"></code><br>

--- a/components/dialogs/formDialog.html
+++ b/components/dialogs/formDialog.html
@@ -1,5 +1,5 @@
 
-<div class="modal fade" data-bind="modal: { onclose: onclose, closer: setCloser }, attr: { 'data-ta-container': taDialogName }">
+<div class="modal fade" data-bind="modal: { onclose: onclose, closer: setCloser }">
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
@@ -12,12 +12,12 @@
 						<label data-bind="text: name, attr: { for: name }" class="col-lg-2 control-label"></label>
 						<div class="col-lg-10">
 							<input class="form-control" id="inputName"
-								data-bind="value: value, attr: { id: name, placeholder: placeholder, type: type, autofocus: autofocus, 'data-ta-input': taName }">
+								data-bind="value: value, attr: { id: name, placeholder: placeholder, type: type, autofocus: autofocus }">
 						</div>
 					</div>
 				</div>
 				<div class="modal-footer">
-					<input type="submit" class="btn btn-primary" value="Submit" data-ta-clickable="submit">
+					<input type="submit" class="btn btn-primary" value="Submit">
 					<button class="btn btn-default" data-bind="click: close, visible: showCancel">Cancel</button>
 				</div>
 			</form>

--- a/components/dialogs/prompt.html
+++ b/components/dialogs/prompt.html
@@ -10,7 +10,7 @@
 			</div>
 			<div class="modal-footer">
 				<!-- ko foreach: alternatives -->
-				<button type="button" class="btn btn-default" data-bind="css: { 'btn-primary': primary }, text: label, click: click, attr: { 'data-ta-clickable': taId }"></button>
+				<button type="button" class="btn btn-default" data-bind="css: { 'btn-primary': primary, 'btn-mute': taId === 'mute' }, text: label, click: click"></button>
 				<!-- /ko -->
 			</div>
 		</div>

--- a/components/gitErrors/gitErrors.html
+++ b/components/gitErrors/gitErrors.html
@@ -1,6 +1,6 @@
 
 <!-- ko foreach: gitErrors -->
-<div class="alert alert-danger" data-ta-container="git-error-container">
+<div class="alert alert-danger">
   <button type="button" class="close" data-bind="click: dismiss">&times;</button>
   <h3><span class="glyphicon glyphicon-warning-sign"></span> Unhandled git error!</h3>
   <p>

--- a/components/graph/graph-graphics.html
+++ b/components/graph/graph-graphics.html
@@ -18,11 +18,11 @@
   </defs>
   <g>
     <!-- ko if: commitNodeEdge -->
-      <g data-ta-clickable="load-ahead" data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}, click: loadAhead">
+      <g class="load-ahead-button" data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}, click: loadAhead">
         <path data-bind="attr: { d: commitNodeEdge }", stroke="#4A4A4A" stroke-width="8" stroke-dasharray="10, 5" />
         <circle data-bind="attr: { stroke: commitNodeColor }" cx="610" cy="35" r="30" data-bind="attr: { stroke: '#4A4A4A' }"  stroke-dasharray="10, 7" stroke-width="10" fill="transparent"/>
         <!-- ko if: skip() > 0 -->
-          <circle class="loadAhead" data-ta-container="nodes-skipped" data-bind="attr: { fill: commitNodeColor }" cx="610" cy="35" r="15" />
+          <circle class="loadAhead" data-bind="attr: { fill: commitNodeColor }" cx="610" cy="35" r="15" />
         <!-- /ko -->
       </g>
     <!-- /ko -->

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -12,10 +12,10 @@
 
       <div class="rightSideContainer" data-bind="style: { left: cx() + r() - 433 + 'px' }">
         <!-- ko foreach: branches -->
-        <span class="ref branch" data-ta-clickable="branch" draggable="true" tabIndex="-1"
+        <span class="ref branch" draggable="true" tabIndex="-1"
             data-bind="css: { current: current, remote: isRemoteBranch, dragging: isDragging, focused: selected },
               click: selected,
-              dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName, 'data-ta-current': current, 'data-ta-local': isLocal }" >
+              dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName, 'data-ta-local': isLocal }" >
           <span class="octicon octicon-broadcast" data-bind="visible: isRemoteBranch"></span>
           <span class="octicon octicon-git-branch"></span>
           <span class="name" data-bind="text: localRefName"></span>
@@ -26,7 +26,7 @@
         <span class="ref tag" data-ta-clickable="tag" draggable="true" tabIndex="0"
             data-bind="css: { current: current, remote: isRemoteTag, dragging: isDragging, focused: selected },
               click: selected,
-              dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName, 'data-ta-current': current }">
+              dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName }">
           <span class="octicon octicon-globe" data-bind="visible: isRemote"></span>
           <span class="octicon octicon-tag"></span>
           <span class="name" data-bind="text: localRefName"></span>
@@ -34,7 +34,7 @@
         <!-- /ko -->
 
         <!-- ko foreach: dropareaGraphActions -->
-        <span class="graphAction droparea" data-bind="css: cssClasses, visible: visible, attr: { 'data-ta-action': style, 'data-ta-visible': visible }, event: { mouseover: mouseover, mouseout: mouseout }">
+        <span class="graphAction droparea" data-bind="css: cssClasses, visible: visible, attr: { 'data-ta-action': style }, event: { mouseover: mouseover, mouseout: mouseout }">
           <!-- ko if: icon --><span data-bind="css: icon" class="icon"></span><!-- /ko -->
           <span data-bind="text: text"></span>
           <div class="dropmask" tabIndex="0" role="button" data-bind="dropOver: visible, drop: doPerform, dragEnter: dragEnter, dragLeave: dragLeave, click: doPerform"></div>
@@ -48,8 +48,8 @@
           <!-- ko if: branchingFormVisible -->
           <div class="form-inline">
             <input class="name form-control" data-ta-input="new-branch-name" type="text" data-bind="value: newBranchName, hasfocus: newBranchNameHasFocus, valueUpdate: 'afterkeydown'"/>
-            <button class="btn btn-primary" data-ta-clickable="create-branch" type="submit" value="Branch" data-bind="click: createBranch, enable: canCreateRef">Branch</button>
-            <button class="btn btn-default" data-ta-clickable="create-tag" data-bind="click: createTag, enable: canCreateRef">Tag</button>
+            <button class="btn btn-primary" type="submit" value="Branch" data-bind="click: createBranch, enable: canCreateRef">Branch</button>
+            <button class="btn btn-default" data-bind="click: createTag, enable: canCreateRef">Tag</button>
           </div>
           <!-- /ko -->
         </span>

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -1,10 +1,10 @@
 
-<div class="graph" data-bind="scrolledToEnd: scrolledToEnd, click: handleBubbledClick" data-ta-clickable="graph">
+<div class="graph" data-bind="scrolledToEnd: scrolledToEnd, click: handleBubbledClick">
 
   <!-- ko template: { name: 'graphGraphics' } --><!-- /ko -->
 
   <div class="nodes" data-bind="foreach: nodes">
-    <div class="nodeContainer animation" data-ta-container="node" data-bind="style: { left: '0px', top: cy() + 'px' }, attr: { 'data-ta-node-title': title }">
+    <div class="nodeContainer animation" data-bind="style: { left: '0px', top: cy() + 'px' }, attr: { 'data-ta-node-title': title }">
       <div class="commit-container animation" data-bind="visible: commitContainerVisible, style: { left: cx() - 620 + 'px' }">
         <!-- ko component: commitComponent -->
         <!-- /ko -->
@@ -23,7 +23,7 @@
         <!-- /ko -->
 
         <!-- ko foreach: tags -->
-        <span class="ref tag" data-ta-clickable="tag" draggable="true" tabIndex="0"
+        <span class="ref tag" draggable="true" tabIndex="0"
             data-bind="css: { current: current, remote: isRemoteTag, dragging: isDragging, focused: selected },
               click: selected,
               dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName }">
@@ -44,10 +44,10 @@
 
         <!-- ko if: showNewRefAction -->
         <span class="newRef" data-bind="css: { editing: branchingFormVisible }">
-          <button class="showBranchingForm" data-ta-clickable="show-new-branch-form" data-bind="click: showBranchingForm, visible: !branchingFormVisible()">&#x271A;</button>
+          <button class="showBranchingForm" data-bind="click: showBranchingForm, visible: !branchingFormVisible()">&#x271A;</button>
           <!-- ko if: branchingFormVisible -->
           <div class="form-inline">
-            <input class="name form-control" data-ta-input="new-branch-name" type="text" data-bind="value: newBranchName, hasfocus: newBranchNameHasFocus, valueUpdate: 'afterkeydown'"/>
+            <input class="name form-control" type="text" data-bind="value: newBranchName, hasfocus: newBranchNameHasFocus, valueUpdate: 'afterkeydown'"/>
             <button class="btn btn-primary" type="submit" value="Branch" data-bind="click: createBranch, enable: canCreateRef">Branch</button>
             <button class="btn btn-default" data-bind="click: createTag, enable: canCreateRef">Tag</button>
           </div>

--- a/components/header/header.html
+++ b/components/header/header.html
@@ -1,14 +1,14 @@
 
 <div class="navbar navbar-default navbar-fixed-top">
 
-  <a data-ta-clickable="home-link" class="backlink bootstrap-tooltip" href="#/" data-toggle="tooltip" data-placement="bottom" data-original-title="Navigate to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
+  <a class="backlink bootstrap-tooltip" href="#/" data-toggle="tooltip" data-placement="bottom" data-original-title="Navigate to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
     <span class="glyphicon glyphicon-arrow-left glyphicon-circled" data-bind="css: { 'glyph-shown': showBackButton }"></span>
     <img src="images/logo.png">
   </a>
 
   <div class="form-container">
     <form class="path-input-form" data-bind="submit: submitPath">
-      <input data-ta-input="navigation-path" type="text" class="form-control input-lg" data-bind="value: path, autocomplete: path" placeholder="Enter path to repository">
+      <input class="form-control input-lg" data-bind="value: path, autocomplete: path" placeholder="Enter path to repository">
       <button type="button" class="add-to-repolist btn btn-default bootstrap-tooltip" data-bind="visible: showAddToRepoListButton, click: addCurrentPathToRepoList" data-toggle="tooltip" data-placement="bottom" data-original-title="Add current git directory to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
         <span class="glyphicon glyphicon-plus"></span>
       </button>

--- a/components/home/home.html
+++ b/components/home/home.html
@@ -1,5 +1,5 @@
 
-<div class="container home animated fadeInLeft" data-ta-container="home-page" data-bind="shown: shown">
+<div class="container home animated fadeInLeft" data-bind="shown: shown">
   <div class="nux" data-bind="visible: showNux">
     <img src="images/logoLarge.png" class="logo-large">
     <div class="alert alert-info">

--- a/components/login/login.html
+++ b/components/login/login.html
@@ -3,24 +3,24 @@
   <div data-bind="visible: status() == 'loading'">
   </div>
 
-  <div class='login col-lg-6' data-bind="visible: status() == 'login'" data-ta-container="login-page">
+  <div class='login col-lg-6' data-bind="visible: status() == 'login'">
     <h1>Login</h1>
     <!-- ko if: loginError -->
-    <div class="loginError" data-ta-element="login-error" data-bind="text: loginError"></div>
+    <div class="loginError" data-bind="text: loginError"></div>
     <!-- /ko -->
     <form data-bind="submit: login" role="form">
 
       <div class="form-group">
         <label for="inputUsername">Username</label>
-        <input type="text" class="form-control" id="inputUsername" placeholder="Username" data-bind="value: username" data-ta-input="username">
+        <input type="text" class="form-control" id="inputUsername" placeholder="Username" data-bind="value: username">
       </div>
 
       <div class="form-group">
         <label for="inputPassword">Password</label>
-        <input type="password" class="form-control" id="inputPassword" placeholder="Password" data-bind="value: password" data-ta-input="password">
+        <input type="password" class="form-control" id="inputPassword" placeholder="Password" data-bind="value: password">
       </div>
 
-      <input type="submit" class="btn btn-primary" value="Login" data-ta-clickable="submit">
+      <input type="submit" class="btn btn-primary" value="Login">
     </form>
   </div>
 </div>

--- a/components/path/path.html
+++ b/components/path/path.html
@@ -1,5 +1,5 @@
 
-<div class="path" data-bind="shown: shown" data-ta-container="path-page">
+<div class="path" data-bind="shown: shown">
 
   <!-- ko if: status() == 'loading' -->
   <div class='animated fadeInLeft'>
@@ -15,7 +15,7 @@
   <!-- /ko -->
 
   <!-- ko if: status() == 'uninited' -->
-  <div class="uninited" data-ta-container="uninited-path-page">
+  <div class="uninited">
     <div class="container">
       <div class="alert alert-info" data-bind="visible: showDirectoryCreatedAlert">
         Directory '<span data-bind="text: dirName"></span>' created
@@ -27,7 +27,7 @@
           <div class="panel panel-default">
             <div class="panel-heading">Create a new repository</div>
             <div class="panel-body">
-              <button data-ta-clickable="init-repository" class="btn btn-primary btn-lg" data-bind='click: initRepository'>
+              <button class="btn btn-primary btn-lg" data-bind='click: initRepository'>
                 Make '<span data-bind="text: dirName"></span>' a repository
               </button>
             </div>
@@ -40,13 +40,13 @@
               <form data-bind="submit: cloneRepository">
                 <div class="form-group">
                   <label for="cloneFromInput">Clone from</label>
-                  <input class="form-control" type="text" data-ta-input="clone-url" id="cloneFromInput" placeholder="url" data-bind="value: cloneUrl, valueUpdate: 'afterkeydown'">
+                  <input class="form-control" type="text" id="cloneFromInput" placeholder="url" data-bind="value: cloneUrl, valueUpdate: 'afterkeydown'">
                 </div>
                 <div class="form-group">
                   <label for="cloneToInput">to</label>
-                  <input class="form-control" type="text" data-ta-input="clone-target" id="cloneToInput" data-bind="value: cloneDestination, attr: { placeholder: cloneDestinationImplicit }">
+                  <input class="form-control" type="text" id="cloneToInput" data-bind="value: cloneDestination, attr: { placeholder: cloneDestinationImplicit }">
                 </div>
-                <input type="submit" class="btn btn-primary btn-lg" data-ta-clickable="clone-repository" value="Clone repository">
+                <input type="submit" class="btn btn-primary btn-lg" value="Clone repository">
               </form>
             </div>
           </div>
@@ -58,11 +58,11 @@
   <!-- /ko -->
 
   <!-- ko if: status() == 'no-such-path' -->
-  <div data-ta-container="invalid-path" data-bind="visible: status() == 'no-such-path'">
+  <div class="invalid-path" data-bind="visible: status() == 'no-such-path'">
     <h2>Invalid path</h2>
     <p>"<span data-bind="text: repoPath"></span>" doesn&#39;t seem to be a valid path.</p>
     <div class="create-dir">
-      <button class="btn btn-primary btn-lg" data-ta-clickable="create-dir" data-bind="click: createDir">Create directory</button>
+      <button class="btn btn-primary btn-lg" data-bind="click: createDir">Create directory</button>
     </div>
   </div>
   <!-- /ko -->

--- a/components/progressBar/progressBar.html
+++ b/components/progressBar/progressBar.html
@@ -1,6 +1,6 @@
 <!-- Always shown -->
 <script type="text/html" id="progressBar">
-	<div class="progress" data-ta-element="progress-bar">
+	<div class="progress">
 		<div class="progress-bar" data-bind="attr: { style: style }"></div>
 	</div>
 </script>

--- a/components/refreshbutton/refreshbutton.html
+++ b/components/refreshbutton/refreshbutton.html
@@ -1,5 +1,5 @@
 
-<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="click: refresh" data-toggle="tooltip" data-placement="bottom" data-original-title="Refresh changes" data-delay='{"show":"2000", "hide":"0"}' data-ta-clickable="refresh-button">
+<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="click: refresh" data-toggle="tooltip" data-placement="bottom" data-original-title="Refresh changes" data-delay='{"show":"2000", "hide":"0"}'>
   <span class="glyphicon glyphicon-refresh"></span>
   <!-- ko component: refreshingProgressBar --><!-- /ko -->
 </button>

--- a/components/remotes/remotes.html
+++ b/components/remotes/remotes.html
@@ -1,13 +1,13 @@
 <div class="btn-group fetchButton">
-  <button type="button" class="btn btn-default btn-main" data-ta-clickable="fetch" data-bind="click: clickFetch, enable: fetchEnabled">
+  <button type="button" class="btn btn-default btn-main" data-bind="click: clickFetch, enable: fetchEnabled">
     <span class="glyphicon glyphicon-download-alt"></span>
     <span data-bind="text: fetchLabel"></span>
     <!-- ko component: fetchingProgressBar --><!-- /ko -->
   </button>
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-ta-clickable="remotes-menu">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu pull-right" role="menu" data-ta-container="remotes">
+  <ul class="dropdown-menu pull-right" role="menu">
     <!-- ko foreach: remotes -->
     <li>
       <a href="#" data-bind="text: name, click: changeRemote, attr: { 'data-ta-clickable': name }"></a>
@@ -15,6 +15,6 @@
     </li>
     <!-- /ko -->
     <li class="divider"></li>
-    <li><a href="#" data-bind="click: showAddRemoteDialog" data-ta-clickable="show-add-remote-dialog">Add a new remote</a></li>
+    <li><a href="#" class="add-new-remote" data-bind="click: showAddRemoteDialog">Add a new remote</a></li>
   </ul>
 </div>

--- a/components/repository/repository.html
+++ b/components/repository/repository.html
@@ -1,4 +1,4 @@
-<div class="repository-view animated fadeInLeft" data-ta-container="repository-view">
+<div class="repository-view animated fadeInLeft">
 
   <!-- ko component: gitErrors --><!-- /ko -->
 

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -14,7 +14,7 @@
         <div>
           <span class="amend" data-bind="visible: canAmend">
             <span class="checkmark" data-bind="css: { checked: amend }">&#10003;</span>
-            <a class="amend-link" href="#" >Amend last commit</a>
+            <a class="amend-link" href="#" data-bind="click: toggleAmend">Amend last commit</a>
           </span>
           <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
         </div>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -5,7 +5,7 @@
       <div class="arrow"></div>
     </div>
     <div data-bind="visible: showNux" class="nux">
-      Nothing to commit. <a href="#" data-bind="click: toggleAmend, visible: canAmend">Amend previous commit?</a>
+      Nothing to commit. <a class="amend-link" href="#" data-bind="click: toggleAmend, visible: canAmend">Amend previous commit?</a>
     </div>
     <div class="row" data-bind="visible: !showNux()">
       <div class="col-lg-3">
@@ -13,12 +13,12 @@
         <textarea class="form-control" rows="2" placeholder="Body" data-bind="value: commitMessageBody, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onAltEnter}"></textarea>
         <div>
           <span class="amend" data-bind="visible: canAmend">
-                  <span class="checkmark" data-bind="css: { checked: amend }">&#10003;</span>
-                          <a href="#" data-bind="click: toggleAmend">Amend last commit</a>
-                  </span>
-                  <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
+            <span class="checkmark" data-bind="css: { checked: amend }">&#10003;</span>
+            <a class="amend-link" href="#" data-bind="click: toggleAmend">Amend last commit</a>
+          </span>
+          <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
         </div>
-        <button class="btn btn-primary btn-lg commit-btn" data-ta-clickable="commit" data-bind="click: commit, visible: isStageValid, enable: !commitValidationError()">
+        <button class="btn btn-primary btn-lg commit-btn" data-bind="click: commit, visible: isStageValid, enable: !commitValidationError()">
           Commit
           <!-- ko component: committingProgressBar --><!-- /ko -->
         </button>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -22,7 +22,7 @@
           Commit
           <!-- ko component: committingProgressBar --><!-- /ko -->
         </button>
-        <button class="btn btn-primary" data-bind="click: conflictContinue, visible: conflictText, enable: !commitValidationError()"  data-ta-action="continue">
+        <button class="btn btn-primary" data-bind="click: conflictContinue, visible: conflictText, enable: !commitValidationError()">
           Continue <span data-bind="text: conflictText"/>
           <!-- ko component: conflictContinueProgressBar --><!-- /ko -->
         </button>
@@ -43,23 +43,23 @@
             <span class="glyphicon glyphicon-trash"></span>
             Discard all
           </button>
-          <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stash-all" data-bind="click: stashAll, css: { disabled: !canStashAll() }" data-toggle="tooltip" data-placement="bottom" data-original-title="Stash all uncommited file changes, including not showing files" data-delay='{"show":"1000", "hide":"0"}'>
+          <button class="btn btn-default bootstrap-tooltip stash-all" data-bind="click: stashAll, css: { disabled: !canStashAll() }" data-toggle="tooltip" data-placement="bottom" data-original-title="Stash all uncommited file changes, including not showing files" data-delay='{"show":"1000", "hide":"0"}'>
             <span class="glyphicon glyphicon-paperclip"></span>
             Stash all
             <!-- ko component: stashProgressBar --><!-- /ko -->
           </button>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-whitespace" data-bind="click: whiteSpace.toggle, css: {active: whiteSpace.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Ignore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: whiteSpace.toggle, css: {active: whiteSpace.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Ignore whitespaces" data-delay='{"show":"2000", "hide":"0"}'>
               <span data-bind="text: whiteSpace.text"></span>
             </button>
           </div>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-defaultDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Show inline diff view" data-delay='{"show":"2000", "hide":"0"}'>
               <span data-bind="text: textDiffType.text"></span>
             </button>
           </div>
           <div class="btn-group pull-right btn-group-sm">
-            <button class="btn btn-default bootstrap-tooltip" data-ta-clickable="stage-nowrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-original-title="Not wrapping words per line" data-delay='{"show":"2000", "hide":"0"}'>
               <span data-bind="text: wordWrap.text"></span>
             </button>
           </div>
@@ -70,7 +70,7 @@
             <div class="checkmark" data-bind="click: toggleStaged, css: { checked: editState() !== 'none' }">
               <span class="glyphicon" data-bind="css: { 'glyphicon-check': editState() === 'staged', 'glyphicon-unchecked': editState() === 'none', 'glyphicon-list-alt': editState() === 'patched'}"></span>
             </div>
-            <button class="name btn btn-default" data-bind="click: toggleDiffs" data-ta-clickable="show-stage-diffs">
+            <button class="name btn btn-default" data-bind="click: toggleDiffs">
               <span data-bind="text: displayName"></span>
               <!-- ko component: diffProgressBar --><!-- /ko -->
             </button>
@@ -81,9 +81,9 @@
             <span class="conflict" data-bind="visible: conflict"><span class="temporary">Conflicts</span><span class="launchmergetool explanation" data-bind="visible: mergeTool, click: launchMergeTool">Launch Merge Tool</span><span class="markresolved explanation" data-bind="click: resolveConflict">Mark as Resolved</span></span>
             <span class="patch bootstrap-tooltip" data-bind="visible: isShowPatch(), click: patchClick"
                 data-toggle="tooltip" data-placement="top" title="Patch changes">Patch</span>
-            <span class="ignore bootstrap-tooltip" data-ta-clickable="ignore-file" data-bind="click: ignoreFile"
+            <span class="ignore bootstrap-tooltip" data-bind="click: ignoreFile"
                 data-toggle="tooltip" data-placement="top" title="Add to .gitignore">i</span>
-            <span class="discard bootstrap-tooltip" data-ta-clickable="discard-file" data-bind="click: discardChanges"
+            <span class="discard bootstrap-tooltip" data-bind="click: discardChanges"
                 data-toggle="tooltip" data-placement="top" title="Discard changes">&#x2716;</span>
             <!-- ko if: isShowingDiffs -->
             <div class="diffContainer" data-bind="component: diff"></div>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -18,7 +18,7 @@
                   </span>
                   <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
         </div>
-        <button class="btn btn-primary btn-lg" data-ta-clickable="commit" data-bind="click: commit, visible: isStageValid, enable: !commitValidationError()">
+        <button class="btn btn-primary btn-lg commit-btn" data-ta-clickable="commit" data-bind="click: commit, visible: isStageValid, enable: !commitValidationError()">
           Commit
           <!-- ko component: committingProgressBar --><!-- /ko -->
         </button>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -9,12 +9,12 @@
     </div>
     <div class="row" data-bind="visible: !showNux()">
       <div class="col-lg-3">
-        <input class="form-control" data-ta-input="staging-commit-title" type="text" placeholder="Title (required)" data-bind="value: commitMessageTitle, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onEnter}"></input>
+        <input class="form-control" type="text" placeholder="Title (required)" data-bind="value: commitMessageTitle, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onEnter}"></input>
         <textarea class="form-control" rows="2" placeholder="Body" data-bind="value: commitMessageBody, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onAltEnter}"></textarea>
         <div>
           <span class="amend" data-bind="visible: canAmend">
             <span class="checkmark" data-bind="css: { checked: amend }">&#10003;</span>
-            <a class="amend-link" href="#" data-bind="click: toggleAmend">Amend last commit</a>
+            <a class="amend-link" href="#" >Amend last commit</a>
           </span>
           <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
         </div>
@@ -26,7 +26,7 @@
           Continue <span data-bind="text: conflictText"/>
           <!-- ko component: conflictContinueProgressBar --><!-- /ko -->
         </button>
-        <button class="btn btn-warning" data-bind="click: conflictAbort, visible: conflictText" data-ta-action="abort">
+        <button class="btn btn-warning btn-stg-abort" data-bind="click: conflictAbort, visible: conflictText">
           Abort <span data-bind="text: conflictText"/>
           <!-- ko component: conflictAbortProgressBar --><!-- /ko -->
         </button>
@@ -66,7 +66,7 @@
         </div>
 
         <div class="files" data-bind="foreach: files">
-          <div class="file" data-bind="css: { showingDiffs: isShowingDiffs }" data-ta-container="staging-file">
+          <div class="file" data-bind="css: { showingDiffs: isShowingDiffs }">
             <div class="checkmark" data-bind="click: toggleStaged, css: { checked: editState() !== 'none' }">
               <span class="glyphicon" data-bind="css: { 'glyphicon-check': editState() === 'staged', 'glyphicon-unchecked': editState() === 'none', 'glyphicon-list-alt': editState() === 'patched'}"></span>
             </div>
@@ -80,7 +80,7 @@
             <span class="deletions" data-bind="text: deletions"></span>
             <span class="conflict" data-bind="visible: conflict"><span class="temporary">Conflicts</span><span class="launchmergetool explanation" data-bind="visible: mergeTool, click: launchMergeTool">Launch Merge Tool</span><span class="markresolved explanation" data-bind="click: resolveConflict">Mark as Resolved</span></span>
             <span class="patch bootstrap-tooltip" data-bind="visible: isShowPatch(), click: patchClick"
-                data-toggle="tooltip" data-placement="top" data-ta-clickable="patch-file" title="Patch changes">Patch</span>
+                data-toggle="tooltip" data-placement="top" title="Patch changes">Patch</span>
             <span class="ignore bootstrap-tooltip" data-ta-clickable="ignore-file" data-bind="click: ignoreFile"
                 data-toggle="tooltip" data-placement="top" title="Add to .gitignore">i</span>
             <span class="discard bootstrap-tooltip" data-ta-clickable="discard-file" data-bind="click: discardChanges"

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -206,8 +206,7 @@ StagingViewModel.prototype.toggleAmend = function() {
   if (!this.amend() && !this.commitMessageTitle()) {
     this.commitMessageTitle(this.HEAD().title);
     this.commitMessageBody(this.HEAD().body);
-  }
-  else if(this.amend()) {
+  } else if(this.amend()) {
     var isPrevDefaultMsg =
       this.commitMessageTitle() == this.HEAD().title &&
       this.commitMessageBody() == this.HEAD().body;

--- a/components/stash/stash.html
+++ b/components/stash/stash.html
@@ -10,7 +10,7 @@
     </h4>
     <div class="list-group" data-bind="foreach: stashedChanges">
       <div class="list-group-item">
-        <a href="#" class="stash-apply" data-bind="click: apply" class="glyphicon glyphicon-pencil glyphicon-circled pull-left" data-toggle="tooltip" title="Apply this stash"></a>
+        <a href="#" class="stash-apply glyphicon glyphicon-pencil glyphicon-circled pull-left" data-bind="click: apply" data-toggle="tooltip" title="Apply this stash"></a>
         <a href="#" class="toggle-show-commit-diffs" data-bind="click: toggleShowCommitDiffs" data-toggle="tooltip" title="Show stash diff">
           <h4 class="list-group-item-heading" data-bind="text: title"></h4>
           <p class="list-group-item-text" data-bind="text: message"></p>

--- a/components/stash/stash.html
+++ b/components/stash/stash.html
@@ -1,4 +1,4 @@
-<div class="stash-toggle stash-toggle-text" data-ta-clickable="stash-toggle" data-bind="click: toggleShowStash, visible: !isShow()" >
+<div class="stash-toggle stash-toggle-text" data-bind="click: toggleShowStash, visible: !isShow()" >
   <span class="glyphicon glyphicon-chevron-up"></span>
   Stash (<span data-bind="text: stashedChanges().length"></span>)
 </div>
@@ -9,14 +9,14 @@
       Stashed changes (<span data-bind="text: stashedChanges().length"></span>)
     </h4>
     <div class="list-group" data-bind="foreach: stashedChanges">
-      <div class="list-group-item" data-ta-container="stash-stash">
-        <a href="#" data-bind="click: apply" class="glyphicon glyphicon-pencil glyphicon-circled pull-left" data-ta-clickable="stash-apply" data-toggle="tooltip" title="Apply this stash"></a>
-        <a href="#" data-bind="click: toggleShowCommitDiffs" data-ta-clickable="stash-diff" data-toggle="tooltip" title="Show stash diff">
+      <div class="list-group-item">
+        <a href="#" class="stash-apply" data-bind="click: apply" class="glyphicon glyphicon-pencil glyphicon-circled pull-left" data-toggle="tooltip" title="Apply this stash"></a>
+        <a href="#" class="toggle-show-commit-diffs" data-bind="click: toggleShowCommitDiffs" data-toggle="tooltip" title="Show stash diff">
           <h4 class="list-group-item-heading" data-bind="text: title"></h4>
           <p class="list-group-item-text" data-bind="text: message"></p>
         </a>
         <!-- ko if: showCommitDiff() -->
-        <div class="diff-wrapper" data-ta-container="stash-diff">
+        <div class="diff-wrapper">
           <div class="diff-inner" data-bind="component: commitDiff"></div>
         </div>
         <!-- /ko -->

--- a/components/submodules/submodules.html
+++ b/components/submodules/submodules.html
@@ -1,14 +1,14 @@
-<div class="btn-group fetchButton">
-  <button type="button" class="btn btn-default btn-main" data-ta-clickable="fetch" data-bind="click: function() {}">
+<div class="btn-group fetchButton submodule">
+  <button type="button" class="btn btn-default btn-main" data-bind="click: function() {}">
     <span class="glyphicon glyphicon-th-large"></span>
     <span data-bind="text: 'Submodules'"></span>
     <!-- ko component: updateProgressBar --><!-- /ko -->
     <!-- ko component: fetchProgressBar --><!-- /ko -->
   </button>
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-ta-clickable="submodules-menu">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu pull-right" role="menu" data-ta-container="submodules">
+  <ul class="dropdown-menu pull-right" role="menu">
     <!-- ko foreach: submodules -->
     <li>
       <a href="#" data-bind="text: name, click: $parent.submodulePathClick, attr: { 'data-ta-clickable': name }"></a>
@@ -17,8 +17,8 @@
     </li>
     <!-- /ko -->
     <li class="divider"></li>
-    <li><a href="#" data-bind="click: updateSubmodules" data-ta-clickable="update-submodule">Update Submodules</a></li>
+    <li><a href="#" class="update-submodule" data-bind="click: updateSubmodules">Update Submodules</a></li>
     <li class="divider"></li>
-    <li><a href="#" data-bind="click: showAddSubmoduleDialog" data-ta-clickable="add-submodule">Add Submodules</a></li>
+    <li><a href="#" class="add-submodule" data-bind="click: showAddSubmoduleDialog">Add Submodules</a></li>
   </ul>
 </div>

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -207,7 +207,7 @@ TextDiffViewModel.prototype.getPatchCheckBox = function (symbol, index, isActive
   if (isActive) {
     this.numberOfSelectedPatchLines++;
   }
-  return '<div class="d2h-code-line-prefix"><span data-bind="visible: editState() !== \'patched\'">' + symbol + '</span><input ' + (isActive ? 'checked' : '') + ' type="checkbox" data-ta-clickable="patch-line-input" data-bind="visible: editState() === \'patched\', click: togglePatchLine.bind($data, ' + index + ')"></input>';
+  return '<div class="d2h-code-line-prefix"><span data-bind="visible: editState() !== \'patched\'">' + symbol + '</span><input ' + (isActive ? 'checked' : '') + ' type="checkbox" data-bind="visible: editState() === \'patched\', click: togglePatchLine.bind($data, ' + index + ')"></input>';
 }
 
 TextDiffViewModel.prototype.togglePatchLine = function (index) {

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -17,18 +17,18 @@ Nightmare.action('ug', {
     done();
   },
   'commit': function(commitMessage, done) {
-    this.wait('.files .file')
+    this.wait('.files .file .btn-default .btn-default')
       .insert('.staging input.form-control', commitMessage)
       .wait(100)
       .click('commit-btn')
-      .ug.waitForElementNotVisible('.files .file')
+      .ug.waitForElementNotVisible('.files .file .btn-default .btn-default')
       .wait(1000)
       .then(done.bind(null, null), done);
   },
   'amendCommit': function(done) {
     this.ug.click('.amend-link')
       .click('.commit-btn')
-      .ug.waitForElementNotVisible('.files .file')
+      .ug.waitForElementNotVisible('.files .file .btn-default .btn-default')
       .wait(1000)
       .then(done.bind(null, null), done);
   },
@@ -43,7 +43,7 @@ Nightmare.action('ug', {
       .then(done.bind(null, null), done);
   },
   'patch': function(commitMessage, done) {
-    this.ug.click('.files .file')
+    this.ug.click('.files .file .btn-default .btn-default ')
       .ug.click('[data-ta-clickable="patch-file"]')
       .wait('[data-ta-clickable="patch-line-input"]')
       .ug.commit('[data-ta-clickable="patch-line-input"]')

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -26,8 +26,8 @@ Nightmare.action('ug', {
       .then(done.bind(null, null), done);
   },
   'amendCommit': function(done) {
-    this.ug.click('[data-bind="click: toggleAmend"]')
-      .click('[data-ta-clickable="commit"]')
+    this.ug.click('.amend-link')
+      .click('.commit-btn')
       .ug.waitForElementNotVisible('.files .file')
       .wait(1000)
       .then(done.bind(null, null), done);

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -17,18 +17,18 @@ Nightmare.action('ug', {
     done();
   },
   'commit': function(commitMessage, done) {
-    this.wait('.files .file .btn-default .btn-default')
+    this.wait('.files .file .btn-default')
       .insert('.staging input.form-control', commitMessage)
       .wait(100)
-      .click('commit-btn')
-      .ug.waitForElementNotVisible('.files .file .btn-default .btn-default')
+      .click('.commit-btn')
+      .ug.waitForElementNotVisible('.files .file .btn-default')
       .wait(1000)
       .then(done.bind(null, null), done);
   },
   'amendCommit': function(done) {
     this.ug.click('.amend-link')
       .click('.commit-btn')
-      .ug.waitForElementNotVisible('.files .file .btn-default .btn-default')
+      .ug.waitForElementNotVisible('.files .file .btn-default')
       .wait(1000)
       .then(done.bind(null, null), done);
   },
@@ -38,12 +38,12 @@ Nightmare.action('ug', {
   },
   'checkout': function(branch, done) {
     this.ug.click(`.branch[data-ta-name="${branch}"]`)
-      .ug.click('[data-ta-action="checkout"]:visible .dropmask')
+      .ug.click('[data-ta-action="checkout"]:not([style*="display: none"]) .dropmask')
       .wait(`.ref.branch[data-ta-name="${branch}"][data-ta-current="true"]`)
       .then(done.bind(null, null), done);
   },
   'patch': function(commitMessage, done) {
-    this.ug.click('.files .file .btn-default .btn-default ')
+    this.ug.click('.files .file .btn-default')
       .ug.click('[data-ta-clickable="patch-file"]')
       .wait('[data-ta-clickable="patch-line-input"]')
       .ug.commit('[data-ta-clickable="patch-line-input"]')
@@ -107,21 +107,21 @@ Nightmare.action('ug', {
   },
   'refAction': function(ref, local, action, done) {
     this.click(`.branch[data-ta-name="${ref}"][data-ta-local="${local}"]`)
-      .ug.click('[data-ta-action="' + action + '"]:visible .dropmask')
+      .ug.click('[data-ta-action="' + action + '"]:not([style*="display: none"]) .dropmask')
       .visible('[data-ta-clickable="yes"]')
       .then((isVisible) => {
         return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
-          .ug.waitForElementNotVisible('[data-ta-action="' + action + '"]:visible')
+          .ug.waitForElementNotVisible('[data-ta-action="' + action + '"]:not([style*="display: none"])')
           .wait(200)
       }).then(done.bind(null, null), done);
   },
   'moveRef': function(ref, targetNodeCommitTitle, done) {
     this.click(`.branch[data-ta-name="${ref}"]`)
-      .ug.click('[data-ta-node-title="' + targetNodeCommitTitle + '"] [data-ta-action="move"]:visible .dropmask')
+      .ug.click('[data-ta-node-title="' + targetNodeCommitTitle + '"] [data-ta-action="move"]:not([style*="display: none"]) .dropmask')
       .visible('[data-ta-clickable="yes"]')
       .then((isVisible) => {
         return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
-          .ug.waitForElementNotVisible('[data-ta-action="move"]:visible')
+          .ug.waitForElementNotVisible('[data-ta-action="move"]:not([style*="display: none"])')
           .wait(200)
       }).then(done.bind(null, null), done);
   },

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -32,14 +32,10 @@ Nightmare.action('ug', {
       .wait(1000)
       .then(done.bind(null, null), done);
   },
-  'createTag': function(name, done) {
-    this.ug.createRef(name, 'tag')
-      .then(done.bind(null, null), done);
-  },
   'checkout': function(branch, done) {
     this.ug.click(`.branch[data-ta-name="${branch}"]`)
       .ug.click('[data-ta-action="checkout"]:not([style*="display: none"]) .dropmask')
-      .wait(`.ref.branch[data-ta-name="${branch}"][data-ta-current="true"]`)
+      .wait(`.ref.branch[data-ta-name="${branch}"].current`)
       .then(done.bind(null, null), done);
   },
   'patch': function(commitMessage, done) {
@@ -125,18 +121,22 @@ Nightmare.action('ug', {
           .wait(200)
       }).then(done.bind(null, null), done);
   },
-  'createRef': function(name, type, done) {
-    console.log(`Creating ${name} as ${type}`);
+  'createTag': function(name, done) {
     this.click('.current ~ .newRef button.showBranchingForm')
       .insert('.newRef.editing input', name)
       .wait(100)
-      .click(`[data-ta-clickable="create-${type}"]`)
-      .wait(`[data-ta-clickable="${type}"][data-ta-name="${name}"]`)
+      .click('.newRef .btn-default')
+      .wait(`.ref.tag[data-ta-name="${name}"]`)
       .wait(300)
       .then(done.bind(null, null), done);
   },
   'createBranch': function(name, done) {
-    this.ug.createRef(name, 'branch')
+    this.click('.current ~ .newRef button.showBranchingForm')
+      .insert('.newRef.editing input', name)
+      .wait(100)
+      .click(`.newRef .btn-primary`)
+      .wait(`.ref.branch[data-ta-name="${name}"]`)
+      .wait(300)
       .then(done.bind(null, null), done);
   },
   'click': function(selector, done) {

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -17,18 +17,18 @@ Nightmare.action('ug', {
     done();
   },
   'commit': function(commitMessage, done) {
-    this.wait('[data-ta-container="staging-file"]')
-      .insert('[data-ta-input="staging-commit-title"]', commitMessage)
+    this.wait('.files .file')
+      .insert('.staging input.form-control', commitMessage)
       .wait(100)
-      .click('[data-ta-clickable="commit"]')
-      .ug.waitForElementNotVisible('[data-ta-container="staging-file"]')
+      .click('commit-btn')
+      .ug.waitForElementNotVisible('.files .file')
       .wait(1000)
       .then(done.bind(null, null), done);
   },
   'amendCommit': function(done) {
     this.ug.click('[data-bind="click: toggleAmend"]')
       .click('[data-ta-clickable="commit"]')
-      .ug.waitForElementNotVisible('[data-ta-container="staging-file"]')
+      .ug.waitForElementNotVisible('.files .file')
       .wait(1000)
       .then(done.bind(null, null), done);
   },
@@ -43,7 +43,7 @@ Nightmare.action('ug', {
       .then(done.bind(null, null), done);
   },
   'patch': function(commitMessage, done) {
-    this.ug.click('[data-ta-container="staging-file"]')
+    this.ug.click('.files .file')
       .ug.click('[data-ta-clickable="patch-file"]')
       .wait('[data-ta-clickable="patch-line-input"]')
       .ug.commit('[data-ta-clickable="patch-line-input"]')

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -37,9 +37,9 @@ Nightmare.action('ug', {
       .then(done.bind(null, null), done);
   },
   'checkout': function(branch, done) {
-    this.ug.click('[data-ta-clickable="branch"][data-ta-name="' + branch + '"]')
-      .ug.click('[data-ta-action="checkout"][data-ta-visible="true"] [role="button"]')
-      .wait('[data-ta-clickable="branch"][data-ta-name="' + branch + '"][data-ta-current="true"]')
+    this.ug.click(`.branch[data-ta-name="${branch}"]`)
+      .ug.click('[data-ta-action="checkout"]:visible .dropmask')
+      .wait(`.ref.branch[data-ta-name="${branch}"][data-ta-current="true"]`)
       .then(done.bind(null, null), done);
   },
   'patch': function(commitMessage, done) {
@@ -106,22 +106,22 @@ Nightmare.action('ug', {
       .then(done.bind(null, null), done);
   },
   'refAction': function(ref, local, action, done) {
-    this.click('[data-ta-clickable="branch"][data-ta-name="' + ref + '"][data-ta-local="' + local + '"]')
-      .ug.click('[data-ta-action="' + action + '"][data-ta-visible="true"] [role="button"]')
+    this.click(`.branch[data-ta-name="${ref}"][data-ta-local="${local}"]`)
+      .ug.click('[data-ta-action="' + action + '"]:visible .dropmask')
       .visible('[data-ta-clickable="yes"]')
       .then((isVisible) => {
         return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
-          .ug.waitForElementNotVisible('[data-ta-action="' + action + '"][data-ta-visible="true"]')
+          .ug.waitForElementNotVisible('[data-ta-action="' + action + '"]:visible')
           .wait(200)
       }).then(done.bind(null, null), done);
   },
   'moveRef': function(ref, targetNodeCommitTitle, done) {
-    this.click('[data-ta-clickable="branch"][data-ta-name="' + ref + '"]')
-      .ug.click('[data-ta-node-title="' + targetNodeCommitTitle + '"] [data-ta-action="move"][data-ta-visible="true"] [role="button"]')
+    this.click(`.branch[data-ta-name="${ref}"]`)
+      .ug.click('[data-ta-node-title="' + targetNodeCommitTitle + '"] [data-ta-action="move"]:visible .dropmask')
       .visible('[data-ta-clickable="yes"]')
       .then((isVisible) => {
         return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
-          .ug.waitForElementNotVisible('[data-ta-action="move"][data-ta-visible="true"]')
+          .ug.waitForElementNotVisible('[data-ta-action="move"]:visible')
           .wait(200)
       }).then(done.bind(null, null), done);
   },

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -44,9 +44,9 @@ Nightmare.action('ug', {
   },
   'patch': function(commitMessage, done) {
     this.ug.click('.files .file .btn-default')
-      .ug.click('[data-ta-clickable="patch-file"]')
-      .wait('[data-ta-clickable="patch-line-input"]')
-      .ug.commit('[data-ta-clickable="patch-line-input"]')
+      .ug.click('.patch')
+      .wait('.d2h-diff-tbody input')
+      .ug.commit(commitMessage)
       .then(done.bind(null, null), done);
   },
   'backgroundAction': function(method, url, body, done) {
@@ -107,20 +107,20 @@ Nightmare.action('ug', {
   },
   'refAction': function(ref, local, action, done) {
     this.click(`.branch[data-ta-name="${ref}"][data-ta-local="${local}"]`)
-      .ug.click('[data-ta-action="' + action + '"]:not([style*="display: none"]) .dropmask')
-      .visible('[data-ta-clickable="yes"]')
+      .ug.click(`[data-ta-action="${action}"]:not([style*="display: none"]) .dropmask`)
+      .visible('.modal-dialog .btn-primary')
       .then((isVisible) => {
-        return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
-          .ug.waitForElementNotVisible('[data-ta-action="' + action + '"]:not([style*="display: none"])')
+        return (isVisible ? this.ug.click('.modal-dialog .btn-primary') : this)
+          .ug.waitForElementNotVisible(`[data-ta-action="${action}"]:not([style*="display: none"])`)
           .wait(200)
       }).then(done.bind(null, null), done);
   },
   'moveRef': function(ref, targetNodeCommitTitle, done) {
     this.click(`.branch[data-ta-name="${ref}"]`)
-      .ug.click('[data-ta-node-title="' + targetNodeCommitTitle + '"] [data-ta-action="move"]:not([style*="display: none"]) .dropmask')
-      .visible('[data-ta-clickable="yes"]')
+      .ug.click(`[data-ta-node-title="${targetNodeCommitTitle}"] [data-ta-action="move"]:not([style*="display: none"]) .dropmask`)
+      .visible('.modal-dialog .btn-primary')
       .then((isVisible) => {
-        return (isVisible ? this.ug.click('[data-ta-clickable="yes"]') : this)
+        return (isVisible ? this.ug.click('.modal-dialog .btn-primary') : this)
           .ug.waitForElementNotVisible('[data-ta-action="move"]:not([style*="display: none"])')
           .wait(200)
       }).then(done.bind(null, null), done);
@@ -130,8 +130,8 @@ Nightmare.action('ug', {
     this.click('.current ~ .newRef button.showBranchingForm')
       .insert('.newRef.editing input', name)
       .wait(100)
-      .click('[data-ta-clickable="create-' + type + '"]')
-      .wait('[data-ta-clickable="' + type + '"][data-ta-name="' + name + '"]')
+      .click(`[data-ta-clickable="create-${type}"]`)
+      .wait(`[data-ta-clickable="${type}"][data-ta-name="${name}"]`)
       .wait(300)
       .then(done.bind(null, null), done);
   },

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -145,7 +145,7 @@ Nightmare.action('ug', {
   },
   'openUngit': function(tempDirPath, done) {
     this.goto(`${rootUrl}/#/repository?path=${encodeURIComponent(tempDirPath)}`)
-      .wait('.graph')
+      .wait('.repository-actions')
       .wait(1000)
       .then(done.bind(null, null), done);
   }

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -101,43 +101,40 @@ Nightmare.action('ug', {
     this.wait((selector) => !document.querySelector(selector), selector)
       .then(done.bind(null, null), done);
   },
-  'refAction': function(ref, local, action, done) {
-    this.click(`.branch[data-ta-name="${ref}"][data-ta-local="${local}"]`)
-      .ug.click(`[data-ta-action="${action}"]:not([style*="display: none"]) .dropmask`)
-      .visible('.modal-dialog .btn-primary')
+  '_verifyRefAction': function(action, done) {
+    this.visible('.modal-dialog .btn-primary')
       .then((isVisible) => {
         return (isVisible ? this.ug.click('.modal-dialog .btn-primary') : this)
           .ug.waitForElementNotVisible(`[data-ta-action="${action}"]:not([style*="display: none"])`)
           .wait(200)
       }).then(done.bind(null, null), done);
   },
+  'refAction': function(ref, local, action, done) {
+    this.click(`.branch[data-ta-name="${ref}"][data-ta-local="${local}"]`)
+      .ug.click(`[data-ta-action="${action}"]:not([style*="display: none"]) .dropmask`)
+      .then(() => this.ug._verifyRefAction(action))
+      .then(done.bind(null, null), done);
+  },
   'moveRef': function(ref, targetNodeCommitTitle, done) {
     this.click(`.branch[data-ta-name="${ref}"]`)
       .ug.click(`[data-ta-node-title="${targetNodeCommitTitle}"] [data-ta-action="move"]:not([style*="display: none"]) .dropmask`)
-      .visible('.modal-dialog .btn-primary')
-      .then((isVisible) => {
-        return (isVisible ? this.ug.click('.modal-dialog .btn-primary') : this)
-          .ug.waitForElementNotVisible('[data-ta-action="move"]:not([style*="display: none"])')
-          .wait(200)
-      }).then(done.bind(null, null), done);
+      .then(() => this.ug._verifyRefAction('move'))
+      .then(done.bind(null, null), done);
+  },
+  '_createRef': function(type, name, done) {
+    this.click('.current ~ .newRef button.showBranchingForm')
+      .insert('.newRef.editing input', name)
+      .wait(100)
+      .click(`.newRef ${type === 'branch' ? '.btn-primary' : '.btn-default'}`)
+      .wait(`.ref.${type}[data-ta-name="${name}"]`)
+      .wait(300)
+      .then(done.bind(null, null), done);
   },
   'createTag': function(name, done) {
-    this.click('.current ~ .newRef button.showBranchingForm')
-      .insert('.newRef.editing input', name)
-      .wait(100)
-      .click('.newRef .btn-default')
-      .wait(`.ref.tag[data-ta-name="${name}"]`)
-      .wait(300)
-      .then(done.bind(null, null), done);
+    this.ug._createRef('tag', name).then(done.bind(null, null), done);
   },
   'createBranch': function(name, done) {
-    this.click('.current ~ .newRef button.showBranchingForm')
-      .insert('.newRef.editing input', name)
-      .wait(100)
-      .click(`.newRef .btn-primary`)
-      .wait(`.ref.branch[data-ta-name="${name}"]`)
-      .wait(300)
-      .then(done.bind(null, null), done);
+    this.ug._createRef('branch', name).then(done.bind(null, null), done);
   },
   'click': function(selector, done) {
     this.wait(selector)

--- a/nmclicktests/spec.bare.js
+++ b/nmclicktests/spec.bare.js
@@ -14,7 +14,7 @@ describe('[BARE]', () => {
   });
 
   it('update branches button without branches', () => {
-    return environment.nm.ug.click('[data-ta-clickable="branch"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"] [data-ta-element="progress-bar"]');
+    return environment.nm.ug.click('.btn-group.branch .btn-main')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]');
   });
 });

--- a/nmclicktests/spec.bare.js
+++ b/nmclicktests/spec.bare.js
@@ -15,6 +15,6 @@ describe('[BARE]', () => {
 
   it('update branches button without branches', () => {
     return environment.nm.ug.click('.btn-group.branch .btn-main')
-      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]');
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress');
   });
 });

--- a/nmclicktests/spec.branches.js
+++ b/nmclicktests/spec.branches.js
@@ -51,7 +51,7 @@ describe('[BRANCHES]', () => {
       .wait(500)
       .click('[data-ta-clickable="branch-3-remove"]')
       .wait(500)
-      .click('[data-ta-clickable="yes"]')
+      .click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress')
       .wait(500);
   });
@@ -71,7 +71,7 @@ describe('[BRANCHES]', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-0"]')
       .ug.click('[data-ta-action="cherry-pick"]:not([style*="display: none"]) .dropmask')
       .ug.click('[data-ta-action="abort"]')
-      .ug.click('[data-ta-clickable="yes"]')
+      .ug.click('.modal-dialog .btn-primary')
       .wait(500)
   });
 

--- a/nmclicktests/spec.branches.js
+++ b/nmclicktests/spec.branches.js
@@ -40,13 +40,13 @@ describe('[BRANCHES]', () => {
   });
 
   it('Check out a branch via selection', () => {
-    return environment.nm.ug.click('[data-ta-clickable="branch-menu"]')
+    return environment.nm.ug.click('.branch .dropdown-toggle')
       .ug.click('[data-ta-clickable="checkoutbranch-2"]')
       .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress')
   });
 
   it('Delete a branch via selection', () => {
-    return environment.nm.click('[data-ta-clickable="branch-menu"]')
+    return environment.nm.click('.branch .dropdown-toggle')
       .wait('[data-ta-clickable="branch-3-remove"]')
       .wait(500)
       .click('[data-ta-clickable="branch-3-remove"]')
@@ -62,7 +62,7 @@ describe('[BRANCHES]', () => {
   });
 
   it('checkout cherypick base', () => {
-    return environment.nm.ug.click('[data-ta-clickable="branch-menu"]')
+    return environment.nm.ug.click('.branch .dropdown-toggle')
       .ug.click('[data-ta-clickable="checkoutbranch-1"]')
       .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress')
   });
@@ -70,7 +70,7 @@ describe('[BRANCHES]', () => {
   it('cherrypick fail case', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-0"]')
       .ug.click('[data-ta-action="cherry-pick"]:not([style*="display: none"]) .dropmask')
-      .ug.click('[data-ta-action="abort"]')
+      .ug.click('.staging .btn-stg-abort')
       .ug.click('.modal-dialog .btn-primary')
       .wait(500)
   });
@@ -79,7 +79,7 @@ describe('[BRANCHES]', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-1"]')
       .ug.click('[data-ta-action="cherry-pick"]:not([style*="display: none"]) .dropmask')
       .wait(500)
-      .visible('[data-ta-action="abort"]')
+      .visible('.staging .btn-stg-abort')
       .then((isVisible) => {
         if (isVisible) {
           throw new Error("Cherry pick errored when success was expected.");
@@ -96,6 +96,6 @@ describe('[BRANCHES]', () => {
       .wait(250)
       .ug.createBranch('autoCheckout')
       .wait(1000)
-      .wait('[data-ta-name="autoCheckout"][data-ta-current="true"]');
+      .wait('[data-ta-name="autoCheckout"].current');
   });
 });

--- a/nmclicktests/spec.branches.js
+++ b/nmclicktests/spec.branches.js
@@ -14,9 +14,9 @@ describe('[BRANCHES]', () => {
   });
 
   it('updateBranches button without branches', () => {
-    return environment.nm.wait('[data-ta-clickable="branch"]')
-      .click('[data-ta-clickable="branch"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"] [data-ta-element="progress-bar"]');
+    return environment.nm.wait('.btn-group.branch .btn-main')
+      .click('.btn-group.branch .btn-main')
+      .ug.waitForElementNotVisible('.branch [data-ta-element="progress-bar"]');
   });
 
   it('add a branch', () => {
@@ -27,8 +27,8 @@ describe('[BRANCHES]', () => {
   });
 
   it('updateBranches button with one branch', () => {
-    return environment.nm.ug.click('[data-ta-clickable="branch"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"] [data-ta-element="progress-bar"]');
+    return environment.nm.ug.click('.btn-group.branch .btn-main')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]');
   });
 
   it('add second branch', () => {
@@ -42,7 +42,7 @@ describe('[BRANCHES]', () => {
   it('Check out a branch via selection', () => {
     return environment.nm.ug.click('[data-ta-clickable="branch-menu"]')
       .ug.click('[data-ta-clickable="checkoutbranch-2"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"][data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]')
   });
 
   it('Delete a branch via selection', () => {
@@ -52,7 +52,7 @@ describe('[BRANCHES]', () => {
       .click('[data-ta-clickable="branch-3-remove"]')
       .wait(500)
       .click('[data-ta-clickable="yes"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"] [data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]')
       .wait(500);
   });
 
@@ -64,13 +64,13 @@ describe('[BRANCHES]', () => {
   it('checkout cherypick base', () => {
     return environment.nm.ug.click('[data-ta-clickable="branch-menu"]')
       .ug.click('[data-ta-clickable="checkoutbranch-1"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"][data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]')
   });
 
   it('cherrypick fail case', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-0"]')
       .ug.log("clicked first node")
-      .ug.click('[data-ta-action="cherry-pick"][data-ta-visible="true"] [role=button]')
+      .ug.click('[data-ta-action="cherry-pick"]:visible [role=button]')
       .ug.log("cherrypick button clicked")
       .ug.click('[data-ta-action="abort"]')
       .ug.log("cherrypick aborted")
@@ -81,7 +81,7 @@ describe('[BRANCHES]', () => {
 
   it('cherrypick success case', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-1"]')
-      .ug.click('[data-ta-action="cherry-pick"][data-ta-visible="true"] [role=button]')
+      .ug.click('[data-ta-action="cherry-pick"]:visible [role=button]')
       .wait(500)
       .visible('[data-ta-action="abort"]')
       .then((isVisible) => {

--- a/nmclicktests/spec.branches.js
+++ b/nmclicktests/spec.branches.js
@@ -16,7 +16,7 @@ describe('[BRANCHES]', () => {
   it('updateBranches button without branches', () => {
     return environment.nm.wait('.btn-group.branch .btn-main')
       .click('.btn-group.branch .btn-main')
-      .ug.waitForElementNotVisible('.branch [data-ta-element="progress-bar"]');
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress');
   });
 
   it('add a branch', () => {
@@ -28,7 +28,7 @@ describe('[BRANCHES]', () => {
 
   it('updateBranches button with one branch', () => {
     return environment.nm.ug.click('.btn-group.branch .btn-main')
-      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]');
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress');
   });
 
   it('add second branch', () => {
@@ -42,7 +42,7 @@ describe('[BRANCHES]', () => {
   it('Check out a branch via selection', () => {
     return environment.nm.ug.click('[data-ta-clickable="branch-menu"]')
       .ug.click('[data-ta-clickable="checkoutbranch-2"]')
-      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress')
   });
 
   it('Delete a branch via selection', () => {
@@ -52,7 +52,7 @@ describe('[BRANCHES]', () => {
       .click('[data-ta-clickable="branch-3-remove"]')
       .wait(500)
       .click('[data-ta-clickable="yes"]')
-      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress')
       .wait(500);
   });
 
@@ -64,24 +64,20 @@ describe('[BRANCHES]', () => {
   it('checkout cherypick base', () => {
     return environment.nm.ug.click('[data-ta-clickable="branch-menu"]')
       .ug.click('[data-ta-clickable="checkoutbranch-1"]')
-      .ug.waitForElementNotVisible('.btn-group.branch .btn-main [data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.btn-group.branch .btn-main .progress')
   });
 
   it('cherrypick fail case', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-0"]')
-      .ug.log("clicked first node")
-      .ug.click('[data-ta-action="cherry-pick"]:visible [role=button]')
-      .ug.log("cherrypick button clicked")
+      .ug.click('[data-ta-action="cherry-pick"]:not([style*="display: none"]) .dropmask')
       .ug.click('[data-ta-action="abort"]')
-      .ug.log("cherrypick aborted")
       .ug.click('[data-ta-clickable="yes"]')
-      .ug.log("clicked yes")
       .wait(500)
   });
 
   it('cherrypick success case', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-1"]')
-      .ug.click('[data-ta-action="cherry-pick"]:visible [role=button]')
+      .ug.click('[data-ta-action="cherry-pick"]:not([style*="display: none"]) .dropmask')
       .wait(500)
       .visible('[data-ta-action="abort"]')
       .then((isVisible) => {

--- a/nmclicktests/spec.discard.js
+++ b/nmclicktests/spec.discard.js
@@ -5,8 +5,12 @@ const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
     .wait('.files .file .btn-default')
     .ug.click('[data-ta-clickable="discard-file"]')
     .then(() => {
-      if (dialogButtonToClick) {
-        return env.nm.click('[data-ta-clickable="' + dialogButtonToClick + '"]');
+      if (dialogButtonToClick === "yes") {
+        return env.nm.ug.click('.modal-dialog .btn-primary');
+      } else if (dialogButtonToClick === "mute") {
+        return env.nm.ug.click('.modal-dialog .btn-mute');
+      } else if (dialogButtonToClick === "no") {
+        return env.nm.ug.click('.modal-dialog .btn-default:last-child');
       } else {
         return env.nm.visible('.modal-dialog .btn-primary')
           .then((isVisible) => { if (isVisible) throw new Error('Should not see yes button'); });
@@ -60,7 +64,6 @@ describe('[DISCARD - withWarn]', () => {
   });
 
   it('Should be possible to discard a created file and disable warn for awhile', () => {
-    // Temporarily disabled to get the tests working
     return createAndDiscard(environment, testRepoPaths[0], 'mute')
       .then(() => createAndDiscard(environment, testRepoPaths[0]))
       .delay(muteGraceTimeDuration + 500)

--- a/nmclicktests/spec.discard.js
+++ b/nmclicktests/spec.discard.js
@@ -8,7 +8,7 @@ const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
       if (dialogButtonToClick) {
         return env.nm.click('[data-ta-clickable="' + dialogButtonToClick + '"]');
       } else {
-        return env.nm.visible('[data-ta-clickable="yes"]')
+        return env.nm.visible('.modal-dialog .btn-primary')
           .then((isVisible) => { if (isVisible) throw new Error('Should not see yes button'); });
       }
     }).then(() => {

--- a/nmclicktests/spec.discard.js
+++ b/nmclicktests/spec.discard.js
@@ -3,7 +3,7 @@ const muteGraceTimeDuration = 2000;
 const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
   return env.nm.ug.createTestFile(testRepoPath + '/testfile2.txt')
     .wait('.files .file .btn-default')
-    .ug.click('[data-ta-clickable="discard-file"]')
+    .ug.click('.files span.discard')
     .then(() => {
       if (dialogButtonToClick === "yes") {
         return env.nm.ug.click('.modal-dialog .btn-primary');

--- a/nmclicktests/spec.discard.js
+++ b/nmclicktests/spec.discard.js
@@ -2,7 +2,7 @@
 const muteGraceTimeDuration = 2000;
 const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
   return env.nm.ug.createTestFile(testRepoPath + '/testfile2.txt')
-    .wait('.files .file')
+    .wait('.files .file .btn-default')
     .ug.click('[data-ta-clickable="discard-file"]')
     .then(() => {
       if (dialogButtonToClick) {
@@ -13,9 +13,9 @@ const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
       }
     }).then(() => {
       if (dialogButtonToClick !== 'no') {
-        return env.nm.ug.waitForElementNotVisible('.files .file');
+        return env.nm.ug.waitForElementNotVisible('.files .file .btn-default');
       } else {
-        return env.nm.wait('.files .file');
+        return env.nm.wait('.files .file .btn-default');
       }
     });
 }

--- a/nmclicktests/spec.discard.js
+++ b/nmclicktests/spec.discard.js
@@ -2,7 +2,7 @@
 const muteGraceTimeDuration = 2000;
 const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
   return env.nm.ug.createTestFile(testRepoPath + '/testfile2.txt')
-    .wait('[data-ta-container="staging-file"]')
+    .wait('.files .file')
     .ug.click('[data-ta-clickable="discard-file"]')
     .then(() => {
       if (dialogButtonToClick) {
@@ -13,9 +13,9 @@ const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
       }
     }).then(() => {
       if (dialogButtonToClick !== 'no') {
-        return env.nm.ug.waitForElementNotVisible('[data-ta-container="staging-file"]');
+        return env.nm.ug.waitForElementNotVisible('.files .file');
       } else {
-        return env.nm.wait('[data-ta-container="staging-file"]');
+        return env.nm.wait('.files .file');
       }
     });
 }

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -88,7 +88,7 @@ describe('[GENERIC]', () => {
   it('Should be possible to create and destroy a branch', () => {
     return environment.nm.ug.createBranch('willbedeleted')
       .ug.click('.branch[data-ta-name="willbedeleted"]')
-      .ug.click('[data-ta-action="delete"]:visible .dropmask')
+      .ug.click('[data-ta-action="delete"]:not([style*="display: none"]) .dropmask')
       .wait('[data-ta-container="yes-no-dialog"]')
       .ug.click('[data-ta-clickable="yes"]')
       .ug.waitForElementNotVisible('.branch[data-ta-name="willbedeleted"]');
@@ -97,7 +97,7 @@ describe('[GENERIC]', () => {
   it('Should be possible to create and destroy a tag', () => {
     return environment.nm.ug.createTag('tagwillbedeleted')
       .ug.click('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]')
-      .ug.click('[data-ta-action="delete"]:visible .dropmask')
+      .ug.click('[data-ta-action="delete"]:not([style*="display: none"]) .dropmask')
       .wait('[data-ta-container="yes-no-dialog"]')
       .ug.click('[data-ta-clickable="yes"]')
       .ug.waitForElementNotVisible('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');
@@ -113,8 +113,8 @@ describe('[GENERIC]', () => {
 
   it('Show stats for changed file and discard it', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
-      .wait('.files .file .btn-default .additions')
-      .wait('.files .file .btn-default .deletions')
+      .wait('.files .file .additions')
+      .wait('.files .file .deletions')
       .ug.click('[data-ta-clickable="discard-file"]')
       .ug.click('[data-ta-clickable="yes"]')
       .ug.waitForElementNotVisible('.files .file .btn-default');

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -39,10 +39,10 @@ describe('[GENERIC]', () => {
 
   it('Should be able to add a new file to .gitignore', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/addMeToIgnore.txt`)
-      .wait('[data-ta-container="staging-file"]')
+      .wait('.files .file')
       .ug.click('[data-ta-clickable="ignore-file"]')
       .ug.click('[data-ta-clickable="ignore-file"]')
-      .ug.waitForElementNotVisible('[data-ta-container="staging-file"]');
+      .ug.waitForElementNotVisible('.files .file');
   });
 
   it('Test showing commit diff between two commits', () => {
@@ -71,14 +71,14 @@ describe('[GENERIC]', () => {
 
   it('Should be possible to discard a created file and ensure patching is not avaliable for new file', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/testfile2.txt`)
-      .wait('[data-ta-container="staging-file"]')
+      .wait('.files .file')
       .ug.click('[data-ta-clickable="show-stage-diffs"]')
-      .wait('[data-ta-container="staging-file"]')
+      .wait('.files .file')
       .ug.click('[data-ta-clickable="show-stage-diffs"]')
       .ug.waitForElementNotVisible('[data-ta-container="patch-file"]')
       .ug.click('[data-ta-clickable="discard-file"]')
       .ug.click('[data-ta-clickable="yes"]')
-      .ug.waitForElementNotVisible('[data-ta-container="staging-file"]')
+      .ug.waitForElementNotVisible('.files .file')
   });
 
   it('Should be possible to create a branch', () => {
@@ -105,19 +105,19 @@ describe('[GENERIC]', () => {
 
   it('Commit changes to a file', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
-      .wait('[data-ta-container="staging-file"]')
+      .wait('.files .file')
       .insert('[data-ta-input="staging-commit-title"]', 'My commit message')
       .click('[data-ta-clickable="commit"]')
-      .ug.waitForElementNotVisible('[data-ta-container="staging-file"]');
+      .ug.waitForElementNotVisible('.files .file');
   });
 
   it('Show stats for changed file and discard it', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
-      .wait('[data-ta-container="staging-file"] .additions')
-      .wait('[data-ta-container="staging-file"] .deletions')
+      .wait('.files .file .additions')
+      .wait('.files .file .deletions')
       .ug.click('[data-ta-clickable="discard-file"]')
       .ug.click('[data-ta-clickable="yes"]')
-      .ug.waitForElementNotVisible('[data-ta-container="staging-file"]');
+      .ug.waitForElementNotVisible('.files .file');
   });
 
   it.skip('Should be possible to patch a file', () => {

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -77,7 +77,7 @@ describe('[GENERIC]', () => {
       .ug.click('[data-ta-clickable="show-stage-diffs"]')
       .ug.waitForElementNotVisible('[data-ta-container="patch-file"]')
       .ug.click('[data-ta-clickable="discard-file"]')
-      .ug.click('[data-ta-clickable="yes"]')
+      .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.files .file .btn-default')
   });
 
@@ -90,7 +90,7 @@ describe('[GENERIC]', () => {
       .ug.click('.branch[data-ta-name="willbedeleted"]')
       .ug.click('[data-ta-action="delete"]:not([style*="display: none"]) .dropmask')
       .wait('[data-ta-container="yes-no-dialog"]')
-      .ug.click('[data-ta-clickable="yes"]')
+      .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.branch[data-ta-name="willbedeleted"]');
   });
 
@@ -99,7 +99,7 @@ describe('[GENERIC]', () => {
       .ug.click('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]')
       .ug.click('[data-ta-action="delete"]:not([style*="display: none"]) .dropmask')
       .wait('[data-ta-container="yes-no-dialog"]')
-      .ug.click('[data-ta-clickable="yes"]')
+      .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');
   });
 
@@ -116,7 +116,7 @@ describe('[GENERIC]', () => {
       .wait('.files .file .additions')
       .wait('.files .file .deletions')
       .ug.click('[data-ta-clickable="discard-file"]')
-      .ug.click('[data-ta-clickable="yes"]')
+      .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.files .file .btn-default');
   });
 

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -107,7 +107,7 @@ describe('[GENERIC]', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
       .wait('.files .file')
       .insert('[data-ta-input="staging-commit-title"]', 'My commit message')
-      .click('[data-ta-clickable="commit"]')
+      .click('.commit-btn')
       .ug.waitForElementNotVisible('.files .file');
   });
 

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -39,10 +39,10 @@ describe('[GENERIC]', () => {
 
   it('Should be able to add a new file to .gitignore', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/addMeToIgnore.txt`)
-      .wait('.files .file')
+      .wait('.files .file .btn-default')
       .ug.click('[data-ta-clickable="ignore-file"]')
       .ug.click('[data-ta-clickable="ignore-file"]')
-      .ug.waitForElementNotVisible('.files .file');
+      .ug.waitForElementNotVisible('.files .file .btn-default');
   });
 
   it('Test showing commit diff between two commits', () => {
@@ -71,14 +71,14 @@ describe('[GENERIC]', () => {
 
   it('Should be possible to discard a created file and ensure patching is not avaliable for new file', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/testfile2.txt`)
-      .wait('.files .file')
+      .wait('.files .file .btn-default')
       .ug.click('[data-ta-clickable="show-stage-diffs"]')
-      .wait('.files .file')
+      .wait('.files .file .btn-default')
       .ug.click('[data-ta-clickable="show-stage-diffs"]')
       .ug.waitForElementNotVisible('[data-ta-container="patch-file"]')
       .ug.click('[data-ta-clickable="discard-file"]')
       .ug.click('[data-ta-clickable="yes"]')
-      .ug.waitForElementNotVisible('.files .file')
+      .ug.waitForElementNotVisible('.files .file .btn-default')
   });
 
   it('Should be possible to create a branch', () => {
@@ -105,19 +105,19 @@ describe('[GENERIC]', () => {
 
   it('Commit changes to a file', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
-      .wait('.files .file')
+      .wait('.files .file .btn-default')
       .insert('[data-ta-input="staging-commit-title"]', 'My commit message')
       .click('.commit-btn')
-      .ug.waitForElementNotVisible('.files .file');
+      .ug.waitForElementNotVisible('.files .file .btn-default');
   });
 
   it('Show stats for changed file and discard it', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
-      .wait('.files .file .additions')
-      .wait('.files .file .deletions')
+      .wait('.files .file .btn-default .additions')
+      .wait('.files .file .btn-default .deletions')
       .ug.click('[data-ta-clickable="discard-file"]')
       .ug.click('[data-ta-clickable="yes"]')
-      .ug.waitForElementNotVisible('.files .file');
+      .ug.waitForElementNotVisible('.files .file .btn-default');
   });
 
   it.skip('Should be possible to patch a file', () => {

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -49,23 +49,23 @@ describe('[GENERIC]', () => {
     return environment.nm.wait('[data-ta-clickable="node-clickable-0"]')
       .ug.click('[data-ta-clickable="node-clickable-0"]')
       .wait('.diff-wrapper')
-      .ug.click('[data-ta-clickable="commitDiffFileName"]')
-      .wait('[data-ta-container="commitLineDiffs"]');
+      .ug.click('.commit-diff-filename')
+      .wait('.commit-line-diffs');
   });
 
   it('Test showing commit side by side diff between two commits', () => {
-    return environment.nm.ug.click('[data-ta-clickable="commit-sideBySideDiff"]')
-      .wait('[data-ta-container="commitLineDiffs"]');
+    return environment.nm.ug.click('.commit-sideBySideDiff')
+      .wait('.commit-line-diffs');
   });
 
   it('Test wordwrap', () => {
-    return environment.nm.ug.click('[data-ta-clickable="commit-wordwrap"]')
+    return environment.nm.ug.click('.commit-wordwrap')
       .wait('.word-wrap');
   });
 
   it('Test wordwrap', () => {
-    return environment.nm.ug.click('[data-ta-clickable="commit-whitespace"]')
-      .wait('[data-ta-container="commitLineDiffs"]')
+    return environment.nm.ug.click('.commit-whitespace')
+      .wait('.commit-line-diffs')
       .ug.click('[data-ta-clickable="node-clickable-0"]');
   });
 
@@ -106,7 +106,7 @@ describe('[GENERIC]', () => {
   it('Commit changes to a file', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
       .wait('.files .file .btn-default')
-      .insert('[data-ta-input="staging-commit-title"]', 'My commit message')
+      .insert('.staging input.form-control', 'My commit message')
       .click('.commit-btn')
       .ug.waitForElementNotVisible('.files .file .btn-default');
   });
@@ -156,7 +156,7 @@ describe('[GENERIC]', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-0"]')
       .wait('[data-ta-action="revert"]')
       .ug.click('[data-ta-action="revert"]')
-      .ug.waitForElementNotVisible('[data-ta-container="user-error-page"]');
+      .ug.waitForElementNotVisible('.crash');
   });
 
   it('Should be possible to move a branch', () => {

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -87,17 +87,17 @@ describe('[GENERIC]', () => {
 
   it('Should be possible to create and destroy a branch', () => {
     return environment.nm.ug.createBranch('willbedeleted')
-      .ug.click('[data-ta-clickable="branch"][data-ta-name="willbedeleted"]')
-      .ug.click('[data-ta-action="delete"][data-ta-visible="true"] [role="button"]')
+      .ug.click('.branch[data-ta-name="willbedeleted"]')
+      .ug.click('[data-ta-action="delete"]:visible .dropmask')
       .wait('[data-ta-container="yes-no-dialog"]')
       .ug.click('[data-ta-clickable="yes"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"][data-ta-name="willbedeleted"]');
+      .ug.waitForElementNotVisible('.branch[data-ta-name="willbedeleted"]');
   });
 
   it('Should be possible to create and destroy a tag', () => {
     return environment.nm.ug.createTag('tagwillbedeleted')
       .ug.click('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]')
-      .ug.click('[data-ta-action="delete"][data-ta-visible="true"] [role="button"]')
+      .ug.click('[data-ta-action="delete"]:visible .dropmask')
       .wait('[data-ta-container="yes-no-dialog"]')
       .ug.click('[data-ta-clickable="yes"]')
       .ug.waitForElementNotVisible('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -21,8 +21,8 @@ describe('[GENERIC]', () => {
   });
 
   it('Check for refresh button', () => {
-    return environment.nm.wait('[data-ta-clickable="refresh-button"]')
-      .ug.click('[data-ta-clickable="refresh-button"]');
+    return environment.nm.wait('.refresh-button')
+      .ug.click('.refresh-button');
   });
 
   it('Should be possible to create and commit a file', () => {
@@ -40,8 +40,8 @@ describe('[GENERIC]', () => {
   it('Should be able to add a new file to .gitignore', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/addMeToIgnore.txt`)
       .wait('.files .file .btn-default')
-      .ug.click('[data-ta-clickable="ignore-file"]')
-      .ug.click('[data-ta-clickable="ignore-file"]')
+      .ug.click('.files span.ignore')
+      .ug.click('.files span.ignore')
       .ug.waitForElementNotVisible('.files .file .btn-default');
   });
 
@@ -72,11 +72,11 @@ describe('[GENERIC]', () => {
   it('Should be possible to discard a created file and ensure patching is not avaliable for new file', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/testfile2.txt`)
       .wait('.files .file .btn-default')
-      .ug.click('[data-ta-clickable="show-stage-diffs"]')
+      .ug.click('.files button')
       .wait('.files .file .btn-default')
-      .ug.click('[data-ta-clickable="show-stage-diffs"]')
+      .ug.click('.files button')
       .ug.waitForElementNotVisible('[data-ta-container="patch-file"]')
-      .ug.click('[data-ta-clickable="discard-file"]')
+      .ug.click('.files span.discard')
       .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.files .file .btn-default')
   });
@@ -96,11 +96,11 @@ describe('[GENERIC]', () => {
 
   it('Should be possible to create and destroy a tag', () => {
     return environment.nm.ug.createTag('tagwillbedeleted')
-      .ug.click('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]')
+      .ug.click('.graph .ref.tag[data-ta-name="tagwillbedeleted"]')
       .ug.click('[data-ta-action="delete"]:not([style*="display: none"]) .dropmask')
       .wait('[data-ta-container="yes-no-dialog"]')
       .ug.click('.modal-dialog .btn-primary')
-      .ug.waitForElementNotVisible('[data-ta-clickable="tag"][data-ta-name="tagwillbedeleted"]');
+      .ug.waitForElementNotVisible('.graph .ref.tag[data-ta-name="tagwillbedeleted"]');
   });
 
   it('Commit changes to a file', () => {
@@ -115,7 +115,7 @@ describe('[GENERIC]', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
       .wait('.files .file .additions')
       .wait('.files .file .deletions')
-      .ug.click('[data-ta-clickable="discard-file"]')
+      .ug.click('.files span.discard')
       .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.files .file .btn-default');
   });
@@ -169,7 +169,7 @@ describe('[GENERIC]', () => {
   });
 
   it('Go to home screen', () => {
-    return environment.nm.ug.click('[data-ta-clickable="home-link"]')
-      .wait('[data-ta-container="home-page"]');
+    return environment.nm.ug.click('.navbar .backlink')
+      .wait('.home');
   });
 });

--- a/nmclicktests/spec.load-ahead.js
+++ b/nmclicktests/spec.load-ahead.js
@@ -31,12 +31,12 @@ describe('[LOAD-AHEAD]', () => {
       .wait('[data-ta-clickable="checkoutbranch-1"]')
       .wait(500)
       .ug.click('[data-ta-clickable="checkoutbranch-1"]')
-      .ug.waitForElementNotVisible('.branch [data-ta-element="progress-bar"]');
+      .ug.waitForElementNotVisible('.branch .progress');
   });
 
   it('Open path screen again and should see only 1 commit', () => {
     return environment.nm.refresh()
-      .wait('[data-ta-container="nodes-skipped"]')
+      .wait('.loadAhead')
       .ug.waitForElementNotVisible('[data-ta-clickable="node-clickable-1"]');
   });
 
@@ -45,8 +45,8 @@ describe('[LOAD-AHEAD]', () => {
   });
 
   it('Load ahead', () => {
-    return environment.nm.ug.click('[data-ta-container="nodes-skipped"]')
+    return environment.nm.ug.click('.load-ahead-button')
       .wait('[data-ta-clickable="node-clickable-1"]')
-      .ug.waitForElementNotVisible('[data-ta-container="nodes-skipped"]')
+      .ug.waitForElementNotVisible('.loadAhead')
   });
 });

--- a/nmclicktests/spec.load-ahead.js
+++ b/nmclicktests/spec.load-ahead.js
@@ -31,7 +31,7 @@ describe('[LOAD-AHEAD]', () => {
       .wait('[data-ta-clickable="checkoutbranch-1"]')
       .wait(500)
       .ug.click('[data-ta-clickable="checkoutbranch-1"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="branch"] [data-ta-element="progress-bar"]');
+      .ug.waitForElementNotVisible('.branch [data-ta-element="progress-bar"]');
   });
 
   it('Open path screen again and should see only 1 commit', () => {

--- a/nmclicktests/spec.load-ahead.js
+++ b/nmclicktests/spec.load-ahead.js
@@ -27,7 +27,7 @@ describe('[LOAD-AHEAD]', () => {
   });
 
   it('Should be possible to create and commit 3', () => {
-    return environment.nm.ug.click('[data-ta-clickable="branch-menu"]')
+    return environment.nm.ug.click('.branch .dropdown-toggle')
       .wait('[data-ta-clickable="checkoutbranch-1"]')
       .wait(500)
       .ug.click('[data-ta-clickable="checkoutbranch-1"]')

--- a/nmclicktests/spec.no-header.js
+++ b/nmclicktests/spec.no-header.js
@@ -11,14 +11,14 @@ describe('[NO-HEADER]', () => {
 
   it('Open path screen', () => {
     return environment.nm.ug.openUngit(testRepoPaths[0])
-      .wait('[data-ta-container="repository-view"]')
+      .wait('.repository-view')
       .exists('[data-ta-container="remote-error-popup"]')
       .then((isVisible) => { if (isVisible) throw new Error('Should not find remote error popup'); });
   });
 
   it('Check for refresh button', () => {
-    return environment.nm.wait('[data-ta-clickable="refresh-button"]')
-      .click('[data-ta-clickable="refresh-button"]')
+    return environment.nm.wait('.refresh-button')
+      .click('.refresh-button')
       .wait(2000)
       .exists('[data-ta-container="remote-error-popup"]')
       .then((isVisible) => { if (isVisible) throw new Error('Should not find remote error popup'); });

--- a/nmclicktests/spec.remotes.js
+++ b/nmclicktests/spec.remotes.js
@@ -40,7 +40,7 @@ describe('[REMOTES]', () => {
   it('Remote delete check', () => {
     return environment.nm.click('[data-ta-clickable="remotes-menu"]')
       .ug.click('[data-ta-clickable="myremote-remove"]')
-      .ug.click('[data-ta-clickable="yes"]')
+      .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('[data-ta-element="progress-bar"]')
       .ug.click('[data-ta-clickable="remotes-menu"]')
       .exists('[data-ta-clickable="myremote"]')

--- a/nmclicktests/spec.remotes.js
+++ b/nmclicktests/spec.remotes.js
@@ -79,6 +79,6 @@ describe('[REMOTES]', () => {
   it('Should be possible to force push a branch', () => {
     return environment.nm.ug.moveRef('branchinclone', 'Init Commit 0')
       .ug.refAction('branchinclone', true, 'push')
-      .ug.waitForElementNotVisible('[data-ta-action="push"]:visible')
+      .ug.waitForElementNotVisible('[data-ta-action="push"]:not([style*="display: none"])')
   });
 });

--- a/nmclicktests/spec.remotes.js
+++ b/nmclicktests/spec.remotes.js
@@ -79,6 +79,6 @@ describe('[REMOTES]', () => {
   it('Should be possible to force push a branch', () => {
     return environment.nm.ug.moveRef('branchinclone', 'Init Commit 0')
       .ug.refAction('branchinclone', true, 'push')
-      .ug.waitForElementNotVisible('[data-ta-action="push"][data-ta-visible="true"]')
+      .ug.waitForElementNotVisible('[data-ta-action="push"]:visible')
   });
 });

--- a/nmclicktests/spec.remotes.js
+++ b/nmclicktests/spec.remotes.js
@@ -20,29 +20,29 @@ describe('[REMOTES]', () => {
   });
 
   it('Adding a remote', () => {
-    return environment.nm.ug.click('[data-ta-clickable="remotes-menu"]')
-      .ug.click('[data-ta-clickable="show-add-remote-dialog"]')
-      .wait('[data-ta-container="add-remote"]')
-      .insert('[data-ta-container="add-remote"] [data-ta-input="name"]', 'myremote')
-      .insert('[data-ta-container="add-remote"] [data-ta-input="url"]', testRepoPaths[0])
-      .click('[data-ta-container="add-remote"] [data-ta-clickable="submit"]')
+    return environment.nm.ug.click('.fetchButton .dropdown-toggle')
+      .ug.click('.add-new-remote')
+      .wait('.modal')
+      .insert('.modal #Name', 'myremote')
+      .insert('.modal #Url', testRepoPaths[0])
+      .click('.modal .modal-footer input')
       .wait(500)
-      .click('[data-ta-clickable="remotes-menu"]')
-      .wait('[data-ta-container="remotes"] [data-ta-clickable="myremote"]');
+      .click('.fetchButton .dropdown-toggle')
+      .wait('.fetchButton .dropdown-menu [data-ta-clickable="myremote"]');
   });
 
   it('Fetch from newly added remote', () => {
-    return environment.nm.click('[data-ta-clickable="fetch"]')
+    return environment.nm.click('.fetchButton .btn-main')
       .wait(500)
-      .ug.waitForElementNotVisible('[data-ta-clickable="fetch"] [data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.fetchButton .btn-main .progress')
   });
 
   it('Remote delete check', () => {
-    return environment.nm.click('[data-ta-clickable="remotes-menu"]')
+    return environment.nm.click('.fetchButton .dropdown-toggle')
       .ug.click('[data-ta-clickable="myremote-remove"]')
       .ug.click('.modal-dialog .btn-primary')
-      .ug.waitForElementNotVisible('[data-ta-element="progress-bar"]')
-      .ug.click('[data-ta-clickable="remotes-menu"]')
+      .ug.waitForElementNotVisible('.progress')
+      .ug.click('.fetchButton .dropdown-toggle')
       .exists('[data-ta-clickable="myremote"]')
       .then((isVisible) => { if (isVisible) throw new Error('Remote exists after delete'); });
   });
@@ -50,24 +50,24 @@ describe('[REMOTES]', () => {
   // ----------- CLONING -------------
   it('navigate to empty folder path', () => {
     return environment.nm.goto(`${environment.getRootUrl()}/#/repository?path=${encodeURIComponent(testRepoPaths[2])}`)
-      .wait('[data-ta-container="uninited-path-page"]');
+      .wait('.uninited');
   });
 
   it('Clone repository should bring you to repo page', () => {
-    return environment.nm.insert('[data-ta-input="clone-url"]', testRepoPaths[1])
-      .insert('[data-ta-input="clone-target"]', testRepoPaths[2])
-      .ug.click('[data-ta-clickable="clone-repository"]')
+    return environment.nm.insert('#cloneFromInput', testRepoPaths[1])
+      .insert('#cloneToInput', testRepoPaths[2])
+      .ug.click('.uninited input[type="submit"]')
       .refresh()  // this is currently neccessary as cloning -> repo view transition is not straight forward
                   // and previous test depends on mouse wiggle that triggers refresh.
-      .wait('[data-ta-container="repository-view"]')
+      .wait('.repository-view')
       .exists('[data-ta-container="remote-error-popup"]')
       .then((isVisible) => { if (isVisible) throw new Error('Should not find remote error popup'); });
   });
 
   it('Should be possible to fetch', () => {
-    return environment.nm.click('[data-ta-clickable="fetch"]')
-      .wait('[data-ta-clickable="fetch"] [data-ta-element="progress-bar"]')
-      .ug.waitForElementNotVisible('[data-ta-clickable="fetch"][data-ta-element="progress-bar"]');
+    return environment.nm.click('.fetchButton .btn-main')
+      .wait('.fetchButton .btn-main .progress')
+      .ug.waitForElementNotVisible('.fetchButton .btn-main.progress');
   });
 
   it('Should be possible to create and push a branch', () => {

--- a/nmclicktests/spec.screens.js
+++ b/nmclicktests/spec.screens.js
@@ -12,50 +12,50 @@ describe('[SCREENS]', () => {
 
   it('Open home screen', () => {
     return environment.nm.goto(environment.getRootUrl())
-      .wait('[data-ta-container="home-page"]');
+      .wait('.home');
   });
 
   it('Open path screen', () => {
     return environment.nm.ug.createTempFolder().then(res => {
         testRepoPaths.push(res.path ? res.path : res)
         return environment.nm.goto(`${environment.getRootUrl()}/#/repository?path=${encodeURIComponent(testRepoPaths[0])}`)
-          .wait('[data-ta-container="uninited-path-page"]');
+          .wait('.uninited');
       });
   });
 
   it('Init repository should bring you to repo page', () =>  {
-    return environment.nm.ug.click('[data-ta-clickable="init-repository"]')
-      .wait('[data-ta-container="repository-view"]')
+    return environment.nm.ug.click('.uninited button.btn-primary')
+      .wait('.repository-view')
       .exists('[data-ta-container="remote-error-popup"]')
       .then((isVisible) => { if (isVisible) throw new Error('Should not find remote error popup'); });
   });
 
   it('Clicking logo should bring you to home screen', () =>  {
-    return environment.nm.ug.click('[data-ta-clickable="home-link"]')
-      .wait('[data-ta-container="home-page"]')
+    return environment.nm.ug.click('.navbar .backlink')
+      .wait('.home')
   });
 
   it('Entering an invalid path and create directory in that location', () =>  {
-    return environment.nm.insert('[data-ta-input="navigation-path"]')
-      .insert('[data-ta-input="navigation-path"]', `${testRepoPaths[0]}-test0/not/existing`)
-      .type('[data-ta-input="navigation-path"]', '\u000d')
-      .wait('[data-ta-container="invalid-path"]')
-      .ug.click('[data-ta-clickable="create-dir"]')
-      .wait('[data-ta-clickable="init-repository"]');
+    return environment.nm.insert('.navbar .path-input-form input')
+      .insert('.navbar .path-input-form input', `${testRepoPaths[0]}-test0/not/existing`)
+      .type('.navbar .path-input-form input', '\u000d')
+      .wait('.invalid-path')
+      .ug.click('.invalid-path button')
+      .wait('.uninited button.btn-primary');
   });
 
   it('Entering an invalid path should bring you to an error screen', () =>  {
-    return environment.nm.insert('[data-ta-input="navigation-path"]')
-      .insert('[data-ta-input="navigation-path"]', '/a/path/that/doesnt/exist')
-      .type('[data-ta-input="navigation-path"]', '\u000d')
-      .wait('[data-ta-container="invalid-path"]');
+    return environment.nm.insert('.navbar .path-input-form input')
+      .insert('.navbar .path-input-form input', '/a/path/that/doesnt/exist')
+      .type('.navbar .path-input-form input', '\u000d')
+      .wait('.invalid-path');
   });
 
   it('Entering a path to a repo should bring you to that repo', () =>  {
-    return environment.nm.insert('[data-ta-input="navigation-path"]')
-      .insert('[data-ta-input="navigation-path"]', testRepoPaths[0])
-      .type('[data-ta-input="navigation-path"]', '\u000d')
-      .wait('[data-ta-container="repository-view"]');
+    return environment.nm.insert('.navbar .path-input-form input')
+      .insert('.navbar .path-input-form input', testRepoPaths[0])
+      .type('.navbar .path-input-form input', '\u000d')
+      .wait('.repository-view');
   });
 
   // getting odd cross-domain-error.
@@ -66,7 +66,7 @@ describe('[SCREENS]', () => {
       .then(() => {
         return environment.nm.wait(2000)
           .goto(`${environment.getRootUrl()}/#/repository?path=${encodeURIComponent(specialRepoPath)}`)
-          .wait('[data-ta-container="uninited-path-page"]')
+          .wait('.uninited')
       });
   });
 });

--- a/nmclicktests/spec.stash.js
+++ b/nmclicktests/spec.stash.js
@@ -15,7 +15,7 @@ describe('[STASH]', () => {
 
   it('Should be possible to stash a file', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/testfile2.txt`)
-      .wait('[data-ta-container="staging-file"]')
+      .wait('.files .file')
       .ug.click('[data-ta-clickable="stash-all"]')
       .visible('[data-ta-clickable="stash-toggle"]')
       .then((isVisible) => {
@@ -32,6 +32,6 @@ describe('[STASH]', () => {
 
   it('Should be possible to pop a stash', () => {
     return environment.nm.click('[data-ta-clickable="stash-apply"]')
-      .wait('[data-ta-container="staging-file"]')
+      .wait('.files .file')
   });
 });

--- a/nmclicktests/spec.stash.js
+++ b/nmclicktests/spec.stash.js
@@ -15,7 +15,7 @@ describe('[STASH]', () => {
 
   it('Should be possible to stash a file', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/testfile2.txt`)
-      .wait('.files .file')
+      .wait('.files .file .btn-default')
       .ug.click('[data-ta-clickable="stash-all"]')
       .visible('[data-ta-clickable="stash-toggle"]')
       .then((isVisible) => {
@@ -32,6 +32,6 @@ describe('[STASH]', () => {
 
   it('Should be possible to pop a stash', () => {
     return environment.nm.click('[data-ta-clickable="stash-apply"]')
-      .wait('.files .file')
+      .wait('.files .file .btn-default')
   });
 });

--- a/nmclicktests/spec.stash.js
+++ b/nmclicktests/spec.stash.js
@@ -16,22 +16,22 @@ describe('[STASH]', () => {
   it('Should be possible to stash a file', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/testfile2.txt`)
       .wait('.files .file .btn-default')
-      .ug.click('[data-ta-clickable="stash-all"]')
-      .visible('[data-ta-clickable="stash-toggle"]')
+      .ug.click('.stash-all')
+      .visible('.stash-toggle')
       .then((isVisible) => {
         // if stash is currently collapsed show it. (localStorage['showStash'] might already be 'true')
-        return (isVisible ? environment.nm.click('[data-ta-clickable="stash-toggle"]') : environment.nm)
-          .wait('[data-ta-container="stash-stash"]')
+        return (isVisible ? environment.nm.click('.stash-toggle') : environment.nm)
+          .wait('.stash .list-group-item')
       });
   });
 
   it('Should be possible to open stash diff', () => {
-    return environment.nm.click('[data-ta-clickable="stash-diff"]')
-      .wait('[data-ta-container="stash-diff"]')
+    return environment.nm.click('.toggle-show-commit-diffs')
+      .wait('.stash .diff-wrapper')
   });
 
   it('Should be possible to pop a stash', () => {
-    return environment.nm.click('[data-ta-clickable="stash-apply"]')
+    return environment.nm.click('.stash .stash-apply')
       .wait('.files .file .btn-default')
   });
 });

--- a/nmclicktests/spec.submodules.js
+++ b/nmclicktests/spec.submodules.js
@@ -36,7 +36,7 @@ describe('[SUMBODULES]', () => {
       .wait('[data-ta-clickable="subrepo-remove"]')
       .ug.click('[data-ta-clickable="subrepo-remove"]')
       .wait('[data-ta-container="yes-no-dialog"]')
-      .ug.click('[data-ta-clickable="yes"]')
+      .ug.click('.modal-dialog .btn-primary')
       .wait(500)
       .ug.waitForElementNotVisible('[data-ta-element="progress-bar"]')
   });

--- a/nmclicktests/spec.submodules.js
+++ b/nmclicktests/spec.submodules.js
@@ -14,30 +14,30 @@ describe('[SUMBODULES]', () => {
   });
 
   it('Submodule add', () => {
-    return environment.nm.ug.click('[data-ta-clickable="submodules-menu"]')
-      .ug.click('[data-ta-clickable="add-submodule"]')
-      .wait('[data-ta-container="add-submodule"]')
-      .insert('[data-ta-container="add-submodule"] [data-ta-input="path"]', 'subrepo')
-      .insert('[data-ta-container="add-submodule"] [data-ta-input="url"]', testRepoPaths[0])
-      .click('[data-ta-container="add-submodule"] [data-ta-clickable="submit"]')
+    return environment.nm.ug.click('.submodule .dropdown-toggle')
+      .ug.click('.fetchButton .add-submodule')
+      .wait('.modal')
+      .insert('.modal #Path', 'subrepo')
+      .insert('.modal #Url', testRepoPaths[0])
+      .click('.modal .modal-footer input')
       .wait(500)
-      .click('[data-ta-clickable="submodules-menu"]')
-      .wait('[data-ta-container="submodules"] [data-ta-clickable="subrepo"]');
+      .click('.submodule .dropdown-toggle')
+      .wait('.fetchButton .dropdown-menu [data-ta-clickable="subrepo"]');
   });
 
   it('Submodule update', () => {
-    return environment.nm.ug.click('[data-ta-clickable="update-submodule"]')
+    return environment.nm.ug.click('.fetchButton .update-submodule')
       .wait(500)
-      .ug.waitForElementNotVisible('[data-ta-element="progress-bar"]');
+      .ug.waitForElementNotVisible('.progress');
   });
 
   it('Submodule delete check', () => {
-    return environment.nm.click('[data-ta-clickable="submodules-menu"]')
+    return environment.nm.click('.submodule .dropdown-toggle')
       .wait('[data-ta-clickable="subrepo-remove"]')
       .ug.click('[data-ta-clickable="subrepo-remove"]')
       .wait('[data-ta-container="yes-no-dialog"]')
       .ug.click('.modal-dialog .btn-primary')
       .wait(500)
-      .ug.waitForElementNotVisible('[data-ta-element="progress-bar"]')
+      .ug.waitForElementNotVisible('.progress')
   });
 });


### PR DESCRIPTION
* removed static `data-ta` tags and move to css tag selector.  (for dynamic `data-ta`s I think it is okay to leave it as it is.)
* changed `grunt nmclicktest` -> `grunt clicktest` as nm click test is stable
* fixed issue where open path on empty repo sometimes fail because knockoutjs sometimes doesn't create the dom when it's contents are empty.  