### PR TITLE
Ensure bin/ungit to bind to 127.0.0.1

### DIFF
--- a/bin/ungit
+++ b/bin/ungit
@@ -84,7 +84,7 @@ const launch = () => {
   child.stderr.on('data', (data) => console.log(`stderr: ${data.toString().trim()}`))
 }
 
-server.listen(config.port, (err) => {
+server.listen(config.port, config.ungitBindIp, (err) => {
   server.close(launch);
 });
 server.on('error', (e) => {


### PR DESCRIPTION
bin/ungit script didn't use config.ungitBindIp like sources/server.js.

On Mac OS, when I type `ungit` command in one terminal, it starts the server and open browser window.
But when I type again in other terminal, it fails with error:
`Error: listen EADDRINUSE: address already in use 127.0.0.1:8449`

lsof shows that server is running on localhost: `TCP localhost:8449 (LISTEN)`