### PR TITLE
Set value for deprecated default options of expressjs session

### DIFF
--- a/source/server.js
+++ b/source/server.js
@@ -131,7 +131,9 @@ if (config.authentication) {
     store: new MemoryStore({
       checkPeriod: 86400000 // prune expired entries every 24h
     }),
-    secret: 'ungit'
+    secret: 'ungit',
+    resave: true,
+    saveUninitialized: true
   }));
   app.use(passport.initialize());
   app.use(passport.session());


### PR DESCRIPTION
Not setting the `resave` and `saveUninitialized` options in the expressjs session is [deprecated](https://github.com/expressjs/session#resave) and leads to warning messages. This PR sets them explicitly to their default values.

![image](https://user-images.githubusercontent.com/2564094/68091017-91876b80-fe2f-11e9-8634-21ddf1214347.png)
