### PR TITLE
Add clickable commit link

### DIFF
--- a/components/commit/commit.html
+++ b/components/commit/commit.html
@@ -22,7 +22,12 @@
             +<span data-bind="text: numberOfAddedLines"></span>,
             -<span data-bind="text: numberOfRemovedLines"></span>
              |
-            <span data-bind="text: sha1.substr(0, 8)"></span>
+             <!-- ko if: commitLink() -->
+             <a data-bind="text: sha1.substr(0, 8), attr: { href: commitLink(), target: '_blank' }"></a>
+             <!-- /ko -->
+             <!-- ko ifnot: commitLink() -->
+             <span data-bind="text: sha1.substr(0, 8)"></span>
+             <!-- /ko -->
           </div>
         </div>
       </div>

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -29,6 +29,16 @@ function CommitViewModel(gitNode) {
   this.authorDateFromNow = ko.observable();
   this.authorName = ko.observable();
   this.authorEmail = ko.observable();
+  this.commitLink = ko.computed(function() {
+    var short_sha1 = self.sha1.substr(0, 8);
+    var link_to_commit = ungit.config.linkToCommit[self.repoPath()]
+    if (link_to_commit != undefined) {
+      return ungit.config.linkToCommit[self.repoPath()].replace(/%h/g, short_sha1).replace(/%H/g, self.sha1)
+    }
+    else {
+      return null
+    }
+  });
   this.fileLineDiffs = ko.observable();
   this.numberOfAddedLines = ko.observable();
   this.numberOfRemovedLines = ko.observable();

--- a/source/config.js
+++ b/source/config.js
@@ -151,6 +151,9 @@ const defaultConfig = {
 
   // a string of ip to bind to, default is `127.0.0.1`
   ungitBindIp: '127.0.0.1',
+
+  // example { "/home/projects/ungit" : "https://github.com/FredrikNoren/ungit/commit/%H" } use %H for full commit hash and %h for short commit hash
+  linkToCommit: {},
 };
 
 // Works for now but should be moved to bin/ungit


### PR DESCRIPTION
Fixes #1118 

This PR adds a new config `commitLink` to the `.ungitrc` of the form:

```
{
  "bugtracking": true,
  "sendUsageStatistics": true,
  "socketId": 1,
  "linkToCommit": {
    "/home/ylecuyer/Projects/ungit": "https://github.com/FredrikNoren/ungit/commit/%H"
  }
}
```

`%h` and `%H` are used respectively for short sha1 hash and sha1 hash (as in git format)

If this config is not set the behaviour of ungit doesn't change otherwise the sha1 of the commit component is clickable and link to the interpolated url.

I have an issue with the commit component because links (mailto included) are no clickable and I haven't figured out why.

Todos:
- [x] implementation
- [ ] test
- [ ] update changelog
- [ ] see why links inside commit components are not clickable
- [ ] add doc to README