### PR TITLE
fix document title on windows

### DIFF
--- a/public/source/main.js
+++ b/public/source/main.js
@@ -116,7 +116,7 @@ function WindowTitle() {
   this.crash = false;
 }
 WindowTitle.prototype.update = function() {
-  var title = this.path.replace('\\', '/').split('/').filter(function(x) { return x; }).reverse().join(' < ');
+  var title = this.path.replace(/\\/g, '/').split('/').filter(function(x) { return x; }).reverse().join(' < ');
   if (this.crash) title = ':( ungit crash ' + title;
   document.title = title;
 }


### PR DESCRIPTION
String#replace does only replace the first occurrence. Use regex to replace all.

Before:
`D:\dev_projects\ungit` -> `dev_projects\ungit < D:`

After:
`D:\dev_projects\ungit` -> `ungit < dev_projects < D:`