### PR TITLE
Add libgconf-2-4 package for nightmare on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ branches:
   only:
     - master
 env:
-  global:
-    - CXX=g++-4.8
   matrix:
     - GIT_VERSION=default
     - GIT_VERSION=edge
@@ -21,11 +19,9 @@ matrix:
       env: GIT_VERSION=edge
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
       - xvfb
+      - libgconf-2-4
 install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &


### PR DESCRIPTION
remove old g++ workarounds (looks like they aren't needed. Introduced in  https://github.com/FredrikNoren/ungit/pull/675)

Looks like `libgconf-2-4` is required for running nightmare (electron) clicktests. See https://github.com/electron/electron/issues/1518
Not sure why this wasn't an issue before.

This just took me [16 tries](https://travis-ci.org/campersau/ungit/builds/604400898) 😄 