### PR TITLE
Set users config to empty map

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -39,7 +39,7 @@ const defaultConfig = {
   authentication: false,
 
   // Map of username/passwords which are granted access.
-  users: undefined,
+  users: {},
 
   // Set to false to show rebase and merge on drag and drop on all nodes.
   showRebaseAndMergeOnlyOnRefs: true,


### PR DESCRIPTION
Starting ungit with `ungit --authentication` but without adding users leads to bad error messages when trying to login because the user-pw map is not initialized. Setting the config default to an empty map prevents this error.
![image](https://user-images.githubusercontent.com/2564094/68090966-f8585500-fe2e-11e9-9599-d23695425d5c.png)
