### PR TITLE
Handle disregarding submodule changes

### DIFF
--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -327,28 +327,27 @@ git.discardChangesInFile = (repoPath, filename) => {
     .then((status) => {
       if (Object.keys(status.files).length == 0) throw new Error(`No files in status in discard, filename: ${filename}`);
       const fileStatus = status.files[Object.keys(status.files)[0]];
+      const fullPath = path.join(repoPath, filename);
 
-      if (!fileStatus.staged) {
-        // If it's just a new file, remove it
-        if (fileStatus.isNew) {
-          return fs.unlinkAsync(path.join(repoPath, filename))
-            .catch((err) => { throw { command: 'unlink', error: err }; });
-        // If it's a changed file, reset the changes
-        } else {
-          return fs.lstatAsync(path.join(repoPath, filename)).then((stats) => {
-            if (stats.isDirectory()) {
-              // file is a dir, which means it's a subrepo changes.
-              return git(['submodule', 'sync'], repoPath)
-                .then(() => git(['submodule', 'update', '--init', '-f', '--recursive', filename], repoPath));
-            } else {
-              // normal file discard
-              return git(['checkout', 'HEAD', '--', filename], repoPath);
-            }
-          });
-        }
-      } else {
+      if (fileStatus.staged) {
+        // if staged, just remove from git
         return git(['rm', '-f', filename], repoPath);
+      } else if (fileStatus.isNew) {
+        // new file, junst unlink
+        return fs.unlinkAsync(fullPath)
+          .catch((err) => { throw { command: 'unlink', error: err }; });
       }
+
+      return fs.isExists(fullPath)
+        .then((isExists) => isExists ? fs.lstatAsync(fullPath).then((stats) => stats.isDirectory()) : false)
+        .then((isSubrepoChange) => {
+          if (isSubrepoChange) {
+            return git(['submodule', 'sync'], repoPath)
+              .then(() => git(['submodule', 'update', '--init', '-f', '--recursive', filename], repoPath));
+          } else {
+            return git(['checkout', 'HEAD', '--', filename], repoPath);
+          }
+        });
     });
 }
 


### PR DESCRIPTION
Add a way to properly disregard submodule changes.

notes:
* "Disregard all" function still doesn't handle submodule changes.  I don't think this is a big problem.
* Added "-f" flag as it didn't work for a "dirty" submodules without commits without that flag.
* will add tests later
* I'm still back and forth on transitioning ungit server to maintain states or not as some of the operations like these can get optimized without doing expansive operations per requests as we do now...

cc: @wonson
