### PR TITLE
handle failed promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
-- 1.4.8: handle failed promises [#1017](https://github.com/FredrikNoren/ungit/issues/1017)
+- 1.4.8:
+  - handle failed promises [#1017](https://github.com/FredrikNoren/ungit/issues/1017)
+  - empty commit [#1028](https://github.com/FredrikNoren/ungit/issues/1028)
+  - fix commit detail layout while hovering over commit node [#1025](https://github.com/FredrikNoren/ungit/issues/1025)
 - 1.4.7: add remote branches to the branch list. [#966](https://github.com/FredrikNoren/ungit/issues/966)
 - 1.4.6:
   - dependency bump to fix dependency's security problem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.8: handle failed promises [#1017](https://github.com/FredrikNoren/ungit/issues/1017)
 - 1.4.7: add remote branches to the branch list. [#966](https://github.com/FredrikNoren/ungit/issues/966)
 - 1.4.6:
   - dependency bump to fix dependency's security problem.

--- a/components/app/app.js
+++ b/components/app/app.js
@@ -67,7 +67,8 @@ AppViewModel.prototype.shown = function() {
     // since ungit may have crashed without the server crashing since we enabled bugtracking,
     // and we don't want to show the nagscreen twice in that case.
     this.server.getPromise('/userconfig')
-      .then(function(userConfig) { self.bugtrackingEnabled(userConfig.bugtracking); });
+      .then(function(userConfig) { self.bugtrackingEnabled(userConfig.bugtracking); })
+      .catch((e) => this.server.unhandledRejection(e));
   }
 
   this.server.getPromise('/latestversion')
@@ -76,13 +77,13 @@ AppViewModel.prototype.shown = function() {
       self.currentVersion(version.currentVersion);
       self.latestVersion(version.latestVersion);
       self.showNewVersionAvailable(!ungit.config.ungitVersionCheckOverride && version.outdated);
-    });
+    }).catch((e) => this.server.unhandledRejection(e));
   this.server.getPromise('/gitversion')
     .then(function(gitversion) {
       if (gitversion && !gitversion.satisfied) {
         self.gitVersionError(gitversion.error);
       }
-    });
+    }).catch((e) => this.server.unhandledRejection(e));
 }
 AppViewModel.prototype.updateAnimationFrame = function(deltaT) {
   if (this.content() && this.content().updateAnimationFrame) this.content().updateAnimationFrame(deltaT);
@@ -128,7 +129,7 @@ AppViewModel.prototype.gitSetUserConfig = function(bugTracking, sendUsageStatist
       if (sendUsageStatistics != undefined) userConfig.sendUsageStatistics = sendUsageStatistics;
       return self.server.postPromise('/userconfig', userConfig)
         .then(function() { self.bugtrackingEnabled(bugTracking); });
-    }).catch(function(err) { })
+    });
 }
 AppViewModel.prototype.enableBugtrackingAndStatistics = function() {
   this.gitSetUserConfig(true, true);

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -79,6 +79,7 @@ BranchesViewModel.prototype.branchRemove = function(branch) {
     .closeThen(function(diag) {
       if (!diag.result()) return;
       self.server.delPromise('/branches', { name: branch.name, path: self.repoPath() })
-        .then(function() { programEvents.dispatch({ event: 'working-tree-changed' }); });
+        .then(function() { programEvents.dispatch({ event: 'working-tree-changed' }); })
+        .catch((e) => this.server.unhandledRejection(e));
     });
 }

--- a/components/gitErrors/gitErrors.js
+++ b/components/gitErrors/gitErrors.js
@@ -39,8 +39,7 @@ function GitErrorViewModel(gitErrors, server, data) {
 
   if (!data.shouldSkipReport && !ungit.config.bugtracking) {
     this.server.getPromise('/userconfig')
-      .then(function(userConfig) { self.showEnableBugtracking(!userConfig.bugtracking); })
-      .catch(function(err) {});
+      .then(function(userConfig) { self.showEnableBugtracking(!userConfig.bugtracking); });
   }
 }
 GitErrorViewModel.prototype.dismiss = function() {
@@ -54,5 +53,5 @@ GitErrorViewModel.prototype.enableBugtrackingAndStatistics = function() {
       userConfig.sendUsageStatistics = true;
       return self.server.postPromise('/userconfig', userConfig)
         .then(function() { self.showEnableBugtracking(false); })
-    }).catch(function(err) {});
+    });
 }

