### PR TITLE
Support alternate git directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -47,7 +47,7 @@ exports.registerApi = (env) => {
             if (!isMac && !isWindows) {
               // recursive fs.watch only works on mac and windows
               const promises = [];
-              const gitDir = gitParser.findGitDir(data.path)
+              const gitDir = gitPromise.findGitDir(data.path)
 
               promises.push(watchPath(socket, path.join(gitDir, 'HEAD')));
               promises.push(watchPath(socket, path.join(gitDir, 'refs', 'heads')));
@@ -559,7 +559,7 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/baserepopath`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const gitDir = gitParser.findGitDir(req.query.path)
+    const gitDir = gitPromise.findGitDir(req.query.path)
 
     jsonResultOrFailProm(res, gitPromise(['rev-parse', '--show-toplevel'], gitDir)
       .then((baseRepoPath) => {
@@ -603,7 +603,7 @@ exports.registerApi = (env) => {
     const task = gitPromise(['submodule', 'deinit', "-f", req.query.submoduleName], req.query.path)
       .then(gitPromise.bind(null, ['rm', '-f', req.query.submoduleName], req.query.path))
       .then(() => {
-        const gitDir = gitParser.findGitDir(req.query.path)
+        const gitDir = gitPromise.findGitDir(req.query.path)
 
         rimraf.sync(path.join(req.query.path, req.query.submodulePath));
         rimraf.sync(path.join(gitDir, 'modules', req.query.submodulePath));

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -47,10 +47,12 @@ exports.registerApi = (env) => {
             if (!isMac && !isWindows) {
               // recursive fs.watch only works on mac and windows
               const promises = [];
-              promises.push(watchPath(socket, path.join('.git', 'HEAD')));
-              promises.push(watchPath(socket, path.join('.git', 'refs', 'heads')));
-              promises.push(watchPath(socket, path.join('.git', 'refs', 'remotes')));
-              promises.push(watchPath(socket, path.join('.git', 'refs', 'tags')));
+              const gitDir = gitParser.findGitDir(data.path)
+
+              promises.push(watchPath(socket, path.join(gitDir, 'HEAD')));
+              promises.push(watchPath(socket, path.join(gitDir, 'refs', 'heads')));
+              promises.push(watchPath(socket, path.join(gitDir, 'refs', 'remotes')));
+              promises.push(watchPath(socket, path.join(gitDir, 'refs', 'tags')));
               return Bluebird.all(promises);
             }
           }).catch((err) => {
@@ -106,12 +108,21 @@ exports.registerApi = (env) => {
       return false;  // ignore files that are in .gitignore
     } else if (filename.endsWith(".lock")) {
       return false;
-    } else if (filename.indexOf(path.join(".git", "refs")) > -1) {
-      return true;   // trigger for all changes under refs
-    } else if (filename == path.join(".git", "HEAD")) {
-      return true;   // Explicitly return true for ".git/HEAD" for branch changes
+    } else if (filename.indexOf(path.join("", "refs")) > -1) {
+      // trigger for all changes under directory named refs
+      // NOTE: This check will catch some other refs directories, but we can't look for .git
+      // in case the git directory has been relocated
+      return true;
+    } else if (filename.endsWith("HEAD")) {
+      // Explicitly return true for ".git/HEAD" for branch changes
+      // NOTE: This check will catch some other HEAD files, but we can't look for .git
+      // in case the git directory has been relocated
+      return true;
     } else if (filename.indexOf(".git") > -1) {
-      return false;  // Ignore other changes under ".git/*"
+      // Ignore other changes under ".git/*"
+      // NOTE: If the git directory has been relocated to a path that doesn't contain
+      // ".git" in the path, then we will end up monitoring it.
+      return false;
     } else {
       return true;
     }
@@ -548,8 +559,9 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/baserepopath`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const currentPath = path.resolve(path.join(req.query.path, '..'));
-    jsonResultOrFailProm(res, gitPromise(['rev-parse', '--show-toplevel'], currentPath)
+    const gitDir = gitParser.findGitDir(req.query.path)
+
+    jsonResultOrFailProm(res, gitPromise(['rev-parse', '--show-toplevel'], gitDir)
       .then((baseRepoPath) => {
         return { path: path.resolve(baseRepoPath.trim()) };
       }).catch((e) => {
@@ -591,8 +603,10 @@ exports.registerApi = (env) => {
     const task = gitPromise(['submodule', 'deinit', "-f", req.query.submoduleName], req.query.path)
       .then(gitPromise.bind(null, ['rm', '-f', req.query.submoduleName], req.query.path))
       .then(() => {
+        const gitDir = gitParser.findGitDir(req.query.path)
+
         rimraf.sync(path.join(req.query.path, req.query.submodulePath));
-        rimraf.sync(path.join(req.query.path, '.git', 'modules', req.query.submodulePath));
+        rimraf.sync(path.join(gitDir, 'modules', req.query.submodulePath));
       });
 
     jsonResultOrFailProm(res, task);

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -108,7 +108,7 @@ exports.registerApi = (env) => {
       return false;  // ignore files that are in .gitignore
     } else if (filename.endsWith(".lock")) {
       return false;
-    } else if (filename.indexOf(path.join("", "refs")) > -1) {
+    } else if (filename.indexOf("refs") > -1) {
       // trigger for all changes under directory named refs
       // NOTE: This check will catch some other refs directories, but we can't look for .git
       // in case the git directory has been relocated

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -337,10 +337,3 @@ exports.parsePatchDiffResult = (patchLineList, text) => {
     return null;
   }
 }
-
-// determine the git directory, always an absolute path
-// TODO: This method does not handle errors, it assumes that repoPath is a valid git repository path
-exports.findGitDir = (repoPath) => {
-  const gitDir = child_process.execSync('git rev-parse --absolute-git-dir', {cwd: repoPath}).toString().trim();
-  return gitDir;
-}

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const fileType = require('./utils/file-type.js');
 const _ = require('lodash')
+const child_process = require('child_process');
 
 exports.parseGitStatus = (text, args) => {
   const lines = text.split('\n');
@@ -335,4 +336,11 @@ exports.parsePatchDiffResult = (patchLineList, text) => {
   } else {
     return null;
   }
+}
+
+// determine the git directory, always an absolute path
+// TODO: This method does not handle errors, it assumes that repoPath is a valid git repository path
+exports.findGitDir = (repoPath) => {
+  const gitDir = child_process.execSync('git rev-parse --absolute-git-dir', {cwd: repoPath}).toString().trim();
+  return gitDir;
 }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -169,8 +169,16 @@ const getGitError = (args, stderr, stdout) => {
   return err;
 }
 
+
+// determine the git directory, always an absolute path
+// TODO: This method does not handle errors, it assumes that repoPath is a valid git repository path
+git.findGitDir = (repoPath) => {
+  const gitDir = child_process.execSync('git rev-parse --absolute-git-dir', {cwd: repoPath}).toString().trim();
+  return gitDir;
+}
+
 git.status = (repoPath, file) => {
-  const gitDir = gitParser.findGitDir(repoPath)
+  const gitDir = git.findGitDir(repoPath)
   return Bluebird.props({
     numStatsStaged: git(['diff', '--no-renames', '--numstat', '--cached', '--', (file || '')], repoPath)
       .then(gitParser.parseGitStatusNumstat),
@@ -305,7 +313,7 @@ git.diffFile = (repoPath, filename, sha1, ignoreWhiteSpace) => {
 }
 
 git.getCurrentBranch = (repoPath) => {
-  const gitDir = gitParser.findGitDir(repoPath)
+  const gitDir = git.findGitDir(repoPath)
   const HEADFile = path.join(gitDir, 'HEAD');
   return fs.isExists(HEADFile).then(isExist => {
     if (!isExist) throw { errorCode: 'not-a-repository', error: `No such file: ${HEADFile}` };


### PR DESCRIPTION
This PR has changes to support a git directory that isn't in the standard location. It leverages the use of `git rev-parse --absolute-git-dir` to do the work of finding the actual git directory.

This fixes FredrikNoren/ungit/#1013.