### PR TITLE
Enable clearing gitignore file

### DIFF
--- a/source/git-api.js
+++ b/source/git-api.js
@@ -679,13 +679,13 @@ exports.registerApi = (env) => {
       });
   });
   app.put(`${exports.pathPrefix}/gitignore`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    if (!req.body.data || req.body.data == '') {
-      return res.status(500).json({ message: "Invalid .gitignore content"});
+    if (!req.body.data && req.body.data !== '') {
+      return res.status(400).json({ message: 'Invalid .gitignore content'});
     }
-    fs.writeFileAsync(path.join(req.body.path, ".gitignore"), req.body.data)
+    fs.writeFileAsync(path.join(req.body.path, '.gitignore'), req.body.data)
       .then(() => res.status(200).json({}))
       .finally(emitGitDirectoryChanged.bind(null, req.body.path))
-      .catch((e) => res.status(500).json(e))
+      .catch((e) => res.status(500).json(e));
   });
 
   if (config.dev) {

--- a/test/spec.git-api.js
+++ b/test/spec.git-api.js
@@ -383,6 +383,9 @@ describe('git-api', () => {
   it('test gitignore api endpoint', () => {
     return common.put(req, '/gitignore', { path: testDir, data: 'abc' })
       .then(() => common.get(req, '/gitignore', { path: testDir }))
-      .then((res) => expect(res.content).to.be('abc'));
+      .then((res) => expect(res.content).to.be('abc'))
+      .then(() => common.put(req, '/gitignore', { path: testDir, data: '' }))
+      .then(() => common.get(req, '/gitignore', { path: testDir }))
+      .then((res) => expect(res.content).to.be(''));
   });
 })


### PR DESCRIPTION
Currently it is not possible to remove all content from the .gitignore file as an empty string request is considered invalid by the server.

* Allow empty string requests for gitignore
* Extend test to cover empty string
* Return 400 instead of 500 for invalid requests (not a server issue)
* Fix lint issues in gitignore function