### PR TITLE
Fetch bug fix and `forceLaunchPath` scope change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.4:
+  - fix a bug where fetch is disabled after page load
+  - make `forceLaunchPath` to supersede `launchBrowser` [#1006](https://github.com/FredrikNoren/ungit/issues/1006)
 - 1.4.3: changing to path navigation to `nprogress` bar. [#1001](https://github.com/FredrikNoren/ungit/issues/1001)
 - 1.4.2:
   - fix navigation redirection on git clone and adding xkcd image

--- a/bin/ungit
+++ b/bin/ungit
@@ -26,18 +26,15 @@ process.on('uncaughtException', (err) => {
 });
 
 const navigate = (override) => {
-  let currentUrl = `${config.urlBase}:${config.port}${config.rootPath}`
-  if (config.forcedLaunchPath === undefined) {
-    currentUrl += `/#/repository?path=${encodeURIComponent(process.cwd())}`
-  } else if (config.forcedLaunchPath !== null && config.forcedLaunchPath !== '') {
-    currentUrl += `/#/repository?path=${encodeURIComponent(config.forcedLaunchPath)}`
+  let pathToNavigateTo = null;
+  if (config.forcedLaunchPath !== undefined && config.forcedLaunchPath !== '') {
+    pathToNavigateTo = `${config.urlBase}:${config.port}${config.rootPath}/#/repository?path=${encodeURIComponent(config.forcedLaunchPath)}`
+  } else if (override || config.launchBrowser) {
+    pathToNavigateTo = `${config.urlBase}:${config.port}${config.rootPath}/#/repository?path=${encodeURIComponent(process.cwd())}`
   }
 
-  if (override || (config.launchBrowser && !config.launchCommand)) {
-    console.log(`Browse to ${currentUrl}`);
-    open(currentUrl);
-  } else if (config.launchCommand) {
-    const command = config.launchCommand.replace(/%U/g, currentUrl);
+  if (config.launchCommand) {
+    const command = config.launchCommand.replace(/%U/g, pathToNavigateTo);
     console.log(`Running custom launch command: ${command}`);
     child_process.exec(command, (err, stdout, stderr) => {
       if (err) {
@@ -45,9 +42,12 @@ const navigate = (override) => {
         return;
       }
       if (config.launchBrowser) {
-        open(currentUrl);
+        open(pathToNavigateTo);
       }
     });
+  } else if (pathToNavigateTo) {
+    console.log(`Browse to ${pathToNavigateTo}`);
+    open(pathToNavigateTo);
   }
 }
 

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -50,7 +50,7 @@ RemotesViewModel.prototype.fetch = function(options) {
       if (options.tags) {
         programEvents.dispatch({ event: 'remote-tags-update', tags: result.tag });
       }
-    });
+    }).finally(() => { this.isFetching = false; })
 }
 
 RemotesViewModel.prototype.updateRemotes = function() {


### PR DESCRIPTION
* Fix disabled fetch after a page load bug fix from #1003 
* `forceLaunchPath` is now used to force browser launch at user configured path despite the `launchBrowser` flag.  fix: #1006 