### PR TITLE
fix missing jquery and jquery ui references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.22: Fix missing jQuery and jQuery UI references [#1086](https://github.com/FredrikNoren/ungit/issues/1086)
 - 1.4.21: Treat remote fetch fail as an warning rather than error [#1081](https://github.com/FredrikNoren/ungit/issues/1081)
 - 1.4.20:
   - deleted checked in 3rd party codes and manage by npm.

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -1,3 +1,4 @@
+const $ = require('jquery');
 const ko = require('knockout');
 const components = require('ungit-components');
 const Selectable = require('./selectable');
@@ -183,7 +184,6 @@ GitNodeViewModel.prototype.showRefSearchForm = function(obj, event) {
     $(this).autocomplete('search', $(this).val());
   }).data("ui-autocomplete")._renderItem = function (ul, item) {
     return $("<li></li>")
-      .data("item.autocomplete", item)
       .append(`<a>${item.dom}</a>`)
       .appendTo(ul);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -8,6 +8,13 @@ require('../vendor/js/bootstrap/modal');
 require('../vendor/js/bootstrap/dropdown');
 require('../vendor/js/bootstrap/tooltip');
 require('jquery-ui');
+require('jquery-ui/ui/version');
+require('jquery-ui/ui/keycode');
+require('jquery-ui/ui/position');
+require('jquery-ui/ui/safe-active-element');
+require('jquery-ui/ui/unique-id');
+require('jquery-ui/ui/widgets/menu');
+require('jquery-ui/ui/widgets/autocomplete');
 require('./knockout-bindings');
 var components = require('ungit-components');
 var Server = require('./server');
@@ -57,7 +64,11 @@ ko.bindingHandlers.autocomplete = {
           noResults: '',
           results: () => {}
         }
-      });
+      }).data("ui-autocomplete")._renderItem = function (ul, item) {
+        return $("<li></li>")
+          .append($("<a>").text(item.label))
+          .appendTo(ul);
+      };
     }
 
     const handleKeyEvent = (event) => {


### PR DESCRIPTION
fixes #1086

upgrading to `jquery-ui` 1.12 required [some changes to `autocomplete`](https://jqueryui.com/upgrade-guide/1.12/#require-wrappers-for-each-menu-item) and the way to [include the different widgets](https://jqueryui.com/upgrade-guide/1.12/#official-package-on-npm).