### PR TITLE
Prevent diff linenumber selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.47: make diff2html line numbers and +/- prefixes unnselectable [#1214](https://github.com/FredrikNoren/ungit/issues/1214), [#1215](https://github.com/FredrikNoren/ungit/pull/1215)
 - 1.4.46: force git out put to be in English within ungit [#1208](https://github.com/FredrikNoren/ungit/pull/1208)
 - 1.4.45: Improve styling of .gitignore edit dialog
 - 1.4.44: add config to disable numstat in staged diff to better performance [#1193](https://github.com/FredrikNoren/ungit/issues/1193)

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -192,7 +192,7 @@ class TextDiffViewModel {
     if (isActive) {
       this.numberOfSelectedPatchLines++;
     }
-    return `<div class="d2h-code-line-prefix"><span data-bind="visible: editState() !== 'patched'">${symbol}</span><input ${isActive ? 'checked' : ''} type="checkbox" data-bind="visible: editState() === 'patched', click: togglePatchLine.bind($data, ${index})"></input>`;
+    return `<div class="d2h-code-line-prefix"><span data-bind="visible: editState() !== 'patched'">${symbol}</span><input ${isActive ? 'checked' : ''} type="checkbox" data-bind="visible: editState() === 'patched', click: togglePatchLine.bind($data, ${index})"></input></div>`;
   }
 
   togglePatchLine(index) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.46",
+  "version": "1.4.47",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.46",
+  "version": "1.4.47",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -173,6 +173,7 @@
   text-overflow: ellipsis;
   border-left: 1px solid rgba(0, 0, 0, 0.34);
   border-right: 1px solid rgba(0, 0, 0, 0.34);
+  user-select: none;
 }
 
 .d2h-del {

--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -119,6 +119,7 @@
 .d2h-code-line-prefix {
   display: inline-flex;
   margin-right: 10px;
+  user-select: none;
 }
 
 .line-num1 {
@@ -150,6 +151,7 @@
   text-overflow: ellipsis;
   border-left: 1px solid rgba(0, 0, 0, 0.34);
   border-right: 1px solid rgba(0, 0, 0, 0.34);
+  user-select: none;
 }
 
 .d2h-cntx {

--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -119,6 +119,9 @@
 .d2h-code-line-prefix {
   display: inline-flex;
   margin-right: 10px;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -151,6 +154,9 @@
   text-overflow: ellipsis;
   border-left: 1px solid rgba(0, 0, 0, 0.34);
   border-right: 1px solid rgba(0, 0, 0, 0.34);
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -173,6 +179,9 @@
   text-overflow: ellipsis;
   border-left: 1px solid rgba(0, 0, 0, 0.34);
   border-right: 1px solid rgba(0, 0, 0, 0.34);
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 


### PR DESCRIPTION
Applies `user-select: none;` to `.d2h-code-line-prefix` and `.d2h-code-linenumber` classes.  This allows selection text from diffs for copy and paste without getting line numbers and +/- prefixes.

Closes #1214 