### PR TITLE
Fix branch search box

### DIFF
--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -173,7 +173,7 @@ class GitNodeViewModel extends Animateable {
     $(textBox).autocomplete({
       source: this.refs().filter(ref => !ref.isHEAD),
       minLength: 0,
-      select(event, ui) {
+      select: (event, ui) => {
         const ref = ui.item;
         const ray = ref.isTag ? this.tagsToDisplay : this.branchesToDisplay;
 


### PR DESCRIPTION
Selection from the branch search autocomplete fails because `this` is set to the jQuery object, not the class instance:
![2018-10-25_17-50-49](https://user-images.githubusercontent.com/2564094/47538140-afb2a700-d87e-11e8-87f6-90c3b1b725b1.png)

