### PR TITLE
Ensure addition of remote tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.34: fix issues when remote tags doesn't show [#1139](https://github.com/FredrikNoren/ungit/issues/1139)
 - 1.4.33:
   - Bump getmac version [#1130](https://github.com/FredrikNoren/ungit/issues/1130)
   - Add config to disable animation [#1136](https://github.com/FredrikNoren/ungit/issues/1136)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.32",
+  "version": "1.4.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.32",
+  "version": "1.4.34",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
fix: #1139 

Ensure all remote tags are added to ungit, even when they don't have the deref tags.  

(which I'm still not sure how it was induced)