### PR TITLE
force LC_ALL=C when running git

### DIFF
--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -39,7 +39,9 @@ const gitExecutorProm = (args, retryCount) => {
       let isCompleted = false;
       let stdout = '';
       let stderr = '';
-      const procOpts = { cwd: args.repoPath, maxBuffer: 1024 * 1024 * 100, detached: false }
+      let env = JSON.parse(JSON.stringify(process.env));
+      env['LC_ALL'] = 'C'
+      const procOpts = { cwd: args.repoPath, maxBuffer: 1024 * 1024 * 100, detached: false, env: env }
       const gitProcess = child_process.spawn(gitBin, args.commands, procOpts);
       if (args.timeout) {
         setTimeout(() => {


### PR DESCRIPTION
Ungit parses git output expecting english.

My default locales configuration is not english so I get a lot of warnings, e.g. when moving a branch.

This PR forces LC_ALL=C before running git commands so the output is always in english.