### PR TITLE
Fix the width value of the header logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- 1.4.48: fix the width value of the header logo [#1221](https://github.com/FredrikNoren/ungit/pull/1221)
 - 1.4.47: make diff2html line numbers and +/- prefixes unnselectable [#1214](https://github.com/FredrikNoren/ungit/issues/1214), [#1215](https://github.com/FredrikNoren/ungit/pull/1215)
 - 1.4.46: force git out put to be in English within ungit [#1208](https://github.com/FredrikNoren/ungit/pull/1208)
 - 1.4.45: Improve styling of .gitignore edit dialog

--- a/components/header/header.less
+++ b/components/header/header.less
@@ -74,7 +74,8 @@
 }
 
 .headerLogo {
-  width: 15%;
+  width: 100px;
+  height: auto;
 }
 .version {
   padding-left: 140px;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.4.47",
+  "version": "1.4.48",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
This PR fixes the header logo width to a constant value.

The width value of the logo image is `15%` now, and it extends the width value of the parent anchor tag (which navigates to the homepage) too big. Eventually, the transparent clickable area is created. 

![AS-IS](https://user-images.githubusercontent.com/6410412/66704413-c8012780-ed56-11e9-8eb0-8be564a542b9.gif)

I fixed the width to 100px to limit the clickable area to the displayed image.

![TO-BE](https://user-images.githubusercontent.com/6410412/66704455-11ea0d80-ed57-11e9-8c5a-b1ec7a3d942d.gif)