### PR TITLE
Mover version number below logo with 140px padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.16:
+  - Move version number to below logo.
 - 1.4.15:
   - fix not setting `pathToNavigateTo` properly when `launchBrowser` is false and `launchCommand` is set [#1065](https://github.com/FredrikNoren/ungit/issues/1065)
 - 1.4.14:

--- a/components/header/header.less
+++ b/components/header/header.less
@@ -1,4 +1,3 @@
-
 .navbarPadder {
   height: 81px;
 }
@@ -16,7 +15,7 @@
     color: #686868;
     &:hover {
       text-decoration: none;
-      color: #A5A5A5;
+      color: #a5a5a5;
     }
     .glyphicon-arrow-left {
       -webkit-transition: opacity 0.5s ease-in-out;
@@ -76,4 +75,7 @@
 
 .headerLogo {
   width: 15%;
+}
+.version {
+  padding-left: 140px;
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
Just a quickie fix I find this more pleasing to my eyes.

![image](https://user-images.githubusercontent.com/1795016/37803164-a38104e8-2dea-11e8-916c-616e02c51a60.png)
