### PR TITLE
Fix credential helper not fetching all the authentication data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.19:
+  - fix credential helper not fetching all the authentication data [#1078](https://github.com/FredrikNoren/ungit/pull/1078)
 - 1.4.18:
   - fix inaccurate git state issue when new branch name conflict and `autoCheckoutOnBranchCreate` is enabled.
   - Add content refresh on .gitignore file change

--- a/bin/credentials-helper
+++ b/bin/credentials-helper
@@ -13,8 +13,12 @@ if (action == 'get') {
   winston.info('Getting credentials');
   http.get(`http://localhost:${portAndRootPath}/api/credentials?socketId=${socketId}&remote=${encodeURIComponent(remote)}`, (res) => {
     winston.info('Got credentials');
-    res.on('data', (body) => {
-      const data = JSON.parse(body);
+    let rawData = '';
+    res.on('data', chunk => {
+        rawData += chunk;
+    });
+    res.on('end', () => {
+      const data = JSON.parse(rawData);
       console.log(`username=${data.username}`);
       console.log(`password=${data.password ? data.password : ''}`);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
This PR fixes #1076.
The problem was that `JSON.parse` was called before all the chunks are fetched from the server.
Therefore the credential helper was printing username and password that are different from the ones typed
in the popup form.

I think this PR also fixes a problem of syntax error during authentication, reported in #1060.
Honestly speaking I don't know why this bug has not been reported. Everyone should've faced this issue?