### PR TITLE
Improve git-init experience

### DIFF
--- a/components/branches/branches.html
+++ b/components/branches/branches.html
@@ -1,9 +1,9 @@
 <div class="btn-group branch">
   <button type="button" class="btn btn-default btn-main" data-bind="click: updateRefs">
     <span data-bind="html: branchIcon"></span>
-    <span data-bind="text: fetchLabel"></span>
+    <span data-bind="text: refsLabel"></span>
   </button>
-  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-bind="enable: listRefsEnabled">
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu pull-right" role="menu">

--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -30,11 +30,8 @@ class BranchesViewModel {
     this.isShowRemote.subscribe(setLocalStorageAndUpdate.bind(null, showRemote));
     this.isShowBranch.subscribe(setLocalStorageAndUpdate.bind(null, showBranch));
     this.isShowTag.subscribe(setLocalStorageAndUpdate.bind(null, showTag));
-    this.fetchLabel = ko.computed(() => {
-      if (this.current()) {
-        return this.current();
-      }
-    });
+    this.refsLabel = ko.computed(() => this.current() || 'master (no commits yet)');
+    this.listRefsEnabled = ko.computed(() => this.branchesAndLocalTags().length > 0);
     this.branchIcon = octicons['git-branch'].toSVG({ 'height': 18 });
     this.closeIcon = octicons.x.toSVG({ 'height': 18 });
     this.updateRefsDebounced = _.debounce(this.updateRefs, 500);

--- a/components/path/path.html
+++ b/components/path/path.html
@@ -1,59 +1,57 @@
-
 <div class="path" data-bind="shown: shown">
 
   <!-- ko if: status() == 'uninited' -->
-  <div class="uninited">
-    <div class="container">
-      <div class="alert alert-info" data-bind="visible: showDirectoryCreatedAlert">
-        Directory '<span data-bind="text: dirName"></span>' created
-      </div>
-      <h1>'<span data-bind="text: dirName"></span>' is not a repository</h1>
-      <p>There is no repository at the selected path.</p>
-      <div class="row">
-        <div class="col-lg-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Create a new repository</div>
-            <div class="panel-body">
-              <button class="btn btn-primary btn-lg" data-bind='click: initRepository'>
-                Make '<span data-bind="text: dirName"></span>' a repository
-              </button>
-            </div>
+  <div class="uninited container">
+    <div class="alert alert-info" data-bind="visible: showDirectoryCreatedAlert">
+      Directory "<span data-bind="text: dirName"></span>" created.
+    </div>
+    <h1>"<span data-bind="text: dirName"></span>" is not a git repository</h1>
+    <p>There is no git repository at the selected path.</p>
+    <div class="row">
+      <div class="col-lg-6">
+        <div class="panel panel-default">
+          <div class="panel-heading">Create a new git repository in "<span data-bind="text: dirName"></span>"</div>
+          <div class="panel-body">
+            <button class="btn btn-primary btn-lg" data-bind="click: initRepository">
+              Create Repository
+            </button>
           </div>
         </div>
-        <div class="col-lg-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Clone a repository into a subfolder of '<span data-bind="text: dirName"></span>'</div>
-            <div class="panel-body">
-              <form data-bind="submit: cloneRepository">
-                <div class="form-group">
-                  <label for="cloneFromInput">Clone from</label>
-                  <input class="form-control" type="text" id="cloneFromInput" placeholder="url" data-bind="value: cloneUrl, valueUpdate: 'afterkeydown'">
-                </div>
-                <div class="form-group">
-                  <label for="cloneToInput">to</label>
-                  <input class="form-control" type="text" id="cloneToInput" data-bind="value: cloneDestination, attr: { placeholder: cloneDestinationImplicit }">
-                </div>
-                <div class="form-group" style="display: flex;">
-                  <label style="width: 230px; padding-top: 11px;">is recurse submodule?</label>
-                  <input class="form-control" type="checkbox" data-bind="checked: isRecursiveSubmodule, attr: { placeholder: cloneDestinationImplicit }">
-                </div>
-                <input type="submit" class="btn btn-primary btn-lg" value="Clone repository">
-              </form>
-            </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="panel panel-default">
+          <div class="panel-heading">Clone a git repository into a subfolder of "<span data-bind="text: dirName"></span>"</div>
+          <div class="panel-body">
+            <form data-bind="submit: cloneRepository">
+              <div class="form-group">
+                <label for="cloneFromInput">Clone from</label>
+                <input class="form-control" type="text" id="cloneFromInput" placeholder="URL" data-bind="value: cloneUrl, valueUpdate: 'afterkeydown'" required />
+              </div>
+              <div class="form-group">
+                <label for="cloneToInput">into</label>
+                <input class="form-control" type="text" id="cloneToInput" data-bind="value: cloneDestination, attr: { placeholder: cloneDestinationImplicit }" />
+              </div>
+              <div class="form-group">
+                <label>
+                  <input type="checkbox" data-bind="checked: isRecursiveSubmodule, attr: { placeholder: cloneDestinationImplicit }" />
+                  Recurse submodules
+                </label>
+              </div>
+              <button type="submit" class="btn btn-primary btn-lg">Clone Repository</button>
+            </form>
           </div>
         </div>
       </div>
     </div>
-
   </div>
   <!-- /ko -->
 
   <!-- ko if: status() == 'no-such-path' -->
-  <div class="invalid-path" data-bind="visible: status() == 'no-such-path'">
-    <h2>Invalid path</h2>
-    <p>"<span data-bind="text: repoPath"></span>" doesn&#39;t seem to be a valid path.</p>
+  <div class="invalid-path container">
+    <h1>Invalid path</h1>
+    <p>"<span data-bind="text: repoPath"></span>" doesn't seem to be a valid path.</p>
     <div class="create-dir">
-      <button class="btn btn-primary btn-lg" data-bind="click: createDir">Create directory</button>
+      <button class="btn btn-primary btn-lg" data-bind="click: createDir">Create Directory</button>
     </div>
   </div>
   <!-- /ko -->

--- a/components/path/path.js
+++ b/components/path/path.js
@@ -1,4 +1,3 @@
-
 const ko = require('knockout');
 const components = require('ungit-components');
 const addressParser = require('ungit-address-parser');
@@ -13,7 +12,7 @@ class PathViewModel {
   constructor(server, path) {
     this.server = server;
     this.repoPath = ko.observable(path);
-    this.dirName = this.repoPath().replace('\\', '/')
+    this.dirName = this.repoPath().replace(/\\/g, '/')
                      .split('/')
                      .filter((s) => s)
                      .slice(-1)[0] || '/';
@@ -58,7 +57,7 @@ class PathViewModel {
           this.repository(null);
         }
         return null;
-      }).catch((err) => { })
+      }).catch((err) => { });
   }
   initRepository() {
     return this.server.postPromise('/init', { path: this.repoPath() })
@@ -76,15 +75,15 @@ class PathViewModel {
     const dest = this.cloneDestination() || this.cloneDestinationImplicit();
 
     return this.server.postPromise('/clone', { path: this.repoPath(), url: this.cloneUrl(), destinationDir: dest, isRecursiveSubmodule: this.isRecursiveSubmodule() })
-      .then((res) => navigation.browseTo('repository?path=' + encodeURIComponent(res.path)) )
+      .then((res) => navigation.browseTo('repository?path=' + encodeURIComponent(res.path)))
       .catch((e) => this.server.unhandledRejection(e))
       .finally(() => {
         programEvents.dispatch({ event: 'working-tree-changed' });
-      })
+      });
   }
   createDir() {
     this.showDirectoryCreatedAlert(true);
-    return this.server.postPromise('/createDir',  { dir: this.repoPath() })
+    return this.server.postPromise('/createDir', { dir: this.repoPath() })
       .catch((e) => this.server.unhandledRejection(e))
       .then(() => this.updateStatus());
   }

