### PR TITLE
Update and Use Latest Octicons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
 
+- Unreleased:
+  - Updated Octicons
 - 1.4.48: fix the width value of the header logo [#1221](https://github.com/FredrikNoren/ungit/pull/1221)
-- 1.4.47: make diff2html line numbers and +/- prefixes unnselectable [#1214](https://github.com/FredrikNoren/ungit/issues/1214), [#1215](https://github.com/FredrikNoren/ungit/pull/1215)
+- 1.4.47: make diff2html line numbers and +/- prefixes unselectable [#1214](https://github.com/FredrikNoren/ungit/issues/1214), [#1215](https://github.com/FredrikNoren/ungit/pull/1215)
 - 1.4.46: force git out put to be in English within ungit [#1208](https://github.com/FredrikNoren/ungit/pull/1208)
-- 1.4.45: Improve styling of .gitignore edit dialog
+- 1.4.45: Improve styling of .gitignore edit dialog [#1205](https://github.com/FredrikNoren/ungit/pull/1205)
 - 1.4.44: add config to disable numstat in staged diff to better performance [#1193](https://github.com/FredrikNoren/ungit/issues/1193)
 - 1.4.43:
-  - fix gitignore manual edit not being saved [644](https://github.com/FredrikNoren/ungit/issues/644)
+  - fix gitignore manual edit not being saved [#644](https://github.com/FredrikNoren/ungit/issues/644)
   - fix issue with detached git processes on some OS and timeout not being enforced.
   - simplify `maxSearchIteration` enforcement for git.log()
   - change `alwaysLoadActiveBranch` boolean config to `maxActiveBranchSearchIteration` numeric config
@@ -38,13 +40,13 @@ Use the following format for additions: ` - VERSION: [feature/patch (if applicab
 - 1.4.29:
   - Add `--no-optional-locks` if git version is appropriate [#1105](https://github.com/FredrikNoren/ungit/issues/1105)
   - Ensure ungit server to bind to `127.0.0.1` [#988](https://github.com/FredrikNoren/ungit/issues/988)
-  - Add node highlight on mouse hover on relationsip path [#1093](https://github.com/FredrikNoren/ungit/issues/1093)
+  - Add node highlight on mouse hover on relationship path [#1093](https://github.com/FredrikNoren/ungit/issues/1093)
 - 1.4.28: adding raven locally for offline access. [#1107](https://github.com/FredrikNoren/ungit/pull/1107)
 - 1.4.27: logic change for the merge conflict resolution
 - 1.4.26: add a way to preconfigure repo lists [#1106](https://github.com/FredrikNoren/ungit/issues/1106)
 - 1.4.25: add git pgp signing docs and code [#740](https://github.com/FredrikNoren/ungit/issues/740)
 - 1.4.24:
-  - change `/api/log` -> `/api/gitlog` as soem ad blockers really hates This
+  - change `/api/log` -> `/api/gitlog` as some ad blockers really hates This
   - Fix excessive error messaging when disconnected from internet
   - Fix Raven initialization error when disconnected from internet
 - 1.4.23:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,9 +12,9 @@ const maxConcurrency = 5;
 module.exports = (grunt) => {
   const packageJson = grunt.file.readJSON('package.json');
   const lessFiles = {
-    "public/css/styles.css": ["public/less/styles.less", "public/vendor/css/animate.css", "public/less/d2h.less"]
-  }
-  fs.readdirSync("./components").map((component) => `components/${component}/${component}`)
+    'public/css/styles.css': ['public/less/styles.less', 'public/vendor/css/animate.css', 'public/less/d2h.less']
+  };
+  fs.readdirSync('./components').map((component) => `components/${component}/${component}`)
     .forEach((str) => lessFiles[`${str}.css`] = `${str}.less`);
 
   grunt.initConfig({
@@ -104,10 +104,10 @@ module.exports = (grunt) => {
     imageEmbed: {
       default: {
         files: {
-          "public/css/styles.css": [ "public/css/styles.css" ],
-          "components/graph/graph.css": ["components/graph/graph.css"],
-          "components/header/header.css": ["components/header/header.css"],
-          "components/staging/staging.css": ["components/staging/staging.css"],
+          'public/css/styles.css': [ 'public/css/styles.css' ],
+          'components/graph/graph.css': ['components/graph/graph.css'],
+          'components/header/header.css': ['components/header/header.css'],
+          'components/staging/staging.css': ['components/staging/staging.css'],
         },
         options: {
           deleteAfterEncoding: false
@@ -184,8 +184,6 @@ module.exports = (grunt) => {
       main: {
         files: [
           // includes files within path
-          { expand: true, flatten: true, src: ['node_modules/octicons/octicons/octicons.ttf'], dest: 'public/css/' },
-          { expand: true, flatten: true, src: ['node_modules/octicons/octicons/octicons.woff'], dest: 'public/css/' },
           { expand: true, flatten: true, src: ['node_modules/nprogress/nprogress.css'], dest: 'public/css/' },
           { expand: true, flatten: true, src: ['node_modules/jquery-ui-bundle/jquery-ui.min.css'], dest: 'public/css/'},
           { expand: true, flatten: true, src: ['node_modules/raven-js/dist/raven.min.js'], dest: 'public/js/' }
@@ -300,6 +298,7 @@ module.exports = (grunt) => {
     b.require('nprogress', { expose: 'nprogress' });
     b.require('jquery', { expose: 'jquery' });
     b.require('dnd-page-scroll', { expose: 'dnd-page-scroll' });
+    b.require('@primer/octicons', { expose: 'octicons' });
     const outFile = fs.createWriteStream('./public/js/ungit.js');
     outFile.on('close', () => done());
     b.bundle().pipe(outFile);
@@ -341,7 +340,7 @@ module.exports = (grunt) => {
 
   const bumpDependency = (packageJson, packageName) => {
     return new Bluebird((resolve, reject) => {
-      const dependencyType = packageJson['dependencies'][packageName] ? 'dependencies' : 'devDependencies'
+      const dependencyType = packageJson['dependencies'][packageName] ? 'dependencies' : 'devDependencies';
       let currentVersion = packageJson[dependencyType][packageName];
       if (currentVersion[0] == '~' || currentVersion[0] == '^') currentVersion = currentVersion.slice(1);
       npm.commands.show([packageName, 'versions'], true, (err, data) => {
@@ -356,24 +355,24 @@ module.exports = (grunt) => {
         resolve();
       });
     });
-  }
+  };
 
   const updatePackageJsonBuildVersion = (commitHash) => {
     const packageJson = JSON.parse(fs.readFileSync('package.json'));
     packageJson.version += `+${commitHash}`;
     fs.writeFileSync('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);
-  }
+  };
   grunt.registerTask('travisnpmpublish', 'Automatically publish to NPM via travis.', function() {
     const done = this.async();
     if (process.env.TRAVIS_BRANCH != 'master' || (process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST != 'false')) {
       console.log('Skipping travis npm publish');
       return done();
     }
-    childProcess.exec("git rev-parse --short HEAD", (err, stdout, stderr) => {
+    childProcess.exec('git rev-parse --short HEAD', (err, stdout, stderr) => {
       const hash = stdout.trim();
       updatePackageJsonBuildVersion(hash);
       fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_authToken=' + process.env.NPM_TOKEN);
-      childProcess.exec("npm publish", (err) => { done(err); });
+      childProcess.exec('npm publish', (err) => { done(err); });
     });
   });
 
@@ -388,9 +387,9 @@ module.exports = (grunt) => {
     const done = this.async();
 
     fs.readdirAsync('./nmclicktests')
-      .then((files) => files.filter((file) => file.startsWith("spec.")))
+      .then((files) => files.filter((file) => file.startsWith('spec.')))
       .then((tests) => {
-        const genericIndx = tests.indexOf("spec.generic.js")
+        const genericIndx = tests.indexOf('spec.generic.js');
         if (genericIndx > -1) {
           tests.splice(0, 0, tests.splice(genericIndx, 1)[0]);
         }
@@ -398,8 +397,8 @@ module.exports = (grunt) => {
       }).then((tests) => {
         grunt.log.writeln('Running click tests in parallel... (this will take a while...)');
         return Bluebird.map(tests, (file) => {
-          let output = "";
-          const outStream = (data) => output += data
+          let output = '';
+          const outStream = (data) => output += data;
 
           grunt.log.writeln(cliColor.set(`Clicktest started! \t${file}`, 'blue'));
           return new Bluebird((resolve, reject) => {
@@ -422,9 +421,9 @@ module.exports = (grunt) => {
         let isSuccess = true;
         results.forEach((result) => {
           if (!result.isSuccess) {
-            grunt.log.writeln(`---- start of ${result.name} log ----`)
+            grunt.log.writeln(`---- start of ${result.name} log ----`);
             grunt.log.writeln(result.output);
-            grunt.log.writeln(`----- end of ${result.name} log -----`)
+            grunt.log.writeln(`----- end of ${result.name} log -----`);
             isSuccess = false;
           }
         });
@@ -437,15 +436,13 @@ module.exports = (grunt) => {
     grunt.log.writeln('Bumping dependencies...');
     npm.load(() => {
       const tempPackageJson = JSON.parse(JSON.stringify(packageJson));
-      const keys = Object.keys(tempPackageJson.dependencies).concat(Object.keys(tempPackageJson.devDependencies))
+      const keys = Object.keys(tempPackageJson.dependencies).concat(Object.keys(tempPackageJson.devDependencies));
 
       const bumps = Bluebird.map(keys, (dep) => {
         // winston 3.x has different API
         if (dep == 'winston') return;
         // babel 7.x.x has alot of changes.... :(
         if (dep.indexOf('babel') > -1) return;
-        // Octicon moved to SCSS instead of less
-        if (dep == 'octicons') return;
 
         return bumpDependency(tempPackageJson, dep);
       });

--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -1,6 +1,6 @@
 <div class="btn-group branch">
   <button type="button" class="btn btn-default btn-main" data-bind="click: updateRefs">
-    <span class="octicon octicon-git-branch"></span>
+    <span data-bind="html: branchIcon"></span>
     <span data-bind="text: fetchLabel"></span>
   </button>
   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
@@ -24,8 +24,8 @@
     <div class="dropdown-divider"></div>
     <!-- ko foreach: branchesAndLocalTags -->
     <li>
-      <a href="#" data-bind="html: displayName, click: $parent.checkoutBranch.bind($parent), attr: { 'data-ta-clickable': 'checkout' + name }"></a>
-      <a href="#" class="list-link list-remove octicon octicon-x" data-bind="click: $parent.branchRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
+      <a href="#" data-bind="html: displayHtml(), click: $parent.checkoutBranch.bind($parent), attr: { 'data-ta-clickable': 'checkout' + name }"></a>
+      <a href="#" class="list-link list-remove" data-bind="html: $parent.closeIcon, click: $parent.branchRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
     </li>
     <!-- /ko -->
   </ul>

--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -9,23 +9,23 @@
   <ul class="dropdown-menu pull-right" role="menu">
     <div class="option" onclick="event.stopPropagation()">
       <label>
+        <input class="glyphicon" type="checkbox" data-bind="checked: isShowRemote, css: { 'glyphicon-check': isShowRemote, 'glyphicon-unchecked': !isShowRemote() }" />
         Remote
-        <input type="checkbox" data-bind="checked: isShowRemote"/>
       </label>
       <label>
+        <input class="glyphicon" type="checkbox" data-bind="checked: isShowBranch, css: { 'glyphicon-check': isShowBranch, 'glyphicon-unchecked': !isShowBranch() }" />
         Branch
-        <input type="checkbox" data-bind="checked: isShowBranch"/>
       </label>
       <label>
+        <input class="glyphicon" type="checkbox" data-bind="checked: isShowTag, css: { 'glyphicon-check': isShowTag, 'glyphicon-unchecked': !isShowTag() }" />
         Tag
-        <input type="checkbox" data-bind="checked: isShowTag"/>
       </label>
     </div>
     <div class="dropdown-divider"></div>
     <!-- ko foreach: branchesAndLocalTags -->
     <li>
       <a href="#" data-bind="html: displayName, click: $parent.checkoutBranch.bind($parent), attr: { 'data-ta-clickable': 'checkout' + name }"></a>
-      <a href="#" class="list-link list-remove" data-bind="click: $parent.branchRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }">X</a>
+      <a href="#" class="list-link list-remove octicon octicon-x" data-bind="click: $parent.branchRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
     </li>
     <!-- /ko -->
   </ul>

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -1,12 +1,12 @@
 const ko = require('knockout');
 const _ = require('lodash');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
 const storage = require('ungit-storage');
 const showRemote = 'showRemote';
 const showBranch = 'showBranch';
 const showTag = 'showTag';
-const Bluebird = require('bluebird');
 
 components.register('branches', (args) => {
   return new BranchesViewModel(args.server, args.graph, args.repoPath);
@@ -26,7 +26,7 @@ class BranchesViewModel {
       storage.setItem(localStorageKey, value);
       this.updateRefs();
       return value;
-    }
+    };
     this.isShowRemote.subscribe(setLocalStorageAndUpdate.bind(null, showRemote));
     this.isShowBranch.subscribe(setLocalStorageAndUpdate.bind(null, showBranch));
     this.isShowTag.subscribe(setLocalStorageAndUpdate.bind(null, showTag));
@@ -35,6 +35,8 @@ class BranchesViewModel {
         return this.current();
       }
     });
+    this.branchIcon = octicons['git-branch'].toSVG({ 'height': 18 });
+    this.closeIcon = octicons.x.toSVG({ 'height': 18 });
     this.updateRefsDebounced = _.debounce(this.updateRefs, 500);
   }
 
@@ -50,7 +52,7 @@ class BranchesViewModel {
   updateRefs() {
     const currentBranchProm = this.server.getPromise('/branches', { path: this.repoPath() })
       .then((branches) => branches.forEach((b) => { if (b.current) { this.current(b.name); } }))
-      .catch((err) => { this.current("~error"); })
+      .catch((err) => { this.current('~error'); });
 
     // refreshes tags branches and remote branches
     const refsProm = this.server.getPromise('/refs', { path: this.repoPath() })
@@ -91,7 +93,7 @@ class BranchesViewModel {
         });
       }).catch((e) => this.server.unhandledRejection(e));
 
-    return Promise.all([currentBranchProm, refsProm])
+    return Promise.all([currentBranchProm, refsProm]);
   }
 
   branchRemove(branch) {
@@ -105,7 +107,7 @@ class BranchesViewModel {
         if (!diag.result()) return;
         const url = `${branch.isRemote ? '/remote' : ''}/branches`;
         return this.server.delPromise(url, { path: this.graph.repoPath(), remote: branch.isRemote ? branch.remote : null, name: branch.refName })
-          .then(() => { programEvents.dispatch({ event: 'working-tree-changed' }) })
+          .then(() => programEvents.dispatch({ event: 'working-tree-changed' }))
           .catch((e) => this.server.unhandledRejection(e));
       });
   }

--- a/components/branches/branches.less
+++ b/components/branches/branches.less
@@ -1,3 +1,16 @@
 .branch .dropdown-menu .option {
+  font-size: 100%;
   min-width: 250px;
+
+  label {
+    cursor: pointer;
+    font-weight: normal;
+    margin-right: 15px;
+  }
+
+  input {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+  }
 }

--- a/components/commit/commit.html
+++ b/components/commit/commit.html
@@ -14,7 +14,7 @@
             <span class="title" data-bind="text: (title().length > 72 ? title().substring(0, 72) + '...' : title)"></span>
             <span class="text-muted">by <a data-bind="text: authorName, attr: { href: 'mailto:' + authorEmail() }"></a></span>
             <!-- ko if: pgpVerifiedString() -->
-              <span class="octicon octicon-key" data-bind="attr: { title: pgpVerifiedString() }" class="bootstrap-tooltip" data-toggle="tooltip" data-placement="top" ></span>
+              <span class="text-muted" data-bind="html: pgpIcon, attr: { title: pgpVerifiedString() }" class="bootstrap-tooltip" data-toggle="tooltip" data-placement="top"></span>
             <!-- /ko -->
           </div>
           <div class="text-muted nodeSummaryContainer">

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -1,10 +1,8 @@
-
 const ko = require('knockout');
-const components = require('ungit-components');
-const navigation = require('ungit-navigation');
-const programEvents = require('ungit-program-events');
 const md5 = require('blueimp-md5');
 const moment = require('moment');
+const octicons = require('octicons');
+const components = require('ungit-components');
 
 components.register('commit', args => new CommitViewModel(args));
 
@@ -17,6 +15,7 @@ class CommitViewModel {
     this.nodeIsMousehover = gitNode.nodeIsMousehover;
     this.selected = gitNode.selected;
     this.pgpVerifiedString = gitNode.pgpVerifiedString;
+    this.pgpIcon = octicons.verified.toSVG({ 'height': 18 });
     this.element = ko.observable();
     this.commitTime = ko.observable();
     this.authorTime = ko.observable();
@@ -30,13 +29,13 @@ class CommitViewModel {
     this.fileLineDiffs = ko.observable();
     this.numberOfAddedLines = ko.observable();
     this.numberOfRemovedLines = ko.observable();
-    this.authorGravatar = ko.computed(() => md5((this.authorEmail() || "").trim().toLowerCase()));
+    this.authorGravatar = ko.computed(() => md5((this.authorEmail() || '').trim().toLowerCase()));
 
     this.showCommitDiff = ko.computed(() => this.fileLineDiffs() && this.fileLineDiffs().length > 0);
 
     this.diffStyle = ko.computed(() => {
       const marginLeft = Math.min((gitNode.branchOrder() * 70), 450) * -1;
-      if (this.selected() && this.element()) return { "margin-left": `${marginLeft}px`, width: `${window.innerWidth - 220}px` };
+      if (this.selected() && this.element()) return { 'margin-left': `${marginLeft}px`, width: `${window.innerWidth - 220}px` };
       else return {};
     });
   }

--- a/components/commit/commit.less
+++ b/components/commit/commit.less
@@ -1,12 +1,7 @@
-
 @import "public/less/variables.less";
 
 .commit {
   position: relative;
-  .octicon-key {
-    color: #428bca;
-    margin-left: 5px;
-  }
 
   &.highlighted {
     z-index: 2;

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -1,9 +1,8 @@
 const $ = require('jquery');
 const ko = require('knockout');
 const components = require('ungit-components');
-const Selectable = require('./selectable');
-const Animateable = require('./animateable');
 const programEvents = require('ungit-program-events');
+const Animateable = require('./animateable');
 const GraphActions = require('./git-graph-actions');
 
 const maxBranchesToDisplay = parseInt(ungit.config.numRefsToShow / 5 * 3);  // 3/5 of refs to show to branches
@@ -27,7 +26,7 @@ class GitNodeViewModel extends Animateable {
     this.signatureMade = ko.observable();
     this.pgpVerifiedString = ko.computed(() => {
       if (this.signatureMade()) {
-        return `PGP by: ${this.signatureMade()} at ${this.signatureDate()}`
+        return `PGP by: ${this.signatureMade()} at ${this.signatureDate()}`;
       }
     });
 
@@ -169,7 +168,7 @@ class GitNodeViewModel extends Animateable {
   showRefSearchForm(obj, event) {
     this.refSearchFormVisible(true);
 
-    const textBox = event.target.nextElementSibling.firstElementChild; // this may not be the best idea...
+    const textBox = event.currentTarget.nextElementSibling.firstElementChild; // this may not be the best idea...
     $(textBox).autocomplete({
       source: this.refs().filter(ref => !ref.isHEAD),
       minLength: 0,
@@ -188,19 +187,19 @@ class GitNodeViewModel extends Animateable {
       }
     }).focus(() => {
       $(this).autocomplete('search', $(this).val());
-    }).data("ui-autocomplete")._renderItem = (ul, item) => $("<li></li>")
+    }).data('ui-autocomplete')._renderItem = (ul, item) => $('<li></li>')
       .append(`<a>${item.dom}</a>`)
-      .appendTo(ul)
+      .appendTo(ul);
     $(textBox).autocomplete('search', '');
   }
 
   createBranch() {
     if (!this.canCreateRef()) return;
-    this.graph.server.postPromise("/branches", { path: this.graph.repoPath(), name: this.newBranchName(), sha1: this.sha1 })
+    this.graph.server.postPromise('/branches', { path: this.graph.repoPath(), name: this.newBranchName(), sha1: this.sha1 })
       .then(() => {
-        this.graph.getRef(`refs/heads/${this.newBranchName()}`).node(this)
+        this.graph.getRef(`refs/heads/${this.newBranchName()}`).node(this);
         if (ungit.config.autoCheckoutOnBranchCreate) {
-          return this.graph.server.postPromise("/checkout", { path: this.graph.repoPath(), name: this.newBranchName() })
+          return this.graph.server.postPromise('/checkout', { path: this.graph.repoPath(), name: this.newBranchName() });
         }
       }).catch((e) => this.graph.server.unhandledRejection(e))
       .finally(() => {

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -1,9 +1,10 @@
 const ko = require('knockout');
 const md5 = require('blueimp-md5');
-const Selectable = require('./selectable');
+const promise = require('bluebird');
+const octicons = require('octicons');
 const programEvents = require('ungit-program-events');
 const components = require('ungit-components');
-const promise = require('bluebird');
+const Selectable = require('./selectable');
 
 class RefViewModel extends Selectable {
   constructor(fullRefName, graph) {
@@ -40,7 +41,7 @@ class RefViewModel extends Selectable {
     if (this.isRemoteTag) {
       this.localRefName = this.name.slice('remote-tag: '.length);
     }
-    const splitedName = this.localRefName.split('/')
+    const splitedName = this.localRefName.split('/');
     if (this.isRemote) {
       // get rid of the origin/ part of origin/branchname
       this.remote = splitedName[0];
@@ -54,29 +55,29 @@ class RefViewModel extends Selectable {
 
     this.node.subscribe(oldNode => {
       if (oldNode) oldNode.removeRef(this);
-    }, null, "beforeChange");
+    }, null, 'beforeChange');
     this.node.subscribe(newNode => {
       if (newNode) newNode.pushRef(this);
     });
 
     // This optimization is for autocomplete display
-    this.value = splitedName[splitedName.length - 1]
-    this.label = this.localRefName
-    this.dom = `${this.localRefName}<span class='octicon ${this.isTag ? 'octicon-tag' : 'octicon-git-branch'}'></span>`
-    this.displayName = ko.computed(() => {
+    this.value = splitedName[splitedName.length - 1];
+    this.label = this.localRefName;
+    this.dom = `${this.localRefName}<span>${octicons[(this.isTag ? 'tag': 'git-branch')].toSVG({ 'height': 18 })}</span>`;
+
+    this.displayHtml = (largeCurrent) => {
+      const size = (largeCurrent && this.current()) ? 26 : 18;
       let prefix = '';
       if (this.isRemote) {
-        prefix = '<span class="octicon octicon-broadcast"></span> ';
+        prefix = `<span>${octicons.globe.toSVG({ 'height': size })}</span> `;
       }
       if (this.isBranch) {
-        prefix += '<span class="octicon octicon-git-branch"></span> ';
-      } else if (this.current()) {
-        prefix += '<span class="octicon octicon-chevron-right"></span> ';
+        prefix += `<span>${octicons['git-branch'].toSVG({ 'height': size })}</span> `;
       } else if (this.isTag) {
-        prefix += '<span class="octicon octicon-tag"></span> ';
+        prefix += `<span>${octicons.tag.toSVG({ 'height': size })}</span> `;
       }
       return prefix + this.localRefName;
-    });
+    };
   }
 
   _colorFromHashOfString(string) {

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -14,22 +14,18 @@
         <!-- ko foreach: branchesToDisplay -->
         <span class="ref branch" draggable="true" tabIndex="-1"
             data-bind="css: { current: current, remote: isRemoteBranch, dragging: isDragging, focused: selected },
+              html: displayHtml(true),
               click: selected,
-              dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName, 'data-ta-local': isLocal }" >
-          <span class="octicon octicon-broadcast" data-bind="visible: isRemoteBranch"></span>
-          <span class="octicon octicon-git-branch"></span>
-          <span class="name" data-bind="text: localRefName"></span>
+              dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName, 'data-ta-local': isLocal }">
         </span>
         <!-- /ko -->
 
         <!-- ko foreach: tagsToDisplay -->
         <span class="ref tag" draggable="true" tabIndex="0"
             data-bind="css: { current: current, remote: isRemoteTag, dragging: isDragging, focused: selected },
+              html: displayHtml(true),
               click: selected,
               dragStart: dragStart, dragEnd: dragEnd, attr: { 'data-ta-name': localRefName }">
-          <span class="octicon octicon-globe" data-bind="visible: isRemote"></span>
-          <span class="octicon octicon-tag"></span>
-          <span class="name" data-bind="text: localRefName"></span>
         </span>
         <!-- /ko -->
 
@@ -43,7 +39,7 @@
 
         <!-- ko if: showNewRefAction -->
         <span class="newRef" data-bind="css: { editing: branchingFormVisible }">
-          <button class="showBranchingForm bootstrap-tooltip" data-bind="click: showBranchingForm, visible: !branchingFormVisible()" data-toggle="tooltip" data-placement="bottom" title="Create a branch or tag"><span class="glyphicon glyphicon-plus"></span></button>
+          <button class="showBranchingForm bootstrap-tooltip" data-bind="html: $parent.plusIcon, click: showBranchingForm, visible: !branchingFormVisible()" data-toggle="tooltip" data-placement="bottom" title="Create a branch or tag"></button>
           <!-- ko if: branchingFormVisible -->
           <div class="form-inline">
             <input class="name form-control" type="text" data-bind="value: newBranchName, hasfocus: newBranchNameHasFocus, valueUpdate: 'afterkeydown'"/>
@@ -56,12 +52,10 @@
 
         <!-- ko if: refs().length > 0 -->
         <span class="newRef" data-bind="css: { editing: branchingFormVisible }">
-          <button class="showSearchForm octicon octicon-search bootstrap-tooltip" data-bind="click: showRefSearchForm, visible: !refSearchFormVisible()" data-toggle="tooltip" data-placement="bottom" title="Search for a branch or tag"></button>
-          <!-- ko if: refSearchFormVisible -->
-          <div class="form-inline">
+          <button class="showSearchForm bootstrap-tooltip" data-bind="html: $parent.searchIcon, click: showRefSearchForm, visible: !refSearchFormVisible()" data-toggle="tooltip" data-placement="bottom" title="Search for a branch or tag"></button>
+          <div class="form-inline" data-bind="visible: refSearchFormVisible()">
             <input class="name form-control" type="text" data-bind="hasfocus: refSearchFormVisible, valueUpdate: 'afterkeydown'"/>
           </div>
-          <!-- /ko -->
         </span>
         <!-- /ko -->
 

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -1,10 +1,11 @@
 const ko = require('knockout');
+const _ = require('lodash');
+const moment = require('moment');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
 const GitNodeViewModel = require('./git-node');
 const GitRefViewModel = require('./git-ref');
-const _ = require('lodash');
-const moment = require('moment');
 const EdgeViewModel = require('./edge');
 const numberOfNodesPerLoad = ungit.config.numberOfNodesPerLoad;
 
@@ -67,6 +68,8 @@ class GraphViewModel {
     this.updateBranches();
     this.graphWidth = ko.observable();
     this.graphHeight = ko.observable(800);
+    this.searchIcon = octicons.search.toSVG({ 'height': 18 });
+    this.plusIcon = octicons.plus.toSVG({ 'height': 18 });
   }
 
   updateNode(parentElement) {
@@ -164,7 +167,7 @@ class GraphViewModel {
       // First occurrence of the branch, find an empty slot for the branch
       if (ideologicalBranch.lastSlottedTimeStamp != updateTimeStamp) {
         ideologicalBranch.lastSlottedTimeStamp = updateTimeStamp;
-        ideologicalBranch.branchOrder = branchSlotCounter++
+        ideologicalBranch.branchOrder = branchSlotCounter++;
       }
 
       node.branchOrder(ideologicalBranch.branchOrder);
@@ -267,7 +270,7 @@ class GraphViewModel {
       .then(res => { this.checkedOutBranch(res); })
       .catch(err => {
         if (err.errorCode != 'not-a-repository') this.server.unhandledRejection(err);
-      })
+      });
   }
 
   setRemoteTags(remoteTags) {
@@ -278,10 +281,10 @@ class GraphViewModel {
       if (tag.name.includes('^{}')) {
         // This tag is a dereference tag, use this sha1.
         const tagRef = tag.name.slice(0, tag.name.length - '^{}'.length);
-        sha1Map[tagRef] = tag.sha1
+        sha1Map[tagRef] = tag.sha1;
       } else if (!sha1Map[tag.name]) {
         // If sha1 wasn't previously set, use this sha1
-        sha1Map[tag.name] = tag.sha1
+        sha1Map[tag.name] = tag.sha1;
       }
     });
 

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -71,9 +71,6 @@
         font-size: 20px;
         margin-top: 2px;
         margin-bottom: -2px;
-        .octicon {
-          font-size: 20px;
-        }
       }
       &.remote {
         color: #5DB4FF;

--- a/components/header/header.html
+++ b/components/header/header.html
@@ -1,6 +1,4 @@
-
 <div class="navbar navbar-default navbar-fixed-top">
-
   <a class="backlink bootstrap-tooltip" href="#/" data-toggle="tooltip" data-placement="bottom" title="Navigate to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
     <span class="glyphicon glyphicon-arrow-left glyphicon-circled" data-bind="css: { 'glyph-shown': showBackButton }"></span>
     <img src="images/logoLarge.png" class="headerLogo">
@@ -9,9 +7,7 @@
   <div class="form-container">
     <form class="path-input-form" data-bind="submit: submitPath">
       <input class="form-control input-lg" data-bind="value: path, autocomplete: path" placeholder="Enter path to repository">
-      <button type="button" class="add-to-repolist btn btn-default bootstrap-tooltip" data-bind="visible: showAddToRepoListButton, click: addCurrentPathToRepoList" data-toggle="tooltip" data-placement="bottom" title="Add current git directory to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
-        <span class="glyphicon glyphicon-plus"></span>
-      </button>
+      <button type="button" class="add-to-repolist btn btn-default bootstrap-tooltip" data-bind="html: addIcon, visible: showAddToRepoListButton, click: addCurrentPathToRepoList" data-toggle="tooltip" data-placement="bottom" title="Add current git directory to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'></button>
     </form>
   </div>
   <div class="toolbar">

--- a/components/header/header.js
+++ b/components/header/header.js
@@ -1,5 +1,5 @@
-
 const ko = require('knockout');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const navigation = require('ungit-navigation');
 const programEvents = require('ungit-program-events');
@@ -14,6 +14,7 @@ class HeaderViewModel {
     this.currentVersion = ungit.version;
     this.refreshButton = components.create('refreshbutton');
     this.showAddToRepoListButton = ko.computed(() => this.path() && !this.app.repoList().includes(this.path()));
+    this.addIcon = octicons.plus.toSVG({ 'height': 18 });
   }
 
   updateNode(parentElement) {

--- a/components/header/header.js
+++ b/components/header/header.js
@@ -12,7 +12,7 @@ class HeaderViewModel {
     this.showBackButton = ko.observable(false);
     this.path = ko.observable();
     this.currentVersion = ungit.version;
-    this.refreshButton = components.create('refreshbutton');
+    this.refreshButton = components.create('refreshbutton', { isLarge: true });
     this.showAddToRepoListButton = ko.computed(() => this.path() && !this.app.repoList().includes(this.path()));
     this.addIcon = octicons.plus.toSVG({ 'height': 18 });
   }

--- a/components/header/header.less
+++ b/components/header/header.less
@@ -29,7 +29,7 @@
   }
   .form-container {
     margin-left: 180px;
-    margin-right: 62px;
+    margin-right: 72px;
     .path-input-form {
       width: 100%;
       position: relative;

--- a/components/home/home.html
+++ b/components/home/home.html
@@ -1,10 +1,9 @@
-
 <div class="container home animated fadeInLeft" data-bind="shown: shown">
   <div class="nux" data-bind="visible: showNux">
-    <img src="images/logoLarge.png" class="logo-large">
+    <img src="images/logoLarge.png" class="logo-large" />
     <div class="alert alert-info">
       <h4>Enter a path to a repository to get started!</h4>
-      Then press the <span class="glyphicon glyphicon-plus"></span> symbol to make it show up here.
+      Then press the <span data-bind="html: addIcon"></span> symbol to make it show up here.
     </div>
   </div>
   <div class="list-group" data-bind="foreach: repos">
@@ -12,7 +11,7 @@
       <span class="glyphicon glyphicon-arrow-right glyphicon-circled pull-left"></span>
       <h4 class="list-group-item-heading" data-bind="text: title"></h4>
       <p class="list-group-item-text" data-bind="text: remote"></p>
-      <button type="button" class="btn btn-default list-item-remove" data-bind="click: remove">&#x2716;</button>
+      <button type="button" class="btn btn-default list-item-remove" data-bind="html: removeIcon, click: remove"></button>
     </a>
   </div>
 </div>

--- a/components/home/home.js
+++ b/components/home/home.js
@@ -1,5 +1,5 @@
-
 const ko = require('knockout');
+const octicons = require('octicons');
 const components = require('ungit-components');
 
 components.register('home', args => new HomeViewModel(args.app));
@@ -15,6 +15,7 @@ class HomeRepositoryViewModel {
     this.pathRemoved = ko.observable(false);
     this.remote = ko.observable('...');
     this.updateState();
+    this.removeIcon = octicons.x.toSVG({ 'height': 18 });
   }
 
   updateState() {
@@ -22,7 +23,7 @@ class HomeRepositoryViewModel {
       .then(exists => { this.pathRemoved(!exists); })
       .catch((e) => this.server.unhandledRejection(e));
     this.server.getPromise(`/remotes/origin?path=${encodeURIComponent(this.path)}`)
-      .then(remote => {	this.remote(remote.address.replace(/\/\/.*?\@/, "//***@")); })
+      .then(remote => {	this.remote(remote.address.replace(/\/\/.*?\@/, '//***@')); })
       .catch(err => { this.remote(''); });
   }
 
@@ -37,6 +38,7 @@ class HomeViewModel {
     this.app = app;
     this.repos = ko.observableArray();
     this.showNux = ko.computed(() => this.repos().length == 0);
+    this.addIcon = octicons.plus.toSVG({ 'height': 18 });
   }
 
   updateNode(parentElement) {

--- a/components/refreshbutton/refreshbutton.html
+++ b/components/refreshbutton/refreshbutton.html
@@ -1,4 +1,1 @@
-
-<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="click: refresh" data-toggle="tooltip" data-placement="bottom" title="Refresh changes" data-delay='{"show":"2000", "hide":"0"}'>
-  <span class="glyphicon glyphicon-refresh"></span>
-</button>
+<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="html: refreshIcon, css: { 'btn-lg': isLarge }, click: refresh" data-toggle="tooltip" data-placement="bottom" title="Refresh changes" data-delay='{"show":"2000", "hide":"0"}'></button>

--- a/components/refreshbutton/refreshbutton.js
+++ b/components/refreshbutton/refreshbutton.js
@@ -1,11 +1,16 @@
-
 const ko = require('knockout');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
 
-components.register('refreshbutton', () => new RefreshButton());
+components.register('refreshbutton', args => new RefreshButton(args.isLarge));
 
 class RefreshButton {
+  constructor(isLarge) {
+    this.isLarge = isLarge;
+    this.refreshIcon = octicons.sync.toSVG({ 'height': isLarge ? 26 : 18 });
+  }
+
   refresh() {
     programEvents.dispatch({ event: 'request-app-content-refresh' });
     return true;

--- a/components/refreshbutton/refreshbutton.less
+++ b/components/refreshbutton/refreshbutton.less
@@ -1,18 +1,6 @@
-
 .toolbar {
   .refresh-button {
     background: rgba(0, 0, 0, 0.1);
-    border: 0px;
-    font-size: 22px;
-  }
-}
-
-.repository-actions {
-  .refresh-button {
-    background: rgba(84, 101, 101, 1);
-    border: 0px;
-    font-size: 20px;
-    height: 34px;
-    padding-top: 3px;
+    border: 0;
   }
 }

--- a/components/remotes/remotes.html
+++ b/components/remotes/remotes.html
@@ -10,7 +10,7 @@
     <!-- ko foreach: remotes -->
     <li>
       <a href="#" data-bind="text: name, click: changeRemote, attr: { 'data-ta-clickable': name }"></a>
-      <a href="#" class="list-link list-remove" data-bind="text: 'X', click: $parent.remoteRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
+      <a href="#" class="list-link list-remove octicon octicon-x" data-bind="click: $parent.remoteRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
     </li>
     <!-- /ko -->
     <li class="divider"></li>

--- a/components/remotes/remotes.html
+++ b/components/remotes/remotes.html
@@ -10,7 +10,7 @@
     <!-- ko foreach: remotes -->
     <li>
       <a href="#" data-bind="text: name, click: changeRemote, attr: { 'data-ta-clickable': name }"></a>
-      <a href="#" class="list-link list-remove octicon octicon-x" data-bind="click: $parent.remoteRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
+      <a href="#" class="list-link list-remove" data-bind="html: $parent.closeIcon, click: $parent.remoteRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
     </li>
     <!-- /ko -->
     <li class="divider"></li>

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -1,9 +1,9 @@
-
 const ko = require('knockout');
 const _ = require('lodash');
+const promise = require('bluebird');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
-const promise = require('bluebird');
 
 components.register('remotes', args => new RemotesViewModel(args.server, args.repoPath));
 
@@ -19,7 +19,8 @@ class RemotesViewModel {
     this.fetchLabel = ko.computed(() => {
       if (this.currentRemote()) return `Fetch from ${this.currentRemote()}`;
       else return 'No remotes specified';
-    })
+    });
+    this.closeIcon = octicons.x.toSVG({ 'height': 18 });
 
     this.fetchEnabled = ko.computed(() => this.remotes().length > 0);
 
@@ -69,7 +70,7 @@ class RemotesViewModel {
       if (errorMessage.includes('Could not resolve host')) {
         if (this.server.isInternetConnected) {
           this.server.isInternetConnected = false;
-          errorMessage = `Could not resolve host.  This usually means you are disconnected from internet and no longer push or fetch from remote. However, Ungit will be functional for local git operations.`;
+          errorMessage = 'Could not resolve host. This usually means you are disconnected from internet and no longer push or fetch from remote. However, Ungit will be functional for local git operations.';
           stdout = '';
           stderr = '';
         } else {
@@ -94,7 +95,7 @@ class RemotesViewModel {
       .then(remotes => {
         remotes = remotes.map(remote => ({
           name: remote,
-          changeRemote: () => { this.currentRemote(remote) }
+          changeRemote: () => { this.currentRemote(remote); }
         }));
         this.remotes(remotes);
         if (!this.currentRemote() && remotes.length > 0) {

--- a/components/repository/repository.html
+++ b/components/repository/repository.html
@@ -29,7 +29,7 @@
 
     <div class="btn-group branch">
       <button type="button" class="btn btn-default btn-main" data-bind="click: editGitignore">
-        <span class="octicon octicon-file-text"></span>
+        <span data-bind="html: ignoreIcon"></span>
         <span>.gitignore</span>
       </button>
     </div>

--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -25,7 +25,7 @@ class RepositoryViewModel {
     this.isSubmodule = ko.computed(() => this.parentModulePath() && this.parentModuleLink());
     this.refreshSubmoduleStatus();
     if (window.location.search.includes('noheader=true')) {
-      this.refreshButton = components.create('refreshbutton');
+      this.refreshButton = components.create('refreshbutton', { isLarge: false });
     } else {
       this.refreshButton = false;
     }

--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -1,7 +1,6 @@
-
 const ko = require('knockout');
+const octicons = require('octicons');
 const components = require('ungit-components');
-const _ = require('lodash');
 const programEvents = require('ungit-program-events');
 
 components.register('repository', args => new RepositoryViewModel(args.server, args.path));
@@ -30,6 +29,7 @@ class RepositoryViewModel {
     } else {
       this.refreshButton = false;
     }
+    this.ignoreIcon = octicons.file.toSVG({ 'height': 18 });
   }
 
   updateNode(parentElement) {
@@ -97,6 +97,6 @@ class RepositoryViewModel {
           stderr: e.stack,
           repoPath: this.repoPath()
         }});
-      })
+      });
   }
 }

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -1,4 +1,3 @@
-
 <div class="staging panel panel-default" data-bind="css: { commitValidationError: commitValidationError }">
   <div class="panel-body">
     <div class="arrowContainer arrowDown">
@@ -92,10 +91,8 @@
             <span class="conflict" data-bind="visible: conflict"><span class="temporary">Conflicts</span><span class="launchmergetool explanation" data-bind="visible: mergeTool, click: launchMergeTool">Launch Merge Tool</span><span class="markresolved explanation" data-bind="click: resolveConflict">Mark as Resolved</span></span>
             <span class="patch bootstrap-tooltip" data-bind="visible: isShowPatch(), click: patchClick"
                 data-toggle="tooltip" data-placement="top" title="Patch changes">Patch</span>
-            <span class="ignore bootstrap-tooltip" data-bind="click: ignoreFile"
-                data-toggle="tooltip" data-placement="top" title="Add to .gitignore">i</span>
-            <span class="discard bootstrap-tooltip" data-bind="click: discardChanges"
-                data-toggle="tooltip" data-placement="top" title="Discard changes">&#x2716;</span>
+            <button class="ignore btn bootstrap-tooltip" data-bind="html: $parent.ignoreIcon, click: ignoreFile" data-toggle="tooltip" data-placement="top" title="Add to .gitignore"></button>
+            <button class="discard btn bootstrap-tooltip" data-bind="html: $parent.discardIcon, click: discardChanges" data-toggle="tooltip" data-placement="top" title="Discard changes"></button>
             <!-- ko if: isShowingDiffs -->
             <div class="diffContainer" data-bind="component: diff"></div>
             <!-- /ko -->

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -1,14 +1,14 @@
 const ko = require('knockout');
-const inherits = require('util').inherits;
+const _ = require('lodash');
+const promise = require('bluebird');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
-const _ = require('lodash');
-const promise = require("bluebird");
 const filesToDisplayIncrmentBy = 50;
 const filesToDisplayLimit = filesToDisplayIncrmentBy;
 // when discard button is clicked and disable discard warning is selected, for next 5 minutes disable discard warnings
 const muteGraceTimeDuration = 60 * 1000 * 5;
-const mergeTool = ungit.config.mergeTool
+const mergeTool = ungit.config.mergeTool;
 
 components.register('staging', args => new StagingViewModel(args.server, args.repoPath, args.graph));
 
@@ -25,7 +25,7 @@ class StagingViewModel {
       this.commitMessageTitleCount(value.length);
     });
     this.commitMessageBody = ko.observable();
-    this.wordWrap = components.create("textdiff.wordwrap");
+    this.wordWrap = components.create('textdiff.wordwrap');
     this.textDiffType = components.create('textdiff.type');
     this.whiteSpace = components.create('textdiff.whitespace');
     this.inRebase = ko.observable(false);
@@ -35,15 +35,15 @@ class StagingViewModel {
       if (this.inMerge()) {
         this.conflictContinue = this.conflictResolution.bind(this, '/merge/continue');
         this.conflictAbort = this.conflictResolution.bind(this, '/merge/abort');
-        return "Merge";
+        return 'Merge';
       } else if (this.inRebase()) {
         this.conflictContinue = this.conflictResolution.bind(this, '/rebase/continue');
         this.conflictAbort = this.conflictResolution.bind(this, '/rebase/abort');
-        return "Rebase";
+        return 'Rebase';
       } else if (this.inCherry()) {
         this.conflictContinue = this.commit;
         this.conflictAbort = this.discardAllChanges;
-        return "Cherry-pick";
+        return 'Cherry-pick';
       } else {
         this.conflictContinue = undefined;
         this.conflictAbort = undefined;
@@ -66,21 +66,21 @@ class StagingViewModel {
     this.showCancelButton = ko.computed(() => this.amend() || this.emptyCommit());
     this.commitValidationError = ko.computed(() => {
       if (this.conflictText()) {
-        if (this.files().some((file) => file.conflict())) return "Files in conflict";
+        if (this.files().some((file) => file.conflict())) return 'Files in conflict';
       } else {
         if (!this.emptyCommit() && !this.amend() && !this.files().some((file) => file.editState() === 'staged' || file.editState() === 'patched')) {
-          return "No files to commit";
+          return 'No files to commit';
         }
         if (!this.commitMessageTitle()) {
-          return "Provide a title"
+          return 'Provide a title';
         }
 
         if (this.textDiffType.value() === 'sidebysidediff') {
           const patchFiles = this.files().filter(file => file.editState() === 'patched');
-          if (patchFiles.length > 0) return "Cannot patch with side by side view."
+          if (patchFiles.length > 0) return 'Cannot patch with side by side view.';
         }
       }
-      return ""
+      return '';
     });
     this.toggleSelectAllGlyphClass = ko.computed(() => {
       if (this.allStageFlag()) return 'glyphicon-unchecked';
@@ -95,6 +95,8 @@ class StagingViewModel {
     this.loadAnyway = false;
     this.isDiagOpen = false;
     this.mutedTime = null;
+    this.discardIcon = octicons.x.toSVG({ 'height': 18 });
+    this.ignoreIcon = octicons.skip.toSVG({ 'height': 18 });
   }
 
   updateNode(parentElement) {
@@ -208,7 +210,7 @@ class StagingViewModel {
   }
 
   toggleEmptyCommit() {
-    this.commitMessageTitle("Empty commit");
+    this.commitMessageTitle('Empty commit');
     this.commitMessageBody();
     this.emptyCommit(true);
   }
@@ -221,7 +223,7 @@ class StagingViewModel {
       element.diff().invalidateDiff();
       element.patchLineList.removeAll();
       element.isShowingDiffs(false);
-      element.editState(element.editState() === 'patched' ? 'none' : element.editState())
+      element.editState(element.editState() === 'patched' ? 'none' : element.editState());
     }
     this.amend(false);
     this.emptyCommit(false);
@@ -251,7 +253,7 @@ class StagingViewModel {
     this.server.postPromise('/commit', { path: this.repoPath(), message: commitMessage, files, amend: this.amend(), emptyCommit: this.emptyCommit() })
       .then(() => {
         this.resetMessages();
-        return this.server.postPromise('/push', { path: this.repoPath(), remote: this.graph.currentRemote() })
+        return this.server.postPromise('/push', { path: this.repoPath(), remote: this.graph.currentRemote() });
       })
       .catch(err => {
         if (err.errorCode == 'non-fast-forward') {
@@ -291,7 +293,7 @@ class StagingViewModel {
       .closeThen((diag) => {
         if (diag.result()) {
           this.server.postPromise('/discardchanges', { path: this.repoPath(), all: true })
-            .catch((e) => this.server.unhandledRejection(e))
+            .catch((e) => this.server.unhandledRejection(e));
         }
       });
   }
@@ -416,7 +418,7 @@ class FileViewModel {
             this.server.postPromise('/discardchanges', { path: this.staging.repoPath(), file: this.name() })
               .catch((e) => this.server.unhandledRejection(e));
           }
-          if (diag.result() === "mute") this.staging.mutedTime = new Date().getTime();
+          if (diag.result() === 'mute') this.staging.mutedTime = new Date().getTime();
         });
     }
   }

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -90,8 +90,6 @@ class StagingViewModel {
     this.refreshContentThrottled = _.throttle(this.refreshContent.bind(this), 400, { trailing: true });
     this.invalidateFilesDiffsThrottled = _.throttle(this.invalidateFilesDiffs.bind(this), 400, { trailing: true });
     this.refreshContentThrottled();
-    if (window.location.search.includes('noheader=true'))
-      this.refreshButton = components.create('refreshbutton');
     this.loadAnyway = false;
     this.isDiagOpen = false;
     this.mutedTime = null;

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -64,6 +64,8 @@
     padding-left: 5px;
     padding-right: 5px;
     cursor: pointer;
+
+    &:focus,
     &:hover {
       background: #000;
       color: rgba(255, 255, 255, 0.9);
@@ -79,6 +81,8 @@
     padding-right: 5px;
     cursor: pointer;
     font-weight: bold;
+
+    &:focus,
     &:hover {
       background: #55f;
       color: rgba(255, 255, 255, 0.9);

--- a/components/stash/stash.html
+++ b/components/stash/stash.html
@@ -1,5 +1,5 @@
 <div class="stash-toggle stash-toggle-text" data-bind="click: toggleShowStash, visible: !isShow()" >
-  <span class="glyphicon glyphicon-chevron-up"></span>
+  <span class="glyphicon glyphicon-chevron-right"></span>
   Stash (<span data-bind="text: stashedChanges().length"></span>)
 </div>
 <div class="panel panel-default stash" data-bind="visible: visible">
@@ -20,7 +20,7 @@
           <div class="diff-inner" data-bind="component: commitDiff"></div>
         </div>
         <!-- /ko -->
-        <button type="button" class="btn btn-default list-item-remove" data-bind="click: drop" data-toggle="tooltip" data-placement="top" title="Drop this stash">&#x2716;</button>
+        <button type="button" class="btn btn-default list-item-remove" data-bind="html: dropIcon, click: drop" data-toggle="tooltip" data-placement="top" title="Drop this stash"></button>
       </div>
     </div>
   </div>

--- a/components/stash/stash.js
+++ b/components/stash/stash.js
@@ -1,5 +1,5 @@
-
 const ko = require('knockout');
+const octicons = require('octicons');
 const moment = require('moment');
 const components = require('ungit-components');
 const storage = require('ungit-storage');
@@ -22,6 +22,7 @@ class StashItemViewModel {
       repoPath: stash.repoPath,
       server: stash.server
     }));
+    this.dropIcon = octicons.x.toSVG({ 'height': 18 });
   }
 
   apply() {
@@ -79,7 +80,7 @@ class StashViewModel {
         }
       }).catch(err => {
         if (err.errorCode != 'no-such-path') this.server.unhandledRejection(err);
-      })
+      });
   }
 
   toggleShowStash() {

--- a/components/submodules/submodules.html
+++ b/components/submodules/submodules.html
@@ -10,13 +10,15 @@
     <!-- ko foreach: submodules -->
     <li>
       <a href="#" data-bind="text: name, click: $parent.submodulePathClick, attr: { 'data-ta-clickable': name }"></a>
-      <a href="#" class="list-link list-url" data-bind="text: '@', click: $parent.submoduleLinkClick, attr: { 'data-ta-clickable': name + '-weblink' }"></a>
-      <a href="#" class="list-link list-remove" data-bind="text: 'X', click: $parent.submoduleRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
+      <a href="#" class="list-link list-url octicon octicon-link-external" data-bind="click: $parent.submoduleLinkClick, attr: { 'data-ta-clickable': name + '-weblink' }"></a>
+      <a href="#" class="list-link list-remove octicon octicon-x" data-bind="click: $parent.submoduleRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
     </li>
     <!-- /ko -->
+    <!-- ko if: submodules().length-->
     <li class="divider"></li>
     <li><a href="#" class="update-submodule" data-bind="click: updateSubmodules">Update Submodules</a></li>
     <li class="divider"></li>
+    <!-- /ko -->
     <li><a href="#" class="add-submodule" data-bind="click: showAddSubmoduleDialog">Add Submodules</a></li>
   </ul>
 </div>

--- a/components/submodules/submodules.html
+++ b/components/submodules/submodules.html
@@ -10,8 +10,8 @@
     <!-- ko foreach: submodules -->
     <li>
       <a href="#" data-bind="text: name, click: $parent.submodulePathClick, attr: { 'data-ta-clickable': name }"></a>
-      <a href="#" class="list-link list-url octicon octicon-link-external" data-bind="click: $parent.submoduleLinkClick, attr: { 'data-ta-clickable': name + '-weblink' }"></a>
-      <a href="#" class="list-link list-remove octicon octicon-x" data-bind="click: $parent.submoduleRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
+      <a href="#" class="list-link list-url" data-bind="html: $parent.linkIcon, click: $parent.submoduleLinkClick, attr: { 'data-ta-clickable': name + '-weblink' }"></a>
+      <a href="#" class="list-link list-remove" data-bind="html: $parent.closeIcon, click: $parent.submoduleRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
     </li>
     <!-- /ko -->
     <!-- ko if: submodules().length-->

--- a/components/submodules/submodules.js
+++ b/components/submodules/submodules.js
@@ -1,5 +1,5 @@
-
 const ko = require('knockout');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
 
@@ -11,6 +11,8 @@ class SubmodulesViewModel {
     this.server = server;
     this.submodules = ko.observableArray();
     this.isUpdating = false;
+    this.closeIcon = octicons.x.toSVG({ 'height': 18 });
+    this.linkIcon = octicons['link-external'].toSVG({ 'height': 18 });
   }
 
   onProgramEvent(event) {

--- a/nmclicktests/spec.branches.js
+++ b/nmclicktests/spec.branches.js
@@ -129,7 +129,7 @@ describe('[BRANCHES]', () => {
     return environment.nm.ug.click('.ref.branch.current')
       .ug.click('[data-ta-node-title="commit-1"] .squash .dropmask')
       .wait('.staging .files .file')
-      .ug.click('.files span.discard')
+      .ug.click('.files button.discard')
       .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.staging .files .file')
   });

--- a/nmclicktests/spec.discard.js
+++ b/nmclicktests/spec.discard.js
@@ -4,7 +4,7 @@ const createAndDiscard = (env, testRepoPath, dialogButtonToClick) => {
   return env.nm.ug.createTestFile(testRepoPath + '/testfile2.txt')
     .wait('.files .file .btn-default')
     .wait(250)
-    .ug.click('.files span.discard')
+    .ug.click('.files button.discard')
     .wait(250)
     .then(() => {
       if (dialogButtonToClick === "yes") {

--- a/nmclicktests/spec.generic.js
+++ b/nmclicktests/spec.generic.js
@@ -46,8 +46,8 @@ describe('[GENERIC]', () => {
   it('Should be able to add a new file to .gitignore', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[0]}/addMeToIgnore.txt`)
       .wait('.files .file .btn-default')
-      .ug.click('.files span.ignore')
-      .ug.click('.files span.ignore')
+      .ug.click('.files button.ignore')
+      .ug.click('.files button.ignore')
       .ug.waitForElementNotVisible('.files .file .btn-default');
   });
 
@@ -82,7 +82,7 @@ describe('[GENERIC]', () => {
       .wait('.files .file .btn-default')
       .ug.click('.files button')
       .ug.waitForElementNotVisible('[data-ta-container="patch-file"]')
-      .ug.click('.files span.discard')
+      .ug.click('.files button.discard')
       .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.files .file .btn-default')
   });
@@ -121,7 +121,7 @@ describe('[GENERIC]', () => {
     return environment.nm.ug.changeTestFile(`${testRepoPaths[0]}/testfile.txt`)
       .wait('.files .file .additions')
       .wait('.files .file .deletions')
-      .ug.click('.files span.discard')
+      .ug.click('.files button.discard')
       .ug.click('.modal-dialog .btn-primary')
       .ug.waitForElementNotVisible('.files .file .btn-default');
   });

--- a/nmclicktests/spec.remotes.js
+++ b/nmclicktests/spec.remotes.js
@@ -1,8 +1,8 @@
 'use strict';
 const environment = require('./environment')();
 const Bluebird = require('bluebird');
-const mkdirp = Bluebird.promisifyAll(require("mkdirp")).mkdirPAsync;
-const rimraf = Bluebird.promisify(require("rimraf"));
+const mkdirp = Bluebird.promisifyAll(require('mkdirp')).mkdirPAsync;
+const rimraf = Bluebird.promisify(require('rimraf'));
 const testRepoPaths = [];
 
 describe('[REMOTES]', () => {
@@ -20,7 +20,7 @@ describe('[REMOTES]', () => {
   });
 
   it('Should not be possible to push without remote', () => {
-    return environment.nm.ug.click(`.branch[data-ta-name="master"][data-ta-local="true"]`)
+    return environment.nm.ug.click('.branch[data-ta-name="master"][data-ta-local="true"]')
       .ug.waitForElementNotVisible('[data-ta-action="push"]:not([style*="display: none"])');
   });
 
@@ -45,7 +45,7 @@ describe('[REMOTES]', () => {
   it('Fetch from newly added remote', () => {
     return environment.nm.click('.fetchButton .btn-main')
       .wait(500)
-      .ug.waitForElementNotVisible('#nprogress')
+      .ug.waitForElementNotVisible('#nprogress');
   });
 
   it('Remote delete check', () => {
@@ -88,18 +88,18 @@ describe('[REMOTES]', () => {
   it('Should be possible to force push a branch', () => {
     return environment.nm.ug.moveRef('branchinclone', 'Init Commit 0')
       .ug.refAction('branchinclone', true, 'push')
-      .ug.waitForElementNotVisible('[data-ta-action="push"]:not([style*="display: none"])')
+      .ug.waitForElementNotVisible('[data-ta-action="push"]:not([style*="display: none"])');
   });
 
   it('Check for fetching remote branches for the branch list', () => {
     return environment.nm.ug.click('.branch .dropdown-toggle')
       .ug.click('div.option input')
       .wait(200)
-      .visible('li .octicon-broadcast')
+      .visible('li .octicon-globe')
       .then((isVisble) => {
         if (!isVisble) {
           return environment.nm.ug.click('div.option input')
-            .wait('li .octicon-broadcast')
+            .wait('li .octicon-globe');
         }
       });
   });
@@ -109,13 +109,13 @@ describe('[REMOTES]', () => {
       .ug.click('.branch .dropdown-toggle')
       .ug.click('[data-ta-clickable="checkoutrefs/remotes/origin/branchinclone"]')
       .wait(200)
-      .wait('[data-ta-name="branchinclone"][data-ta-local="true"]')
+      .wait('[data-ta-name="branchinclone"][data-ta-local="true"]');
   });
 
   it('Should be possible to commitnpush', () => {
     return environment.nm.ug.createTestFile(`${testRepoPaths[2]}/commitnpush.txt`)
       .ug.commitnpush('Commit & Push')
-      .wait('.nux')
+      .wait('.nux');
   });
 
   it('Should be possible to commitnpush with ff', () => {
@@ -123,6 +123,6 @@ describe('[REMOTES]', () => {
       .ug.click('.commit-grp .dropdown-toggle')
       .ug.click('.commitnpush')
       .ug.click('.modal-dialog .btn-primary')
-      .wait('.nux')
+      .wait('.nux');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.4.47",
+  "version": "1.4.48",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,6 +19,14 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
+    },
+    "@primer/octicons": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.2.0.tgz",
+      "integrity": "sha512-3vv7bBqVUHhU7ChpmQhmzz3WmHEKKSk9z/xEK5KnU8Egh96RoqKIim07geRj825ISa+IWj9cPdOA1ShqW5k3Yw==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
@@ -11317,11 +11325,6 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
-    },
-    "octicons": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/octicons/-/octicons-3.5.0.tgz",
-      "integrity": "sha1-9/9ZNWdNixFPbYDEVL+qAXl6TjA="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "0ungit-credentials-helper": "./bin/credentials-helper"
   },
   "dependencies": {
+    "@primer/octicons": "^9.2.0",
     "bluebird": "~3.5.4",
     "blueimp-md5": "~2.10.0",
     "body-parser": "~1.19.0",
@@ -46,7 +47,6 @@
     "npm": "~6.9.1-next.0",
     "npm-registry-client": "~8.6.0",
     "nprogress": "^0.2.0",
-    "octicons": "3.5.0",
     "open": "~6.1.0",
     "passport": "~0.4.0",
     "passport-local": "~1.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,6 @@
 	<link rel="shortcut icon" href="__ROOT_PATH__/favicon.ico" >
 	<link rel="shortcut icon" href="/images/icon.png" >
 	<title>ungit</title>
-	<!-- these are broken even in google official datalab tutorial! -->
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css">
 </head>
 <body>
 

--- a/public/less/generic.less
+++ b/public/less/generic.less
@@ -1,10 +1,9 @@
-
 // Generic.less
 // This file can be used to style any page to look like "ungit", i.e. anything that's not
 // application specific goes here.
 
 @import "../vendor/less/bootstrap/bootstrap.less";
-@import "../../node_modules/octicons/octicons/octicons.less";
+@import (inline) "../../node_modules/@primer/octicons/build/build.css";
 @import "variables.less";
 
 @font-face {


### PR DESCRIPTION
This builds on #1223 but with the latest version of Octicons.
With that version the icons are used as SVG instead of fonts.
(Credit to @exsilium for the work in https://github.com/exsilium/mungit/pull/4.)

* All changes from #1223
* Use latest version of Octicons
* Changed icons
  * Use `verified` instead of `key` for PGP signatures (as GitHub does)
  * Use `skip` instead of `i` to add files to ignore (avoid confusion from `i` being used for "information")
  * Use `globe` instead of `broadcast` for "remote" consistently (as it was already the case for tags)
* Switch `+` and `x` to octicons consistently (from glyphicons and unicode)
* Use octicons for refresh button and align design with other buttons
* Use actual `<button>` for ignore and discard files in staging
* Fix all semicolon and quote mark lint violations in changed files