--- a/components/graph/git-graph-actions.js
+++ b/components/graph/git-graph-actions.js
@@ -34,7 +34,9 @@ GraphActions.ActionBase.prototype.doPerform = function() {
   if (this.isRunning()) return;
   this.graph.hoverGraphAction(null);
   this.isRunning(true);
-  this.perform().finally(() => { this.isRunning(false); });
+  this.perform()
+    .catch((e) => this.server.unhandledRejection(e))
+    .finally(() => { this.isRunning(false); });
 }
 GraphActions.ActionBase.prototype.dragEnter = function() {
   if (!this.visible()) return;

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -197,7 +197,8 @@ GitNodeViewModel.prototype.createBranch = function() {
   this.graph.server.postPromise(command, { path: this.graph.repoPath(), name: this.newBranchName(), sha1: this.sha1 })
     .then(function() {
       self.graph.getRef('refs/heads/' + self.newBranchName()).node(self);
-    }).finally(function() {
+    }).catch((e) => this.server.unhandledRejection(e))
+    .finally(function() {
       self.branchingFormVisible(false);
       self.newBranchName('');
       programEvents.dispatch({ event: 'branch-updated' });
@@ -210,7 +211,8 @@ GitNodeViewModel.prototype.createTag = function() {
     .then(function() {
       var newRef = self.graph.getRef('tag: refs/tags/' + self.newBranchName());
       newRef.node(self);
-    }).finally(function() {
+    }).catch((e) => this.server.unhandledRejection(e))
+    .finally(function() {
       self.branchingFormVisible(false);
       self.newBranchName('');
     });

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -139,7 +139,7 @@ RefViewModel.prototype.moveTo = function(target, rewindWarnOverride) {
         self.graph.HEADref().node(targetNode);
       }
       self.node(targetNode);
-    });
+    }).catch((e) => this.server.unhandledRejection(e));
 }
 
 RefViewModel.prototype.remove = function() {
@@ -151,7 +151,8 @@ RefViewModel.prototype.remove = function() {
     .then(function() {
       self.node().removeRef(self);
       self.graph.refsByRefName[self.name] = undefined;
-    }).finally(function() {
+    }).catch((e) => this.server.unhandledRejection(e))
+    .finally(function() {
       if (url == '/remote/tags') {
         programEvents.dispatch({ event: 'request-fetch-tags' });
       } else {
@@ -189,11 +190,11 @@ RefViewModel.prototype.canBePushed = function(remote) {
 
 RefViewModel.prototype.createRemoteRef = function() {
   var self = this;
-  return this.server.postPromise('/push', { path: this.graph.repoPath(), remote: this.graph.currentRemote(),
-    refSpec: this.refName, remoteBranch: this.refName }).then(function() {
+  return this.server.postPromise('/push', { path: this.graph.repoPath(), remote: this.graph.currentRemote(), refSpec: this.refName, remoteBranch: this.refName })
+    .then(function() {
       var newRef = self.graph.getRef("refs/remotes/" + self.graph.currentRemote() + "/" + self.refName);
       newRef.node(self.node());
-    });
+    }).catch((e) => this.server.unhandledRejection(e));
 }
 RefViewModel.prototype.checkout = function() {
   const isRemote = this.isRemoteBranch;

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -145,7 +145,8 @@ GraphViewModel.prototype.loadNodesFromApi = function() {
         self.graphHeight(nodes[nodes.length - 1].cy() + 80);
       }
       self.graphWidth(1000 + (self.heighstBranchOrder * 90));
-    }).finally(function() {
+    }).catch((e) => this.server.unhandledRejection(e))
+    .finally(function() {
       if (window.innerHeight - self.graphHeight() > 0 && nodeSize != self.nodes().length) {
         self.scrolledToEnd();
       }

--- a/components/home/home.js
+++ b/components/home/home.js
@@ -20,7 +20,8 @@ function HomeRepositoryViewModel(home, path) {
 HomeRepositoryViewModel.prototype.updateState = function() {
   var self = this;
   this.server.getPromise('/fs/exists?path=' + encodeURIComponent(this.path))
-    .then(function(exists) { self.pathRemoved(!exists); });
+    .then(function(exists) { self.pathRemoved(!exists); })
+    .catch((e) => this.server.unhandledRejection(e));
   this.server.getPromise('/remotes/origin?path=' + encodeURIComponent(this.path))
     .then(function(remote) {	self.remote(remote.address.replace(/\/\/.*?\@/, "//***@")); })
     .catch(function(err) { self.remote(''); });

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -61,6 +61,7 @@ class PathViewModel {
   }
   initRepository() {
     return this.server.postPromise('/init', { path: this.repoPath() })
+      .catch((e) => this.server.unhandledRejection(e))
       .finally((res) => { this.updateStatus(); });
   }
   onProgramEvent(event) {
@@ -75,6 +76,7 @@ class PathViewModel {
 
     return this.server.postPromise('/clone', { path: this.repoPath(), url: this.cloneUrl(), destinationDir: dest })
       .then((res) => navigation.browseTo('repository?path=' + encodeURIComponent(res.path)) )
+      .catch((e) => this.server.unhandledRejection(e))
       .finally(() => {
         programEvents.dispatch({ event: 'working-tree-changed' });
       })
@@ -82,6 +84,7 @@ class PathViewModel {
   createDir() {
     this.showDirectoryCreatedAlert(true);
     return this.server.postPromise('/createDir',  { dir: this.repoPath() })
+      .catch((e) => this.server.unhandledRejection(e))
       .then(() => this.updateStatus());
   }
 }

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -50,7 +50,8 @@ RemotesViewModel.prototype.fetch = function(options) {
       if (options.tags) {
         programEvents.dispatch({ event: 'remote-tags-update', tags: result.tag });
       }
-    }).finally(() => { this.isFetching = false; })
+    }).catch((e) => this.server.unhandledRejection(e))
+    .finally(() => { this.isFetching = false; })
 }
 
 RemotesViewModel.prototype.updateRemotes = function() {
@@ -88,7 +89,8 @@ RemotesViewModel.prototype.showAddRemoteDialog = function() {
     .closeThen(function(diag) {
       if(diag.isSubmitted()) {
         return self.server.postPromise('/remotes/' + encodeURIComponent(diag.name()), { path: self.repoPath(), url: diag.url() })
-          .then(function() { self.updateRemotes(); });
+          .then(function() { self.updateRemotes(); })
+          .catch((e) => this.server.unhandledRejection(e));
       }
     });
 }
@@ -100,7 +102,8 @@ RemotesViewModel.prototype.remoteRemove = function(remote) {
     .closeThen(function(diag) {
       if (diag.result()) {
         return self.server.delPromise('/remotes/' + remote.name, { path: self.repoPath() })
-          .then(() => { self.updateRemotes(); });
+          .then(() => { self.updateRemotes(); })
+          .catch((e) => this.server.unhandledRejection(e));
       }
     });
 }

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -237,12 +237,14 @@ StagingViewModel.prototype.commit = function() {
 
   this.server.postPromise('/commit', { path: this.repoPath(), message: commitMessage, files: files, amend: this.amend() })
     .then(() => { self.resetMessages(); })
+    .catch((e) => this.server.unhandledRejection(e));
 }
 StagingViewModel.prototype.conflictResolution = function(apiPath) {
   var self = this;
   var commitMessage = this.commitMessageTitle();
   if (this.commitMessageBody()) commitMessage += '\n\n' + this.commitMessageBody();
   this.server.postPromise(apiPath, { path: this.repoPath(), message: commitMessage })
+    .catch((e) => this.server.unhandledRejection(e))
     .finally((err) => { self.resetMessages(); });
 }
 StagingViewModel.prototype.invalidateFilesDiffs = function() {
@@ -255,12 +257,16 @@ StagingViewModel.prototype.discardAllChanges = function() {
   components.create('yesnodialog', { title: 'Are you sure you want to discard all changes?', details: 'This operation cannot be undone.'})
     .show()
     .closeThen(function(diag) {
-      if (diag.result()) self.server.postPromise('/discardchanges', { path: self.repoPath(), all: true });
+      if (diag.result()) {
+        self.server.postPromise('/discardchanges', { path: self.repoPath(), all: true })
+          .catch((e) => this.server.unhandledRejection(e))
+      }
     });
 }
 StagingViewModel.prototype.stashAll = function() {
   var self = this;
-  this.server.postPromise('/stashes', { path: this.repoPath(), message: this.commitMessageTitle() });
+  this.server.postPromise('/stashes', { path: this.repoPath(), message: this.commitMessageTitle() })
+    .catch((e) => this.server.unhandledRejection(e));
 }
 StagingViewModel.prototype.toggleAllStages = function() {
   var self = this;
@@ -360,12 +366,16 @@ FileViewModel.prototype.toggleStaged = function() {
 FileViewModel.prototype.discardChanges = function() {
   var self = this;
   if (ungit.config.disableDiscardWarning || new Date().getTime() - this.staging.mutedTime < ungit.config.disableDiscardMuteTime) {
-    self.server.postPromise('/discardchanges', { path: self.staging.repoPath(), file: self.name() });
+    self.server.postPromise('/discardchanges', { path: self.staging.repoPath(), file: self.name() })
+      .catch((e) => this.server.unhandledRejection(e));
   } else {
     components.create('yesnomutedialog', { title: 'Are you sure you want to discard these changes?', details: 'This operation cannot be undone.'})
       .show()
       .closeThen(function(diag) {
-        if (diag.result()) self.server.postPromise('/discardchanges', { path: self.staging.repoPath(), file: self.name() });
+        if (diag.result()) {
+          self.server.postPromise('/discardchanges', { path: self.staging.repoPath(), file: self.name() })
+            .catch((e) => this.server.unhandledRejection(e));
+        }
         if (diag.result() === "mute") self.staging.mutedTime = new Date().getTime();
       });
   }
@@ -383,10 +393,12 @@ FileViewModel.prototype.ignoreFile = function() {
     });
 }
 FileViewModel.prototype.resolveConflict = function() {
-  this.server.postPromise('/resolveconflicts', { path: this.staging.repoPath(), files: [this.name()] });
+  this.server.postPromise('/resolveconflicts', { path: this.staging.repoPath(), files: [this.name()] })
+    .catch((e) => this.server.unhandledRejection(e));
 }
 FileViewModel.prototype.launchMergeTool = function() {
-  this.server.postPromise('/launchmergetool', { path: this.staging.repoPath(), file: this.name(), tool: mergeTool });
+  this.server.postPromise('/launchmergetool', { path: this.staging.repoPath(), file: this.name(), tool: mergeTool })
+    .catch((e) => this.server.unhandledRejection(e));
 }
 FileViewModel.prototype.toggleDiffs = function() {
   if (this.renamed()) return; // do not show diffs for renames

--- a/components/stash/stash.js
+++ b/components/stash/stash.js
@@ -25,7 +25,8 @@ function StashItemViewModel(stash, data) {
 }
 StashItemViewModel.prototype.apply = function() {
   var self = this;
-  this.server.delPromise('/stashes/' + this.id, { path: this.stash.repoPath(), apply: true });
+  this.server.delPromise('/stashes/' + this.id, { path: this.stash.repoPath(), apply: true })
+    .catch((e) => this.server.unhandledRejection(e));
 }
 StashItemViewModel.prototype.drop = function() {
   var self = this;
@@ -33,7 +34,8 @@ StashItemViewModel.prototype.drop = function() {
     .show()
     .closeThen(function(diag) {
       if (diag.result()) {
-          self.server.delPromise('/stashes/' + self.id, { path: self.stash.repoPath() });
+          self.server.delPromise('/stashes/' + self.id, { path: self.stash.repoPath() })
+            .catch((e) => this.server.unhandledRejection(e));
       }
   });
 }

--- a/components/submodules/submodules.js
+++ b/components/submodules/submodules.js
@@ -31,13 +31,14 @@ SubmodulesViewModel.prototype.fetchSubmodules = function() {
     .then(function(submodules) {
       self.submodules(submodules && Array.isArray(submodules) ? submodules : []);
       return self;
-    });
+    }).catch((e) => this.server.unhandledRejection(e));
 }
 
 SubmodulesViewModel.prototype.updateSubmodules = function() {
   if (this.isUpdating) return;
   this.isUpdating = true;
   return this.server.postPromise('/submodules/update', { path: this.repoPath() })
+    .catch((e) => this.server.unhandledRejection(e))
     .finally(() => { this.isUpdating = false; });
 }
 
@@ -49,6 +50,7 @@ SubmodulesViewModel.prototype.showAddSubmoduleDialog = function() {
       this.isUpdating = true;
       this.server.postPromise('/submodules/add', { path: this.repoPath(), submoduleUrl: diag.url(), submodulePath: diag.path() })
         .then(() => { programEvents.dispatch({ event: 'submodule-fetch' }); })
+        .catch((e) => this.server.unhandledRejection(e))
         .finally(() => { this.isUpdating = false; });
     });
 }
@@ -68,6 +70,7 @@ SubmodulesViewModel.prototype.submoduleRemove = function(submodule) {
     .closeThen(function(diag) {
       if (!diag.result()) return;
       self.server.delPromise('/submodules', { path: self.repoPath(), submodulePath: submodule.path, submoduleName: submodule.name })
-        .then(() => { programEvents.dispatch({ event: 'submodule-fetch' }); });
+        .then(() => { programEvents.dispatch({ event: 'submodule-fetch' }); })
+        .catch((e) => this.server.unhandledRejection(e));
     });
 }

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -166,7 +166,7 @@ class Environment {
     this.config.serverTimeout = this.config.serverTimeout || 15000;
     this.config.viewWidth = 2000;
     this.config.viewHeight = 2000;
-    this.config.showServerOutput = this.config.showServerOutput || true;
+    this.config.showServerOutput = this.config.showServerOutput === undefined ? true : this.config.showServerOutput;
     this.config.serverStartupOptions = this.config.serverStartupOptions || [];
     this.shuttinDown = false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
fixes #1017 

tldr; I was trying to be clever in handling promise rejections, it introduced intermittent test failures, and I have sloppily fixed it.  Now it is handled manually to be more precise.

----
Each promises calls requires proper catch function to either ignore or handle exceptions.  However, I thought I was being clever by using [`onPossiblyUnhandledRejection`](http://bluebirdjs.com/docs/api/promise.onpossiblyunhandledrejection.html) and this caused some inconsistencies in click tests, especially in windows side, as name suggests, its "possible" not definite.  

So I have sloppily removed it and now here we are manually attaching custom individual catch blocks to all promises, which it bit annoying but I can't think of any other better way.