### PR TITLE
fix commit detail layout while hovering over commit node

### DIFF
--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -42,7 +42,7 @@ function CommitViewModel(gitNode) {
   this.diffStyle = ko.computed(function() {
     var marginLeft = Math.min((gitNode.branchOrder() * 70), 450) * -1;
     if (self.selected() && self.element()) return { "margin-left": marginLeft + 'px', width: (window.innerWidth - 220) + 'px' };
-    else return { left: '0px', width: self.element() ? ((self.element().clientWidth - 20) + 'px') : 'inherit' };
+    else return {};
   });
 }
 CommitViewModel.prototype.updateNode = function(parentElement) {


### PR DESCRIPTION
Returning an empty object will remove the inline styles completly. No need to set everything back to 0 or inherit.
Not sure when this issue occured the first time.

fixes #1025