### PR TITLE
fixing broken git icons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,8 @@
 	<link rel="shortcut icon" href="__ROOT_PATH__/favicon.ico" >
 	<link rel="shortcut icon" href="/images/icon.png" >
 	<title>ungit</title>
+	<!-- these are broken even in google official datalab tutorial! -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css">
 </head>
 <body>
 


### PR DESCRIPTION
fixing broken git icons, which occurs when ungit is served from proxy with url rewrite (like datalab does).

#1190 is what I'm trying to address here!