### PR TITLE
fix changing remotes in remotes dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
-- 1.4.36: fix changing remotes in remotes dropdown
+- 1.4.36: fix changing remotes in remotes dropdown [#1158](https://github.com/FredrikNoren/ungit/pull/1158)
 - 1.4.35:
   - allow disabling of nprogress bar [#1143](https://github.com/FredrikNoren/ungit/issues/1143)
   - set `ungitVersionCheckOverride` as boolean in config [#1102](https://github.com/FredrikNoren/ungit/issues/1102)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.36: fix changing remotes in remotes dropdown
 - 1.4.35:
   - allow disabling of nprogress bar [#1143](https://github.com/FredrikNoren/ungit/issues/1143)
   - set `ungitVersionCheckOverride` as boolean in config [#1102](https://github.com/FredrikNoren/ungit/issues/1102)

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -92,7 +92,6 @@ class RemotesViewModel {
   updateRemotes() {
     return this.server.getPromise('/remotes', { path: this.repoPath() })
       .then(remotes => {
-        const outerThis = this;
         remotes = remotes.map(remote => ({
           name: remote,
           changeRemote: () => { this.currentRemote(remote) }

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -95,7 +95,7 @@ class RemotesViewModel {
         const outerThis = this;
         remotes = remotes.map(remote => ({
           name: remote,
-          changeRemote() { outerThis.currentRemote(remote) }
+          changeRemote: () => { this.currentRemote(remote) }
         }));
         this.remotes(remotes);
         if (!this.currentRemote() && remotes.length > 0) {

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -92,9 +92,10 @@ class RemotesViewModel {
   updateRemotes() {
     return this.server.getPromise('/remotes', { path: this.repoPath() })
       .then(remotes => {
+        const outerThis = this;
         remotes = remotes.map(remote => ({
           name: remote,
-          changeRemote() { this.currentRemote(remote) }
+          changeRemote() { outerThis.currentRemote(remote) }
         }));
         this.remotes(remotes);
         if (!this.currentRemote() && remotes.length > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
When changing remotes using the dropdown in ungit 1.4.35, the following error occurs:

Firefox 64
```
TypeError: this.currentRemote is not a function[Learn More] remotes.js:97
    changeRemote remotes.js:97
    init/</< knockout:99
    dispatch jquery:5182
    add/elemData.handle jquery:4991
```

Chrome 69
```
Uncaught TypeError: this.currentRemote is not a function
    at Object.changeRemote (remotes.js:97)
    at HTMLAnchorElement.<anonymous> (knockout:99)
    at HTMLAnchorElement.dispatch (jquery:5183)
    at HTMLAnchorElement.elemData.handle (jquery:4991)
```

This issue prevents the user from changing remotes.
