### PR TITLE
Add remote branch listing feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.7: add remote branches to the branch list. [#966](https://github.com/FredrikNoren/ungit/issues/966)
 - 1.4.6:
   - dependency bump to fix dependency's security problem.
   - Add emphasis if remote branch delete for confirmation dialog. [#947](https://github.com/FredrikNoren/ungit/issues/947)
-  - add remote branches to the branch list. [#966](https://github.com/FredrikNoren/ungit/issues/966)
 - 1.4.5: fix a bug where no diff wasn't properly showing [#969](https://github.com/FredrikNoren/ungit/issues/969)
 - 1.4.4:
   - fix a bug where fetch is disabled after page load

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Use the following format for additions: ` - VERSION: [feature/patch (if applicab
 - 1.4.6:
   - dependency bump to fix dependency's security problem.
   - Add emphasis if remote branch delete for confirmation dialog. [#947](https://github.com/FredrikNoren/ungit/issues/947)
+  - add remote branches to the branch list. [#966](https://github.com/FredrikNoren/ungit/issues/966)
 - 1.4.5: fix a bug where no diff wasn't properly showing [#969](https://github.com/FredrikNoren/ungit/issues/969)
 - 1.4.4:
   - fix a bug where fetch is disabled after page load

--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -7,6 +7,11 @@
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu pull-right" role="menu">
+    <div class="option" onclick="event.stopPropagation()">
+      Is fetch remote?
+      <input type="checkbox" data-bind="checked: isFetchRemoteBranches, "></input>
+    </div>
+    <div class="dropdown-divider"></div>
     <!-- ko foreach: branches -->
     <li>
       <a href="#" data-bind="html: displayName, click: $parent.checkoutBranch.bind($parent), attr: { 'data-ta-clickable': 'checkout' + name }"></a>

--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -9,7 +9,7 @@
   <ul class="dropdown-menu pull-right" role="menu">
     <!-- ko foreach: branches -->
     <li>
-      <a href="#" data-bind="text: name, click: $parent.checkoutBranch.bind($parent), attr: { 'data-ta-clickable': 'checkout' + name }"></a>
+      <a href="#" data-bind="html: displayName, click: $parent.checkoutBranch.bind($parent), attr: { 'data-ta-clickable': 'checkout' + name }"></a>
       <a href="#" class="list-link list-remove" data-bind="click: $parent.branchRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }">X</a>
     </li>
     <!-- /ko -->

--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -8,8 +8,8 @@
   </button>
   <ul class="dropdown-menu pull-right" role="menu">
     <div class="option" onclick="event.stopPropagation()">
-      Is fetch remote?
-      <input type="checkbox" data-bind="checked: isFetchRemoteBranches, "></input>
+      Only local branch?
+      <input type="checkbox" data-bind="checked: isLocalBranchOnly, "></input>
     </div>
     <div class="dropdown-divider"></div>
     <!-- ko foreach: branches -->

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -40,8 +40,7 @@ BranchesViewModel.prototype.onProgramEvent = function(event) {
   }
 }
 BranchesViewModel.prototype.checkoutBranch = function(branch) {
-  const refName = `refs/${branch.name.indexOf('remotes/') === 0 ? '' : 'heads/'}${branch.name}`;
-  this.graph.getRef(refName).checkout();
+  branch.checkout();
 }
 BranchesViewModel.prototype.updateBranches = function() {
   var self = this;
@@ -50,17 +49,15 @@ BranchesViewModel.prototype.updateBranches = function() {
     .then(function(branches) {
       const sorted = branches.filter((b) => b.name.indexOf('->') === -1)
         .map((b) => {
-          b.isRemote = b.name.indexOf('remotes/') === 0;
-          b.displayName = b.name.replace('remotes/', '<span class="octicon octicon-broadcast"></span> ');
+          const refName = `refs/${b.name.indexOf('remotes/') === 0 ? '' : 'heads/'}${b.name}`;
           if (b.current) {
             self.current(b.name);
-            b.displayName = `<span class="octicon octicon-chevron-right"></span> ${b.name}`
           }
-          return b;
+          return self.graph.getRef(refName);
         }).sort((a, b) => {
-          if (a.current || b.current) {
-            return a.current ? -1 : 1;
-          } else if (a.isRemote === b.isRemote) {
+          if (a.current() || b.current()) {
+            return a.current() ? -1 : 1;
+          } else if (a.isRemoteBranch === b.isRemoteBranch) {
             if (a.name < b.name) {
                return -1;
             } if (a.name > b.name) {
@@ -68,7 +65,7 @@ BranchesViewModel.prototype.updateBranches = function() {
             }
             return 0;
           } else {
-            return a.isRemote ? 1 : -1;
+            return a.isRemoteBranch ? 1 : -1;
           }
         });
       self.branches(sorted);

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -7,16 +7,17 @@ var programEvents = require('ungit-program-events');
 const isFetchRemoteBranches = 'isFetchRemoteBranches';
 
 components.register('branches', function(args) {
-  return new BranchesViewModel(args.server, args.repoPath);
+  return new BranchesViewModel(args.server, args.graph, args.repoPath);
 });
 
-function BranchesViewModel(server, repoPath) {
+function BranchesViewModel(server, graph, repoPath) {
   var self = this;
   this.repoPath = repoPath;
   this.server = server;
   this.branches = ko.observableArray();
   this.current = ko.observable();
   this.isFetchRemoteBranches = ko.observable(localStorage.getItem(isFetchRemoteBranches) == 'true');
+  this.graph = graph;
   this.isFetchRemoteBranches.subscribe((value) => {
     localStorage.setItem(isFetchRemoteBranches, value);
     this.updateBranches();
@@ -39,9 +40,8 @@ BranchesViewModel.prototype.onProgramEvent = function(event) {
   }
 }
 BranchesViewModel.prototype.checkoutBranch = function(branch) {
-  var self = this;
-  this.server.postPromise('/checkout', { path: this.repoPath(), name: branch.name })
-    .then(function() { self.current(branch.name); });
+  const refName = `refs/${branch.name.indexOf('remotes/') === 0 ? '' : 'heads/'}${branch.name}`;
+  this.graph.getRef(refName).checkout();
 }
 BranchesViewModel.prototype.updateBranches = function() {
   var self = this;

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -41,20 +41,26 @@ BranchesViewModel.prototype.updateBranches = function() {
 
   this.server.getPromise('/branches', { path: this.repoPath() })
     .then(function(branches) {
-      var sorted = branches.sort(function(a, b) {
-        if (a.name < b.name)
-           return -1;
-        if (a.name > b.name)
-          return 1;
-        return 0;
-      });
+      const sorted = branches.filter((b) => b.name.indexOf('->') === -1)
+        .map((b) => {
+          if (b.current) self.current(b.name);
+          b.displayName = b.name.replace('remotes/', '<span class="octicon octicon-broadcast"></span> ');
+          return b;
+        }).sort((a, b) => {
+          const isARemote = a.name.indexOf('remotes/')
+          const isBRemote = b.name.indexOf('remotes/')
+          if (isARemote === isBRemote) {
+            if (a.name < b.name)
+               return -1;
+            if (a.name > b.name)
+              return 1;
+            return 0;
+          } else {
+            return isARemote ? -1 : 1;
+          }
+          return 0;
+        });
       self.branches(sorted);
-      self.current(undefined);
-      branches.forEach(function(branch) {
-        if (branch.current) {
-          self.current(branch.name);
-        }
-      });
     }).catch(function(err) { self.current("~error"); });
 }
 

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var async = require('async');
 var components = require('ungit-components');
 var programEvents = require('ungit-program-events');
+const isFetchRemoteBranches = 'isFetchRemoteBranches';
 
 components.register('branches', function(args) {
   return new BranchesViewModel(args.server, args.repoPath);
@@ -15,6 +16,12 @@ function BranchesViewModel(server, repoPath) {
   this.server = server;
   this.branches = ko.observableArray();
   this.current = ko.observable();
+  this.isFetchRemoteBranches = ko.observable(localStorage.getItem(isFetchRemoteBranches) == 'true');
+  this.isFetchRemoteBranches.subscribe((value) => {
+    localStorage.setItem(isFetchRemoteBranches, value);
+    this.updateBranches();
+    return value;
+  });
   this.fetchLabel = ko.computed(function() {
     if (self.current()) {
       return self.current();
@@ -39,7 +46,7 @@ BranchesViewModel.prototype.checkoutBranch = function(branch) {
 BranchesViewModel.prototype.updateBranches = function() {
   var self = this;
 
-  this.server.getPromise('/branches', { path: this.repoPath() })
+  this.server.getPromise('/branches', { path: this.repoPath(), isFetchRemoteBranches: this.isFetchRemoteBranches() })
     .then(function(branches) {
       const sorted = branches.filter((b) => b.name.indexOf('->') === -1)
         .map((b) => {

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -50,22 +50,26 @@ BranchesViewModel.prototype.updateBranches = function() {
     .then(function(branches) {
       const sorted = branches.filter((b) => b.name.indexOf('->') === -1)
         .map((b) => {
-          if (b.current) self.current(b.name);
+          b.isRemote = b.name.indexOf('remotes/') === 0;
           b.displayName = b.name.replace('remotes/', '<span class="octicon octicon-broadcast"></span> ');
+          if (b.current) {
+            self.current(b.name);
+            b.displayName = `<span class="octicon octicon-chevron-right"></span> ${b.name}`
+          }
           return b;
         }).sort((a, b) => {
-          const isARemote = a.name.indexOf('remotes/')
-          const isBRemote = b.name.indexOf('remotes/')
-          if (isARemote === isBRemote) {
-            if (a.name < b.name)
+          if (a.current || b.current) {
+            return a.current ? -1 : 1;
+          } else if (a.isRemote === b.isRemote) {
+            if (a.name < b.name) {
                return -1;
-            if (a.name > b.name)
+            } if (a.name > b.name) {
               return 1;
+            }
             return 0;
           } else {
-            return isARemote ? -1 : 1;
+            return a.isRemote ? 1 : -1;
           }
-          return 0;
         });
       self.branches(sorted);
     }).catch(function(err) { self.current("~error"); });

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 var async = require('async');
 var components = require('ungit-components');
 var programEvents = require('ungit-program-events');
-const isFetchRemoteBranches = 'isFetchRemoteBranches';
+const isLocalBranchOnly = 'isLocalBranchOnly';
 
 components.register('branches', function(args) {
   return new BranchesViewModel(args.server, args.graph, args.repoPath);
@@ -16,10 +16,10 @@ function BranchesViewModel(server, graph, repoPath) {
   this.server = server;
   this.branches = ko.observableArray();
   this.current = ko.observable();
-  this.isFetchRemoteBranches = ko.observable(localStorage.getItem(isFetchRemoteBranches) == 'true');
+  this.isLocalBranchOnly = ko.observable(localStorage.getItem(isLocalBranchOnly) == 'true');
   this.graph = graph;
-  this.isFetchRemoteBranches.subscribe((value) => {
-    localStorage.setItem(isFetchRemoteBranches, value);
+  this.isLocalBranchOnly.subscribe((value) => {
+    localStorage.setItem(isLocalBranchOnly, value);
     this.updateBranches();
     return value;
   });
@@ -45,7 +45,7 @@ BranchesViewModel.prototype.checkoutBranch = function(branch) {
 BranchesViewModel.prototype.updateBranches = function() {
   var self = this;
 
-  this.server.getPromise('/branches', { path: this.repoPath(), isFetchRemoteBranches: this.isFetchRemoteBranches() })
+  this.server.getPromise('/branches', { path: this.repoPath(), isLocalBranchOnly: this.isLocalBranchOnly() })
     .then(function(branches) {
       const sorted = branches.filter((b) => b.name.indexOf('->') === -1)
         .map((b) => {

--- a/components/graph/git-graph-actions.js
+++ b/components/graph/git-graph-actions.js
@@ -220,36 +220,7 @@ GraphActions.Checkout.prototype.text = 'Checkout';
 GraphActions.Checkout.prototype.style = 'checkout';
 GraphActions.Checkout.prototype.icon = 'octicon octicon-desktop-download';
 GraphActions.Checkout.prototype.perform = function() {
-  var self = this;
-  var context = this.graph.currentActionContext();
-  var refName = context instanceof RefViewModel ? context.refName : context.sha1;
-
-  var movePromise = Promise.resolve();
-  var isRemote = context instanceof RefViewModel && context.isRemoteBranch;
-  var isLocalCurrent = context.getLocalRef() && context.getLocalRef().current();
-  if (isRemote && !isLocalCurrent) {
-    movePromise = this.server.postPromise('/branches', {
-      path: this.graph.repoPath(),
-      name: context.refName,
-      sha1: context.name,
-      force: true
-    });
-  }
-  return this.server.postPromise('/checkout', { path: this.graph.repoPath(), name: refName })
-    .then(function() {
-      if (isRemote && isLocalCurrent) {
-        return self.server.postPromise('/reset', { path: self.graph.repoPath(), to: context.name, mode: 'hard' })
-          .then(function() {
-            self.graph.HEADref().node(context instanceof RefViewModel ? context.node() : context);
-          }).catch(function(err) {
-            if (err.errorCode == 'merge-failed') self.server.unhandledRejection(err);
-          });
-      } else {
-        self.graph.HEADref().node(context instanceof RefViewModel ? context.node() : context);
-      }
-    }).catch(function(err) {
-      if (err.errorCode != 'merge-failed') self.server.unhandledRejection(err);
-    });
+  return this.graph.currentActionContext().checkout();
 }
 
 GraphActions.Delete = function(graph, node) {

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -65,6 +65,15 @@ var RefViewModel = function(fullRefName, graph) {
   this.value = splitedName[splitedName.length - 1]
   this.label = this.localRefName
   this.dom = `${this.localRefName}<span class='octicon ${this.isTag ? 'octicon-tag' : 'octicon-git-branch'}'></span>`
+  this.displayName = ko.computed(function() {
+    if (self.isRemoteBranch) {
+      return self.name.replace('refs/remotes/', '<span class="octicon octicon-broadcast"></span> ');
+    } else if (self.current()) {
+      return `<span class="octicon octicon-chevron-right"></span> ${self.name.replace('refs/', '')}`
+    } else {
+      return self.name.replace('refs/', '');
+    }
+  });
 };
 module.exports = RefViewModel;
 

--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -20,7 +20,7 @@ var RepositoryViewModel = function(server, path) {
   this.submodules = components.create('submodules', { server: server, repoPath: this.repoPath });
   this.stash = this.isBareDir ? {} : components.create('stash', { server: server, repoPath: this.repoPath });
   this.staging = this.isBareDir ? {} : components.create('staging', { server: server, repoPath: this.repoPath });
-  this.branches = components.create('branches', { server: server, repoPath: this.repoPath });
+  this.branches = components.create('branches', { server: server, graph: this.graph, repoPath: this.repoPath });
   this.repoPath.subscribe(function(value) { self.sever.watchRepository(value); });
   this.server.watchRepository(this.repoPath());
   this.showLog = self.isBareDir ? ko.observable(true) : self.staging.isStageValid;

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -313,7 +313,7 @@ var FileViewModel = function(staging, name) {
 
   this.editState.subscribe(function (value) {
     if (value === 'none') {
-      self.patchLineList([]);
+      self.removeAll();
     } else if (value === 'patched') {
       if (self.diff().render) self.diff().render();
     }

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -313,7 +313,7 @@ var FileViewModel = function(staging, name) {
 
   this.editState.subscribe(function (value) {
     if (value === 'none') {
-      self.removeAll();
+      self.patchLineList.removeAll();
     } else if (value === 'patched') {
       if (self.diff().render) self.diff().render();
     }

--- a/nmclicktests/spec.branches.js
+++ b/nmclicktests/spec.branches.js
@@ -67,17 +67,14 @@ describe('[BRANCHES]', () => {
 
   it('Check out a branch via selection', () => {
     return environment.nm.ug.click('.branch .dropdown-toggle')
-      .ug.click('[data-ta-clickable="checkoutbranch-2"]')
+      .ug.click('[data-ta-clickable="checkoutrefs/heads/branch-2"]')
       .ug.waitForElementNotVisible('#nprogress')
   });
 
   it('Delete a branch via selection', () => {
     return environment.nm.click('.branch .dropdown-toggle')
-      .wait('[data-ta-clickable="branch-3-remove"]')
-      .wait(500)
-      .click('[data-ta-clickable="branch-3-remove"]')
-      .wait(500)
-      .click('.modal-dialog .btn-primary')
+      .ug.click('[data-ta-clickable="refs/heads/branch-3-remove"]')
+      .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('#nprogress')
       .wait(500);
   });
@@ -89,7 +86,7 @@ describe('[BRANCHES]', () => {
 
   it('checkout cherypick base', () => {
     return environment.nm.ug.click('.branch .dropdown-toggle')
-      .ug.click('[data-ta-clickable="checkoutbranch-1"]')
+      .ug.click('[data-ta-clickable="checkoutrefs/heads/branch-1"]')
       .ug.waitForElementNotVisible('#nprogress')
   });
 

--- a/nmclicktests/spec.load-ahead.js
+++ b/nmclicktests/spec.load-ahead.js
@@ -28,9 +28,7 @@ describe('[LOAD-AHEAD]', () => {
 
   it('Should be possible to create and commit 3', () => {
     return environment.nm.ug.click('.branch .dropdown-toggle')
-      .wait('[data-ta-clickable="checkoutbranch-1"]')
-      .wait(500)
-      .ug.click('[data-ta-clickable="checkoutbranch-1"]')
+      .ug.click('[data-ta-clickable="checkoutrefs/heads/branch-1"]')
       .ug.waitForElementNotVisible('#nprogress');
   });
 

--- a/nmclicktests/spec.remotes.js
+++ b/nmclicktests/spec.remotes.js
@@ -79,4 +79,25 @@ describe('[REMOTES]', () => {
       .ug.refAction('branchinclone', true, 'push')
       .ug.waitForElementNotVisible('[data-ta-action="push"]:not([style*="display: none"])')
   });
+
+  it('Check for fetching remote branches for the branch list', () => {
+    return environment.nm.ug.click('.branch .dropdown-toggle')
+      .ug.click('div.option input')
+      .wait(200)
+      .visible('li .octicon-broadcast')
+      .then((isVisble) => {
+        if (!isVisble) {
+          return environment.nm.ug.click('div.option input')
+            .wait('li .octicon-broadcast')
+        }
+      });
+  });
+
+  it('checkout remote branches with matching local branch at wrong place', () => {
+    return environment.nm.ug.moveRef('branchinclone', 'Init Commit 1')
+      .ug.click('.branch .dropdown-toggle')
+      .ug.click('[data-ta-clickable="checkoutrefs/remotes/origin/branchinclone"]')
+      .wait(200)
+      .wait('[data-ta-name="branchinclone"][data-ta-local="true"]')
+  });
 });

--- a/nmclicktests/spec.submodules.js
+++ b/nmclicktests/spec.submodules.js
@@ -33,7 +33,6 @@ describe('[SUMBODULES]', () => {
 
   it('Submodule delete check', () => {
     return environment.nm.click('.submodule .dropdown-toggle')
-      .wait('[data-ta-clickable="subrepo-remove"]')
       .ug.click('[data-ta-clickable="subrepo-remove"]')
       .wait('[data-ta-container="yes-no-dialog"]')
       .ug.click('.modal-dialog .btn-primary')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -85,6 +85,19 @@
   max-height: 500px;
   height: auto;
   overflow-y: scroll;
+  min-width: 205px;
+  widht: auto;
+  .option {
+    padding-left: 20px;
+    font-size: 120%;
+    color: black;
+  }
+  .dropdown-divider {
+    height: 0;
+    margin: .5rem 0;
+    overflow: hidden;
+    border-top: 1px solid #e9ecef;
+  }
   li {
     a {
       &.list-url {

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -100,6 +100,7 @@
   }
   li {
     a {
+      padding-right: 30px;
       &.list-url {
         padding: 0px 4px 0px 4px;
         margin-right: 30px;

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -82,6 +82,9 @@
 }
 
 .dropdown-menu {
+  max-height: 500px;
+  height: auto;
+  overflow-y: scroll;
   li {
     a {
       &.list-url {

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -86,7 +86,7 @@
   height: auto;
   overflow-y: scroll;
   min-width: 205px;
-  widht: auto;
+  width: auto;
   .option {
     padding-left: 20px;
     font-size: 120%;

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -403,11 +403,30 @@ exports.registerApi = (env) => {
       .finally(emitGitDirectoryChanged.bind(null, req.query.path));
   });
 
+  const createBranchIfPossible = (branchName, path, retry) => {
+    retry = retry || 3;
+    return gitPromise(['branch', branchName], path).catch((e) => {
+        if (retry > -1) {
+          return createBranchIfPossible(`ungit-${crypto.randomBytes(4).toString('hex')}`, path, retry - 1);
+        } else {
+          throw e;
+        }
+      }).then(() => branchName);
+  }
+
   app.post(`${exports.pathPrefix}/checkout`, ensureAuthenticated, ensurePathExists, (req, res) => {
     const arg = !!req.body.sha1 ? ['checkout', '-b', req.body.name.trim(), req.body.sha1] : ['checkout', req.body.name.trim()];
+    const isRemote = !!req.body.name && req.body.name.indexOf('remote/') === 0;
 
-    jsonResultOrFailProm(res, autoStashExecuteAndPop(arg, req.body.path))
-      .then(emitGitDirectoryChanged.bind(null, req.body.path))
+    jsonResultOrFailProm(res, autoStashExecuteAndPop(arg, req.body.path).then(() => {
+        if (isRemote) {
+          // preferred branch name will not work as expected when remote or branch nae has '/'
+          const preferredBranchName = `${req.body.name.splice('/').slice(2).join('/')}`
+          return createBranchIfPossible(preferredBranchName, req.body.path)
+            // sucessfully create the branch, checkout and be marry
+            .then((createdName) => return gitPromise(['checkout', createdName], req.body.path));
+        }
+      })).then(emitGitDirectoryChanged.bind(null, req.body.path))
       .then(emitWorkingTreeChanged.bind(null, req.body.path));
   });
 

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -338,7 +338,7 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/branches`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    jsonResultOrFailProm(res, gitPromise(['branch'], req.query.path).then(gitParser.parseGitBranches));
+    jsonResultOrFailProm(res, gitPromise(['branch', '-a'], req.query.path).then(gitParser.parseGitBranches));
   });
 
   app.post(`${exports.pathPrefix}/branches`, ensureAuthenticated, ensurePathExists, (req, res) => {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -404,29 +404,11 @@ exports.registerApi = (env) => {
       .finally(emitGitDirectoryChanged.bind(null, req.query.path));
   });
 
-  const createBranchIfPossible = (branchName, path, retry) => {
-    return gitPromise(['branch', branchName], path).catch((e) => {
-        if (retry > 0) {
-          return createBranchIfPossible(`ungit-${crypto.randomBytes(4).toString('hex')}`, path, retry - 1);
-        } else {
-          throw e;
-        }
-      }).then(() => branchName);
-  }
-
   app.post(`${exports.pathPrefix}/checkout`, ensureAuthenticated, ensurePathExists, (req, res) => {
     const arg = !!req.body.sha1 ? ['checkout', '-b', req.body.name.trim(), req.body.sha1] : ['checkout', req.body.name.trim()];
-    const isRemote = !!req.body.name && req.body.name.indexOf('remote/') === 0;
 
-    jsonResultOrFailProm(res, autoStashExecuteAndPop(arg, req.body.path).then(() => {
-        if (isRemote) {
-          // preferred branch name will not work as expected when remote or branch nae has '/'
-          const preferredBranchName = `${req.body.name.splice('/').slice(2).join('/')}`
-          return createBranchIfPossible(preferredBranchName, req.body.path, 3)
-            // sucessfully create the branch, checkout and be marry
-            .then((createdName) => gitPromise(['checkout', createdName], req.body.path));
-        }
-      })).then(emitGitDirectoryChanged.bind(null, req.body.path))
+    jsonResultOrFailProm(res, autoStashExecuteAndPop(arg, req.body.path))
+      .then(emitGitDirectoryChanged.bind(null, req.body.path))
       .then(emitWorkingTreeChanged.bind(null, req.body.path));
   });
 

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -406,7 +406,7 @@ exports.registerApi = (env) => {
 
   const createBranchIfPossible = (branchName, path, retry) => {
     return gitPromise(['branch', branchName], path).catch((e) => {
-        if (retry > -1) {
+        if (retry > 0) {
           return createBranchIfPossible(`ungit-${crypto.randomBytes(4).toString('hex')}`, path, retry - 1);
         } else {
           throw e;

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -338,7 +338,9 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/branches`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    jsonResultOrFailProm(res, gitPromise(['branch', '-a'], req.query.path).then(gitParser.parseGitBranches));
+    const isFetchRemoteBranches = req.query.isFetchRemoteBranches == 'true'
+    jsonResultOrFailProm(res, gitPromise(['branch', isFetchRemoteBranches ? '-a' : ''], req.query.path)
+      .then(gitParser.parseGitBranches));
   });
 
   app.post(`${exports.pathPrefix}/branches`, ensureAuthenticated, ensurePathExists, (req, res) => {

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -339,8 +339,8 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/branches`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const isFetchRemoteBranches = req.query.isFetchRemoteBranches == 'true'
-    jsonResultOrFailProm(res, gitPromise(['branch', isFetchRemoteBranches ? '-a' : ''], req.query.path)
+    const isLocalBranchOnly = req.query.isLocalBranchOnly == 'false';
+    jsonResultOrFailProm(res, gitPromise(['branch', isLocalBranchOnly ? '-a' : ''], req.query.path)
       .then(gitParser.parseGitBranches));
   });
 


### PR DESCRIPTION
fixes #966

* ability to list all branches including remote branches within branch list bar.
* lots of refactoring to recycle and share git-ref objects and checkout logic for simplified code path
* ability to checkout remote branches[1]

[1] Current implementation of remote branch logic is something that I'm not sure if it is a good idea always.
Currently, when remote branch checkout is performed, ungit will FORCE move local branch of the remote branch to the remote branch's location and checkout that local branch.  

This is not always ideal and needs to be discussed more and is demonstrated below.

<img width="997" alt="screen shot 2018-01-15 at 13 46 02" src="http://g.recordit.co/CduoBBVc3q.gif">

* you can see that remote branch `remot/imgtest` and local `imgtest` branch is in different locations.
* when `remot/imgtest` is checked out, local `imgtest` is force moved to `remot/imgtest`.



Considering this was an existing behavior, perhaps users are okay with this but I may fix this so to create tmp branches as briefly discussed in #966.