### PR TITLE
Correctly initialize tooltips on stash

### DIFF
--- a/components/stash/stash.html
+++ b/components/stash/stash.html
@@ -10,8 +10,8 @@
     </h4>
     <div class="list-group" data-bind="foreach: stashedChanges">
       <div class="list-group-item">
-        <a href="#" class="stash-apply glyphicon glyphicon-pencil glyphicon-circled pull-left" data-bind="click: apply" data-toggle="tooltip" title="Apply this stash"></a>
-        <a href="#" class="toggle-show-commit-diffs" data-bind="click: toggleShowCommitDiffs" data-toggle="tooltip" title="Show stash diff">
+        <a href="#" class="stash-apply glyphicon glyphicon-pencil glyphicon-circled pull-left bootstrap-tooltip" data-bind="click: apply" data-toggle="tooltip" title="Apply this stash"></a>
+        <a href="#" class="toggle-show-commit-diffs bootstrap-tooltip" data-bind="click: toggleShowCommitDiffs" data-toggle="tooltip" title="Show stash diff">
           <h4 class="list-group-item-heading" data-bind="text: title"></h4>
           <p class="list-group-item-text" data-bind="text: message"></p>
         </a>
@@ -20,7 +20,7 @@
           <div class="diff-inner" data-bind="component: commitDiff"></div>
         </div>
         <!-- /ko -->
-        <button type="button" class="btn btn-default list-item-remove" data-bind="click: drop" data-toggle="tooltip" data-placement="top" title="Drop this stash">&#x2716;</button>
+        <button type="button" class="btn btn-default list-item-remove bootstrap-tooltip" data-bind="click: drop" data-toggle="tooltip" data-placement="top" title="Drop this stash">&#x2716;</button>
       </div>
     </div>
   </div>

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -43,7 +43,7 @@ var adBlocker = require('just-detect-adblock');
 
   programEvents.add(function(event) {
     if (event.event === 'init-tooltip') {
-      $('.bootstrap-tooltip').tooltip();
+      $('.bootstrap-tooltip').tooltip().removeClass('bootstrap-tooltip');
     }
   });
 


### PR DESCRIPTION
The buttons in the "Stashed Changes" didn't get the correct tooltips due to a missing class.

This PR also removes the class after tooltips are initialized so they don't get called multiple times.