--- a/components/path/path.less
+++ b/components/path/path.less
@@ -1,0 +1,3 @@
+.create-dir {
+  margin-top: 50px;
+}

--- a/components/path/ungit-plugin.json
+++ b/components/path/ungit-plugin.json
@@ -3,6 +3,7 @@
     "knockoutTemplates": {
       "path": "path.html"
     },
-    "javascript": "path.bundle.js"
+    "javascript": "path.bundle.js",
+    "css": "path.css"
   }
 }

--- a/components/remotes/remotes.html
+++ b/components/remotes/remotes.html
@@ -13,7 +13,9 @@
       <a href="#" class="list-link list-remove" data-bind="html: $parent.closeIcon, click: $parent.remoteRemove.bind($parent), attr: { 'data-ta-clickable': name + '-remove' }"></a>
     </li>
     <!-- /ko -->
+    <!-- ko if: remotes().length -->
     <li class="divider"></li>
+    <!-- /ko -->
     <li><a href="#" class="add-new-remote" data-bind="click: showAddRemoteDialog">Add a new remote</a></li>
   </ul>
 </div>

--- a/nmclicktests/spec.remotes.js
+++ b/nmclicktests/spec.remotes.js
@@ -67,7 +67,7 @@ describe('[REMOTES]', () => {
   it('Clone repository should bring you to repo page', () => {
     return environment.nm.insert('#cloneFromInput', testRepoPaths[1])
       .insert('#cloneToInput', testRepoPaths[2])
-      .ug.click('.uninited input[type="submit"]')
+      .ug.click('.uninited button[type="submit"]')
       .wait('.repository-view')
       .exists('[data-ta-container="remote-error-popup"]')
       .then((isVisible) => { if (isVisible) throw new Error('Should not find remote error popup'); });

--- a/public/less/generic.less
+++ b/public/less/generic.less
@@ -186,7 +186,3 @@ a.disabled {
 ::-webkit-scrollbar-corner {
       background-color: black;
 }
-
-.create-dir {
-	margin-top: 50px;
-}


### PR DESCRIPTION
* Invalid Path
  * Use `container` to center the content
* No repository
  ![image](https://user-images.githubusercontent.com/2564094/67608341-aa5f9500-f73c-11e9-9f5e-6f557c74f6db.png)
  ![image](https://user-images.githubusercontent.com/2564094/67608293-797f6000-f73c-11e9-922b-a8702219d328.png)
  * Use "git repository" instead of just "repository" to be more precise
  * Fix path display string on windows
  * Unify panel header and button texts
  * Fix checkbox design
* Empty repository
  ![image](https://user-images.githubusercontent.com/2564094/67608434-104c1c80-f73d-11e9-9fcc-8c8d4775908f.png)
  ![image](https://user-images.githubusercontent.com/2564094/67608281-63719f80-f73c-11e9-862c-fa185d2dc914.png)
  * Remove divider when list of remotes is empty
  * Disable branch dropdown when list of refs is empty
  * Use default label when there are no commits


For a better view of the changes (without the indentation) use https://github.com/FredrikNoren/ungit/pull/1228/files?w=1
