### PR TITLE
Fix cred helper for remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
-- 1.1.28: **UNPUBLISHED** please append your changes to here instead of new version.
+- 1.1.28: please append your changes to here instead of new version.
   - Refactoring to remove static data-ta tags from tests
   - `grunt nmclicktest` -> `grunt clicktest`
   - Stabilize ungit open test of clicktest via using a tag that is guaranteed to be generated
   - Add click test bailout on tes failure
+  - Remove deps to fix config init bug for the `credentials-helper`. [#838](https://github.com/FredrikNoren/ungit/issues/838)
 - 1.1.27: Add alert when moving back in time. [#914](https://github.com/FredrikNoren/ungit/issues/914)
 - 1.1.26:
   - fix invalid path input for autocomplete causing front end crash [#942](https://github.com/FredrikNoren/ungit/issues/942)

--- a/bin/credentials-helper
+++ b/bin/credentials-helper
@@ -1,33 +1,10 @@
 #!/usr/bin/env node
-var config = require('../src/config');
 var winston = require('winston');
-var path = require('path');
-var async = require('async');
-
-winston.remove(winston.transports.Console);
-
-var BugTracker = require('../src/bugtracker');
-var bugtracker = new BugTracker('credentials-helper');
-var usageStatistics = require('../src/usage-statistics');
-
-process.on('uncaughtException', function(err) {
-  console.error(err.stack.toString());
-  async.parallel([
-    bugtracker.notify.bind(bugtracker, err, 'credentials-helper'),
-    usageStatistics.addEvent.bind(usageStatistics, 'credentials-helper-exception')
-  ], function() {
-    process.exit();
-  });
-});
-
-if (config.logDirectory)
-  winston.add(winston.transports.File, { filename: path.join(config.logDirectory, 'credentials-helper.log'), maxsize: 100*1024, maxFiles: 2 });
-
 var socketId = process.argv[2];
 var port = process.argv[3];
-winston.info('Credentials helper invoked; port ' + port + ', socketId ' + socketId);
-
 var http = require('http');
+winston.remove(winston.transports.Console);
+winston.info('Credentials helper invoked; port ' + port + ', socketId ' + socketId);
 
 if (process.argv[4] == 'get') {
   winston.info('Getting credentials');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
fix: #838

Basically due to how the [config.js](https://github.com/FredrikNoren/ungit/blob/master/source/config.js) is doing initialization validation, spawned [credential-helpr](https://github.com/codingtwinky/ungit/blob/master/bin/credentials-helper) by git process to trigger credential collection died silently without erros being properly logged.  

Solution is to remove those dependencies.  (All deps were for logging and error usage tracking, but the value of those are questionable at best and considering this is a specialized process that is to be spawned by git, we really should keep it skinny as possible.)

FYI, because I forgot how cred helpers work and me simply assuming this bug was due to recent git promise upgrade, this was one of the most exhausting bug that I've worked on while solution being so simple.

@viharm please let me know if this doesn't work for you.  