### PR TITLE
Hide diff-buttons on commit hover

### DIFF
--- a/components/commit/commit.html
+++ b/components/commit/commit.html
@@ -29,7 +29,7 @@
       <!-- ko if: selected() || nodeIsMousehover() -->
       <div class="details">
         <div class="body" data-bind="visible: title().length > 72, text: '...' + title().substring(72)"></div>
-        <div class="body" data-bind="text: body"></div>
+        <div class="body" data-bind="text: body, visible: body"></div>
         <div class="diff-wrapper" data-bind="visible: showCommitDiff, style: diffStyle, click: stopClickPropagation">
           <div class="diff-inner" data-bind="component: commitDiff"></div>
         </div>

--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -1,10 +1,7 @@
-
 const ko = require('knockout');
-const components = require('ungit-components');
-const navigation = require('ungit-navigation');
-const programEvents = require('ungit-program-events');
 const md5 = require('blueimp-md5');
 const moment = require('moment');
+const components = require('ungit-components');
 
 components.register('commit', args => new CommitViewModel(args));
 
@@ -30,13 +27,13 @@ class CommitViewModel {
     this.fileLineDiffs = ko.observable();
     this.numberOfAddedLines = ko.observable();
     this.numberOfRemovedLines = ko.observable();
-    this.authorGravatar = ko.computed(() => md5((this.authorEmail() || "").trim().toLowerCase()));
+    this.authorGravatar = ko.computed(() => md5((this.authorEmail() || '').trim().toLowerCase()));
 
     this.showCommitDiff = ko.computed(() => this.fileLineDiffs() && this.fileLineDiffs().length > 0);
 
     this.diffStyle = ko.computed(() => {
       const marginLeft = Math.min((gitNode.branchOrder() * 70), 450) * -1;
-      if (this.selected() && this.element()) return { "margin-left": `${marginLeft}px`, width: `${window.innerWidth - 220}px` };
+      if (this.selected() && this.element()) return { 'margin-left': `${marginLeft}px`, width: `${window.innerWidth - 220}px` };
       else return {};
     });
   }
@@ -64,7 +61,8 @@ class CommitViewModel {
       fileLineDiffs: this.fileLineDiffs(),
       sha1: this.sha1,
       repoPath: this.repoPath,
-      server: this.server
+      server: this.server,
+      showDiffButtons: this.selected
     }));
   }
 

--- a/components/commit/commit.less
+++ b/components/commit/commit.less
@@ -1,4 +1,3 @@
-
 @import "public/less/variables.less";
 
 .commit {
@@ -30,6 +29,7 @@
   &.selected {
     .details {
       .diff-wrapper {
+        margin-bottom: 5px;
         transition:width 0.1s, left 0.05s;
         box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.15);
         .diff-inner {
@@ -39,7 +39,7 @@
         }
         .btn-group {
           padding: 2px;
-          margin: 10px 0px 0px 10px;
+          margin-top: 10px;
           margin-bottom: 0px;
         }
       }
@@ -95,9 +95,7 @@
         color: #8F9FA6;
       }
       .diff-wrapper {
-        margin: 0px;
         margin-top: 10px;
-        margin-bottom: 10px;
         background: #4B5766;
         border-radius: 3px;
       }

--- a/components/commitdiff/commitdiff.js
+++ b/components/commitdiff/commitdiff.js
@@ -9,8 +9,7 @@ class CommitDiff {
     this.commitLineDiffs = ko.observableArray();
     this.sha1 = args.sha1;
 
-    // parent components can provide their own buttons (e.g. staging component)
-    this.showDiffButtons = ko.observable(!args.textDiffType);
+    this.showDiffButtons = args.showDiffButtons;
     this.textDiffType = args.textDiffType = args.textDiffType || components.create('textdiff.type');
     this.wordWrap = args.wordWrap = args.wordWrap || components.create('textdiff.wordwrap');
     this.whiteSpace = args.whiteSpace = args.whiteSpace || components.create('textdiff.whitespace');

--- a/components/stash/stash.js
+++ b/components/stash/stash.js
@@ -1,4 +1,3 @@
-
 const ko = require('knockout');
 const moment = require('moment');
 const components = require('ungit-components');
@@ -20,7 +19,8 @@ class StashItemViewModel {
       fileLineDiffs: data.fileLineDiffs.slice(),
       sha1: this.sha1,
       repoPath: stash.repoPath,
-      server: stash.server
+      server: stash.server,
+      showDiffButtons: ko.observable(true)
     }));
   }
 
@@ -79,7 +79,7 @@ class StashViewModel {
         }
       }).catch(err => {
         if (err.errorCode != 'no-such-path') this.server.unhandledRejection(err);
-      })
+      });
   }
 
   toggleShowStash() {


### PR DESCRIPTION
* Show the diff buttons only when a commit is selected, but not on hover
* Remove empty space when no commit message body is present
* Align margins in the commit-"card"
* Clean up lint issues in changed files

*Before*
![image](https://user-images.githubusercontent.com/2564094/67340415-31fd9780-f4e2-11e9-875f-84cf27e29a6c.png)

*After*
![image](https://user-images.githubusercontent.com/2564094/67340428-3924a580-f4e2-11e9-9f3c-a5693c5d6152.png)