### PR TITLE
Use glyphicon for commit amend checkbox

### DIFF
--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -14,12 +14,12 @@
         <input class="form-control" type="text" placeholder="Title (required)" data-bind="value: commitMessageTitle, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onEnter}"></input>
         <textarea class="form-control" rows="2" placeholder="Body" data-bind="value: commitMessageBody, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onAltEnter}"></textarea>
         <div>
-          <span class="amend" data-bind="visible: canAmend">
-            <div class="checkmark" data-bind="click: toggleAmend, css: { checked: amend }">
+          <button class="amend-button btn btn-link" data-bind="visible: canAmend, click: toggleAmend">
+            <div class="checkmark" data-bind="css: { checked: amend }">
               <span class="glyphicon" data-bind="css: { 'glyphicon-check': amend, 'glyphicon-unchecked': !amend() }"></span>
             </div>
-            <a class="amend-link" href="#" data-bind="click: toggleAmend">Amend last commit</a>
-          </span>
+            <span>Amend last commit</span>
+          </button>
           <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>
         </div>
         <div class="btn-group commit-grp" data-bind="visible: isStageValid">

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -15,7 +15,9 @@
         <textarea class="form-control" rows="2" placeholder="Body" data-bind="value: commitMessageBody, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onAltEnter}"></textarea>
         <div>
           <span class="amend" data-bind="visible: canAmend">
-            <span class="checkmark" data-bind="css: { checked: amend }">&#10003;</span>
+            <div class="checkmark" data-bind="click: toggleAmend, css: { checked: amend }">
+              <span class="glyphicon" data-bind="css: { 'glyphicon-check': amend, 'glyphicon-unchecked': !amend() }"></span>
+            </div>
             <a class="amend-link" href="#" data-bind="click: toggleAmend">Amend last commit</a>
           </span>
           <span class="commit-message-title-counter" data-bind="text: commitMessageTitleCount"/>

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -234,6 +234,14 @@
   position: absolute;
 }
 
+.amend-button {
+  padding: 0;
+  &:active,
+  &:focus,
+  &:hover {
+    text-decoration: none;
+  }
+}
 
 .checkmark {
   color: #fff;

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -138,6 +138,11 @@
           border-bottom-right-radius: 0px;
         }
       }
+      .checkmark {
+        span {
+          top: 5px;
+        }
+      }
       .name {
         background: transparent;
         font-size: 1.3em;
@@ -237,8 +242,5 @@
   cursor: pointer;
   &.checked {
     opacity: 0.8;
-  }
-  span {
-    top: 5px;
   }
 }


### PR DESCRIPTION
Using the glyphicons makes it easier to see the state of the checkbox.

![2018-10-25_16-32-47](https://user-images.githubusercontent.com/2564094/47537967-965d2b00-d87d-11e8-9793-e269d5dd5e13.png)
![2018-10-25_16-33-04](https://user-images.githubusercontent.com/2564094/47537968-978e5800-d87d-11e8-9479-5e4c14948e4c.png)
