### PR TITLE
Wrap localStorage to not depend on it

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -279,6 +279,7 @@ module.exports = (grunt) => {
     b.require('./public/source/components.js', { expose: 'ungit-components' });
     b.require('./public/source/program-events.js', { expose: 'ungit-program-events' });
     b.require('./public/source/navigation.js', { expose: 'ungit-navigation' });
+    b.require('./public/source/storage.js', { expose: 'ungit-storage' });
     b.require('./public/source/main.js', { expose: 'ungit-main' });
     b.require('./source/address-parser.js', { expose: 'ungit-address-parser' });
     b.require('knockout', { expose: 'knockout' });
@@ -320,6 +321,7 @@ module.exports = (grunt) => {
         b.external(['ungit-components',
                 'ungit-program-events',
                 'ungit-navigation',
+                'ungit-storage',
                 'ungit-main',
                 'ungit-address-parser',
                 'knockout',

--- a/components/app/app.js
+++ b/components/app/app.js
@@ -3,6 +3,7 @@ const ko = require('knockout');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
 const navigation = require('ungit-navigation');
+const storage = require('ungit-storage');
 
 components.register('app', (args) => {
   return new AppViewModel(args.appContainer, args.server);
@@ -18,33 +19,33 @@ class AppViewModel {
     }
     this.dialog = ko.observable(null);
     this.repoList = ko.observableArray(this.getRepoList()); // visitedRepositories is legacy, remove in the next version
-    this.repoList.subscribe((newValue) => { localStorage.setItem('repositories', JSON.stringify(newValue)); });
+    this.repoList.subscribe((newValue) => { storage.setItem('repositories', JSON.stringify(newValue)); });
     this.content = ko.observable(components.create('home', { app: this }));
     this.currentVersion = ko.observable();
     this.latestVersion = ko.observable();
     this.showNewVersionAvailable = ko.observable();
     this.newVersionInstallCommand = (ungit.platform == 'win32' ? '' : 'sudo -H ') + 'npm update -g ungit';
     this.bugtrackingEnabled = ko.observable(ungit.config.bugtracking);
-    this.bugtrackingNagscreenDismissed = ko.observable(localStorage.getItem('bugtrackingNagscreenDismissed'));
+    this.bugtrackingNagscreenDismissed = ko.observable(storage.getItem('bugtrackingNagscreenDismissed'));
     this.showBugtrackingNagscreen = ko.computed(() => {
       return !this.bugtrackingEnabled() && !this.bugtrackingNagscreenDismissed();
     });
-    this.gitVersionErrorDismissed = ko.observable(localStorage.getItem('gitVersionErrorDismissed'));
+    this.gitVersionErrorDismissed = ko.observable(storage.getItem('gitVersionErrorDismissed'));
     this.gitVersionError = ko.observable();
     this.gitVersionErrorVisible = ko.computed(() => {
       return !ungit.config.gitVersionCheckOverride && this.gitVersionError() && !this.gitVersionErrorDismissed();
     });
 
-    const NPSSurveyLastDismissed = parseInt(localStorage.getItem('NPSSurveyLastDismissed') || '0');
+    const NPSSurveyLastDismissed = parseInt(storage.getItem('NPSSurveyLastDismissed') || '0');
     const monthsSinceNPSLastDismissed = (Date.now() - NPSSurveyLastDismissed) / (1000 * 60 * 60 * 24 * 30);
     this.showNPSSurvey = ko.observable(monthsSinceNPSLastDismissed >= 6 && Math.random() < 0.01);
   }
   getRepoList() {
-    const localStorageRepo = JSON.parse(localStorage.getItem('repositories') || localStorage.getItem('visitedRepositories') || '[]');
+    const localStorageRepo = JSON.parse(storage.getItem('repositories') || storage.getItem('visitedRepositories') || '[]');
     const newRepos = localStorageRepo.concat(ungit.config.defaultRepositories || [])
       .filter((v, i, a) => a.indexOf(v) === i)
       .sort();
-    localStorage.setItem('repositories', JSON.stringify(newRepos));
+    storage.setItem('repositories', JSON.stringify(newRepos));
     return newRepos;
   }
   sendNPS(value) {
@@ -137,16 +138,16 @@ class AppViewModel {
     this.gitSetUserConfig(true);
   }
   dismissBugtrackingNagscreen() {
-    localStorage.setItem('bugtrackingNagscreenDismissed', true);
+    storage.setItem('bugtrackingNagscreenDismissed', true);
     this.bugtrackingNagscreenDismissed(true);
   }
   dismissGitVersionError() {
-    localStorage.setItem('gitVersionErrorDismissed', true);
+    storage.setItem('gitVersionErrorDismissed', true);
     this.gitVersionErrorDismissed(true);
   }
   dismissNPSSurvey() {
     this.showNPSSurvey(false);
-    localStorage.setItem('NPSSurveyLastDismissed', Date.now());
+    storage.setItem('NPSSurveyLastDismissed', Date.now());
   }
   dismissNewVersion() {
     this.showNewVersionAvailable(false);

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -2,6 +2,7 @@ const ko = require('knockout');
 const _ = require('lodash');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
+const storage = require('ungit-storage');
 const showRemote = 'showRemote';
 const showBranch = 'showBranch';
 const showTag = 'showTag';
@@ -17,12 +18,12 @@ class BranchesViewModel {
     this.server = server;
     this.branchesAndLocalTags = ko.observableArray();
     this.current = ko.observable();
-    this.isShowRemote = ko.observable(localStorage.getItem(showRemote) != 'false');
-    this.isShowBranch = ko.observable(localStorage.getItem(showBranch) != 'false');
-    this.isShowTag = ko.observable(localStorage.getItem(showTag) != 'false');
+    this.isShowRemote = ko.observable(storage.getItem(showRemote) != 'false');
+    this.isShowBranch = ko.observable(storage.getItem(showBranch) != 'false');
+    this.isShowTag = ko.observable(storage.getItem(showTag) != 'false');
     this.graph = graph;
     const setLocalStorageAndUpdate = (localStorageKey, value) => {
-      localStorage.setItem(localStorageKey, value);
+      storage.setItem(localStorageKey, value);
       this.updateRefs();
       return value;
     }

--- a/components/stash/stash.js
+++ b/components/stash/stash.js
@@ -2,6 +2,7 @@
 var ko = require('knockout');
 var moment = require('moment');
 var components = require('ungit-components');
+var storage = require('ungit-storage');
 
 components.register('stash', function(args) {
   return new StashViewModel(args.server, args.repoPath);
@@ -48,7 +49,7 @@ function StashViewModel(server, repoPath) {
   this.server = server;
   this.repoPath = repoPath;
   this.stashedChanges = ko.observable([]);
-  this.isShow = ko.observable(localStorage['showStash'] === 'true');
+  this.isShow = ko.observable(storage.getItem('showStash') === 'true');
   this.visible = ko.computed(function() { return self.stashedChanges().length > 0 && self.isShow(); });
   this.refresh();
 }
@@ -84,5 +85,5 @@ StashViewModel.prototype.refresh = function() {
 }
 StashViewModel.prototype.toggleShowStash = function() {
   this.isShow(!this.isShow());
-  localStorage['showStash'] = this.isShow();
+  storage.setItem('showStash', this.isShow());
 }

--- a/nmclicktests/spec.stash.js
+++ b/nmclicktests/spec.stash.js
@@ -19,7 +19,7 @@ describe('[STASH]', () => {
       .ug.click('.stash-all')
       .visible('.stash-toggle')
       .then((isVisible) => {
-        // if stash is currently collapsed show it. (localStorage['showStash'] might already be 'true')
+        // if stash is currently collapsed show it. (storage['showStash'] might already be 'true')
         return (isVisible ? environment.nm.click('.stash-toggle') : environment.nm)
           .wait('.stash .list-group-item')
       });

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -13,6 +13,7 @@ var components = require('ungit-components');
 var Server = require('./server');
 var programEvents = require('ungit-program-events');
 var navigation = require('ungit-navigation');
+var storage = require('ungit-storage');
 
 // Request animation frame polyfill
 (function() {
@@ -83,9 +84,9 @@ ko.bindingHandlers.autocomplete = {
         // enter key is struck, navigate to the path
         event.preventDefault();
         navigation.browseTo(`repository?path=${encodeURIComponent(value)}`);
-      } else if (value === '' && localStorage && localStorage.repositories) {
+      } else if (value === '' && storage.getItem('repositories')) {
         // if path is emptied out, show save path options
-        const folderNames = JSON.parse(localStorage.repositories).map((value) => {
+        const folderNames = JSON.parse(storage.getItem('repositories')).map((value) => {
           return {
             value: value,
             label: value.substring(value.lastIndexOf(ungit.config.fileSeparator) + 1)

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -83,7 +83,7 @@ ko.bindingHandlers.autocomplete = {
         // enter key is struck, navigate to the path
         event.preventDefault();
         navigation.browseTo(`repository?path=${encodeURIComponent(value)}`);
-      } else if (value === '' && localStorage.repositories) {
+      } else if (value === '' && localStorage && localStorage.repositories) {
         // if path is emptied out, show save path options
         const folderNames = JSON.parse(localStorage.repositories).map((value) => {
           return {

--- a/public/source/storage.js
+++ b/public/source/storage.js
@@ -1,0 +1,34 @@
+/**
+ * A wrapper aroung LocalStorage to support environments where LocalStorage is not available.
+ * Stores and retrieves items from LocalStorage if available and uses a non-persistent cache otherwise.
+ */
+var storage = {};
+module.exports = storage;
+
+storage.cache = {};
+
+/**
+ * The getItem() method of the Storage interface, when passed a key name, will return that key's value or null if the key does not exist.
+ * @param {string} key A DOMString containing the name of the key you want to retrieve the value of.
+ * @returns {string | null} A DOMString containing the value of the key. If the key does not exist, null is returned.
+ */
+storage.getItem = function (key) {
+    if (localStorage) {
+        return localStorage.getItem(key);
+    } else {
+        return this.cache[key] || null;
+    }
+};
+
+/**
+ * The setItem() method of the Storage interface, when passed a key name and value, will add that key to the storage, or update that key's value if it already exists.
+ * @param {string} key A DOMString containing the name of the key you want to create/update.
+ * @param {string} value A DOMString containing the value you want to give the key you are creating/updating.
+ */
+storage.setItem = function (key, value) {
+    if (localStorage) {
+        localStorage.setItem(key, value);
+    } else {
+        this.cache[key] = value;
+    }
+};

--- a/public/source/storage.js
+++ b/public/source/storage.js
@@ -1,34 +1,17 @@
 /**
- * A wrapper aroung LocalStorage to support environments where LocalStorage is not available.
+ * A wrapper around LocalStorage to support environments where LocalStorage is not available.
  * Stores and retrieves items from LocalStorage if available and uses a non-persistent cache otherwise.
  */
 var storage = {};
-module.exports = storage;
+try {
+    storage.getItem = localStorage.getItem;
+    storage.setItem = localStorage.setItem;
+} catch (e) { /* Ignore Exception, use fallback implementation. */ }
 
-storage.cache = {};
+if (!storage) {
+    var cache = Object.create(null);
+    storage.getItem = function (key) { return cache[key] || null; };
+    storage.setItem = function (key, value) { cache[key] = value; };
+}
 
-/**
- * The getItem() method of the Storage interface, when passed a key name, will return that key's value or null if the key does not exist.
- * @param {string} key A DOMString containing the name of the key you want to retrieve the value of.
- * @returns {string | null} A DOMString containing the value of the key. If the key does not exist, null is returned.
- */
-storage.getItem = function (key) {
-    if (localStorage) {
-        return localStorage.getItem(key);
-    } else {
-        return this.cache[key] || null;
-    }
-};
-
-/**
- * The setItem() method of the Storage interface, when passed a key name and value, will add that key to the storage, or update that key's value if it already exists.
- * @param {string} key A DOMString containing the name of the key you want to create/update.
- * @param {string} value A DOMString containing the value you want to give the key you are creating/updating.
- */
-storage.setItem = function (key, value) {
-    if (localStorage) {
-        localStorage.setItem(key, value);
-    } else {
-        this.cache[key] = value;
-    }
-};
+module.export = storage;

--- a/public/source/storage.js
+++ b/public/source/storage.js
@@ -2,16 +2,20 @@
  * A wrapper around LocalStorage to support environments where LocalStorage is not available.
  * Stores and retrieves items from LocalStorage if available and uses a non-persistent cache otherwise.
  */
-var storage = {};
+var storage;
 try {
-    storage.getItem = localStorage.getItem;
-    storage.setItem = localStorage.setItem;
+    storage = {
+        getItem: localStorage.getItem.bind(localStorage),
+        setItem: localStorage.setItem.bind(localStorage),
+    };
 } catch (e) { /* Ignore Exception, use fallback implementation. */ }
 
 if (!storage) {
     var cache = Object.create(null);
-    storage.getItem = function (key) { return cache[key] || null; };
-    storage.setItem = function (key, value) { cache[key] = value; };
+    storage = {
+        getItem: function (key) { return cache[key] || null; },
+        setItem: function (key, value) { cache[key] = value; },
+    };
 }
 
-module.export = storage;
+module.exports = storage;


### PR DESCRIPTION
This change wraps usages of localStorage with a custom storage object so that ungit still works in environments where localStorage is not available. It is not an ideal solution and does not provide the same features as actual localStorage, but is intended to not break.

Background: I am trying to update the [VSCode Ungit extension](https://github.com/Hirse/vscode-ungit) to use the new, better [VSCode WebView API](https://code.visualstudio.com/docs/extensions/webview), but am blocked due to the [missing localStorage support](https://github.com/Microsoft/vscode/issues/52246).