### PR TITLE
Travis and AppVeyor config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
 sudo: required
 language: node_js
 node_js:
-  - "8"
+  - node
+  - "12"
   - "10"
-  - "11"
+  - "8"
 branches:
   only:
     - master
 env:
   matrix:
-    - GIT_VERSION=default
     - GIT_VERSION=edge
+    - GIT_VERSION=default
 matrix:
   exclude:
-    - node_js: "8"
+    - node_js: "12"
       env: GIT_VERSION=edge
     - node_js: "10"
+      env: GIT_VERSION=edge
+    - node_js: "8"
       env: GIT_VERSION=edge
 addons:
   apt:
@@ -25,13 +28,12 @@ addons:
 install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-  - npm install --unsafe-perm=true --allow-root
-before_script:
-  - npm install -g grunt-cli
   - if [ "$GIT_VERSION" = "edge" ]; then sudo add-apt-repository ppa:git-core/ppa -y && sudo apt-get update -q && sudo apt-get install -y git; fi
+  - npm ci
+before_script:
   - git config --global user.email "test@testy.com"
   - git config --global user.name "Test testy"
   - git version
-  - grunt -d
-after_script:
-  - grunt travisnpmpublish
+  - npm run build
+after_success:
+  - npm run travisnpmpublish

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ skip_branch_with_pr: true
 
 environment:
   matrix:
+  - nodejs_version: "" # latest
+  - nodejs_version: "12"
+  - nodejs_version: "10"
   - nodejs_version: "8"
 
 branches:
@@ -10,15 +13,17 @@ branches:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - git config --global user.email "test@testy.com"
-  - git config --global user.name "Test testy"
-  - npm install
-  - npm install -g grunt-cli
-
-test_script:
   - node --version
   - npm --version
-  - grunt
-  - npm test
+  - npm ci
 
-build: off
+build_script:
+  - npm run build
+
+before_test:
+  - git config --global user.email "test@testy.com"
+  - git config --global user.name "Test testy"
+  - git --version
+
+test_script:
+  - npm test

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "scripts": {
     "start": "node ./bin/ungit",
     "test": "grunt test",
+    "unittest": "grunt unittest",
     "build": "grunt",
-    "watch": "grunt watch"
+    "watch": "grunt watch",
+    "travisnpmpublish": "grunt travisnpmpublish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The click tests have been failing for a while on Travis (i.e. on Linux) due to a timeout.
I have tried to get them to run on [AppVeyor Linux](https://ci.appveyor.com/project/Hirse/ungit/builds/28439957), [GitHub Actions](https://github.com/Hirse/ungit/runs/277006406), [Azure Pipelines](https://janpilzer.visualstudio.com/ungit/_build/results?buildId=2), and [CircleCi](https://app.circleci.com/jobs/github/Hirse/ungit/5) but keep running into the same timeout issue.
I was even able to reproduce that using the WSL on my Windows machine.

The click tests pass on locally on Windows as well as on AppVeyor Windows images.
To get the build status back to green this PR restricts Travis to run only the unit tests and extends the build matrix for AppVeyor.

* Add more npm scripts to remove dependency on grunt-cli for testrunners
* Travis
  * Only run unit tests
  * Update node versions to [latest, 12, 10, 8] (see [Release Schedule](https://github.com/nodejs/Release))
  * Use [`npm ci`](https://docs.npmjs.com/cli/ci.html)
  * Remove setup for UI tests
  * Remove grunt-cli
* AppVeyor
  * Increase node versions to [latest, 12, 10, 8] (see [Release Schedule](https://github.com/nodejs/Release))
  * Use [`npm ci`](https://docs.npmjs.com/cli/ci.html)
  * Remove grunt-cli
* [ ] Add AppVeyor badge to Readme (I cannot access the correct URL at https://ci.appveyor.com/project/FredrikNoren/ungit/settings/badges)
  