### PR TITLE
Add raven.js map file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ public/js/ungit.js
 public/js/ungit.js.map
 public/js/devStyling.js
 public/js/raven.min.js
+public/js/raven.min.js.map
 public/images/
 
 .ungitrc

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -186,7 +186,8 @@ module.exports = (grunt) => {
           // includes files within path
           { expand: true, flatten: true, src: ['node_modules/nprogress/nprogress.css'], dest: 'public/css/' },
           { expand: true, flatten: true, src: ['node_modules/jquery-ui-bundle/jquery-ui.min.css'], dest: 'public/css/'},
-          { expand: true, flatten: true, src: ['node_modules/raven-js/dist/raven.min.js'], dest: 'public/js/' }
+          { expand: true, flatten: true, src: ['node_modules/raven-js/dist/raven.min.js'], dest: 'public/js/' },
+          { expand: true, flatten: true, src: ['node_modules/raven-js/dist/raven.min.js.map'], dest: 'public/js/' }
         ]
       },
       electron: {


### PR DESCRIPTION
Add raven.min.js.map to stop Firefox from issuing a warning.
I mostly did this to reduce the number of warning and be able to better focus on actual issues.

![image](https://user-images.githubusercontent.com/2564094/68090939-9dbef900-fe2e-11e9-8848-871883972c48.png)
