### PR TITLE
wait for cherrypick in tests

### DIFF
--- a/nmclicktests/spec.branches.js
+++ b/nmclicktests/spec.branches.js
@@ -93,6 +93,7 @@ describe('[BRANCHES]', () => {
   it('cherrypick fail case', () => {
     return environment.nm.ug.click('[data-ta-clickable="node-clickable-0"]')
       .ug.click('[data-ta-action="cherry-pick"]:not([style*="display: none"]) .dropmask')
+      .wait(3000) // on windows clicking on cherry pick which results in conflicts might take some time
       .ug.click('.staging .btn-stg-abort')
       .ug.click('.modal-dialog .btn-primary')
       .wait(500)


### PR DESCRIPTION
on windows clicking on cherry pick which results in conflicts might take some time

hopfully fixes #1043

I observed the same issue as @ylecuyer in #1045 but on my local windows machine.
I tested it serveral times and I only got reliable results with `3000` milliseconds or more with nightmare visible `true` and `false`. Let's see if that works for appveyor.