### PR TITLE
Electron publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,15 @@ before_script:
   - DISPLAY= npm run package
 after_success:
   - npm run travisnpmpublish
+before_deploy:
+  - npm run electronpublish
+deploy:
+  provider: releases
+  api_key: ${GITHUB_TOKEN}
+  file_glob: true
+  file: dist/*.zip
+  overwrite: true
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: $GIT_VERSION = edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 branches:
   only:
     - master
+    - /^v\d+\.\d+\.\d+$/
 env:
   matrix:
     - GIT_VERSION=edge
@@ -48,6 +49,7 @@ deploy:
   file: dist/*.zip
   overwrite: true
   skip_cleanup: true
+  body: "[Changelog](https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md#${TRAVIS_TAG//[v\\.]})"
   on:
     tags: true
     condition: $GIT_VERSION = edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,200 +1,541 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
-Use the following format for additions: ` - VERSION: [feature/patch (if applicable)] Short description of change. Links to relevant issues/PRs.`
+We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-- Unreleased:
-  - Updated Octicons [#1224](https://github.com/FredrikNoren/ungit/pull/1224)
-  - Hide diff buttons on hover [#1225](https://github.com/FredrikNoren/ungit/pull/1225)
-  - Fix stash tooltips [#1227](https://github.com/FredrikNoren/ungit/pull/1227)
-  - Improve git-init experience [#1228](https://github.com/FredrikNoren/ungit/pull/1228)
-  - Fix inconsistent diff options [#1229](https://github.com/FredrikNoren/ungit/issues/1229)
-  - Fix clearing .gitignore [#1236](https://github.com/FredrikNoren/ungit/pull/1236)
-  - Fix electron package [#1240](https://github.com/FredrikNoren/ungit/pull/1240)
-  - Include file diff in merge commits [#1242](https://github.com/FredrikNoren/ungit/pull/1242)
-  - Restore icons on graph actions using Octicons [#1245](https://github.com/FredrikNoren/ungit/pull/1245)
-  - Minor fixes to remove warnings [#1235](https://github.com/FredrikNoren/ungit/pull/1235), [#1237](https://github.com/FredrikNoren/ungit/pull/1237), [#1238](https://github.com/FredrikNoren/ungit/pull/1238), [#1239](https://github.com/FredrikNoren/ungit/pull/1239)
-- 1.4.48: fix the width value of the header logo [#1221](https://github.com/FredrikNoren/ungit/pull/1221)
-- 1.4.47: make diff2html line numbers and +/- prefixes unselectable [#1214](https://github.com/FredrikNoren/ungit/issues/1214), [#1215](https://github.com/FredrikNoren/ungit/pull/1215)
-- 1.4.46: force git out put to be in English within ungit [#1208](https://github.com/FredrikNoren/ungit/pull/1208)
-- 1.4.45: Improve styling of .gitignore edit dialog [#1205](https://github.com/FredrikNoren/ungit/pull/1205)
-- 1.4.44: add config to disable numstat in staged diff to better performance [#1193](https://github.com/FredrikNoren/ungit/issues/1193)
-- 1.4.43:
-  - fix gitignore manual edit not being saved [#644](https://github.com/FredrikNoren/ungit/issues/644)
-  - fix issue with detached git processes on some OS and timeout not being enforced.
-  - simplify `maxSearchIteration` enforcement for git.log()
-  - change `alwaysLoadActiveBranch` boolean config to `maxActiveBranchSearchIteration` numeric config
-  - bumped node engine requirement to [10.14 Dubnium](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.14.2)
-- 1.4.42: Add "Ignore white space" config [#1185](https://github.com/FredrikNoren/ungit/pull/1185)
-- 1.4.41: Remove Google Analytics [#1182](https://github.com/FredrikNoren/ungit/pull/1182)
-- 1.4.40: Remove Keen.io [#1180](https://github.com/FredrikNoren/ungit/pull/1180)
-- 1.4.39: Add git bin path config. [#1151](https://github.com/FredrikNoren/ungit/issues/1151)
-- 1.4.38: Fix: Highlight current branch in submodules
-- 1.4.37: Sort modules by names
-- 1.4.36: fix changing remotes in remotes dropdown [#1158](https://github.com/FredrikNoren/ungit/pull/1158)
-- 1.4.35:
-  - allow disabling of nprogress bar [#1143](https://github.com/FredrikNoren/ungit/issues/1143)
-  - set `ungitVersionCheckOverride` as boolean in config [#1102](https://github.com/FredrikNoren/ungit/issues/1102)
-- 1.4.34: fix issues when remote tags doesn't show [#1139](https://github.com/FredrikNoren/ungit/issues/1139)
-- 1.4.33:
-  - Bump getmac version [#1130](https://github.com/FredrikNoren/ungit/issues/1130)
-  - Add config to disable animation [#1136](https://github.com/FredrikNoren/ungit/issues/1136)
-  - dependency bumps
-  - Remove node6. Add node8 and node9 explicitly.
-- 1.4.32:
-  - Handle crashes with better logs
-  - Wrap localStorage to support environments without access to it
-- 1.4.31: Add error logging for npm publish
-- 1.4.30: Add `ungitBindIp` config to allow default binding in some cases [#1112](https://github.com/FredrikNoren/ungit/issues/1112)
-- 1.4.29:
-  - Add `--no-optional-locks` if git version is appropriate [#1105](https://github.com/FredrikNoren/ungit/issues/1105)
-  - Ensure ungit server to bind to `127.0.0.1` [#988](https://github.com/FredrikNoren/ungit/issues/988)
-  - Add node highlight on mouse hover on relationship path [#1093](https://github.com/FredrikNoren/ungit/issues/1093)
-- 1.4.28: adding raven locally for offline access. [#1107](https://github.com/FredrikNoren/ungit/pull/1107)
-- 1.4.27: logic change for the merge conflict resolution
-- 1.4.26: add a way to preconfigure repo lists [#1106](https://github.com/FredrikNoren/ungit/issues/1106)
-- 1.4.25: add git pgp signing docs and code [#740](https://github.com/FredrikNoren/ungit/issues/740)
-- 1.4.24:
-  - change `/api/log` -> `/api/gitlog` as some ad blockers really hates This
-  - Fix excessive error messaging when disconnected from internet
-  - Fix Raven initialization error when disconnected from internet
-- 1.4.23:
-  - add feature to do `--recurse-submodules` for git clone [#1080](https://www.gnupg.org/documentation/manpage.html
-  - increase debounce 250->500 wait and 1000->2000 sec so UI can pick up server changes more accurately
-- 1.4.22: Fix missing jQuery and jQuery UI references [#1086](https://github.com/FredrikNoren/ungit/issues/1086)
-- 1.4.21: Treat remote fetch fail as an warning rather than error [#1081](https://github.com/FredrikNoren/ungit/issues/1081)
-- 1.4.20:
-  - deleted checked in 3rd party codes and manage by npm.
-  - remove dependencies on async lib
-- 1.4.19:
-  - fix credential helper not fetching all the authentication data [#1078](https://github.com/FredrikNoren/ungit/pull/1078)
-- 1.4.18:
-  - fix inaccurate git state issue when new branch name conflict and `autoCheckoutOnBranchCreate` is enabled.
-  - Add content refresh on .gitignore file change
-  - fix reference filtering
-- 1.4.17: fix textarea with in dialog when editing .gitignore [#1068](https://github.com/FredrikNoren/ungit/pull/1068)
-- 1.4.16: Move version number to below logo. [#1069](https://github.com/FredrikNoren/ungit/pull/1069)
-- 1.4.15: fix not setting `pathToNavigateTo` properly when `launchBrowser` is false and `launchCommand` is set [#1065](https://github.com/FredrikNoren/ungit/issues/1065)
-- 1.4.14: fix credential helper when ungit is used with rootpath [#1060](https://github.com/FredrikNoren/ungit/issues/1060)
-- 1.4.13:
-  - Change raven web client source to CDN rather than local copy [#972](https://github.com/FredrikNoren/ungit/issues/972)
-  - dependency bump
-- 1.4.12:
-  - Adding internet disconnected state handling [#1014](https://github.com/FredrikNoren/ungit/issues/1014)
-  - Allow editing .gitignore via ungit [#976](https://github.com/FredrikNoren/ungit/issues/1014)
-- 1.4.11:
-  - differentiate remote vs local tag. [#1016](https://github.com/FredrikNoren/ungit/issues/1016)
-  - fix push not throwing giterror
-  - fix remote tag push not creating remote tag
-  - change ref refresh logic
-  - show error on incorrect credentials [#1042](https://github.com/FredrikNoren/ungit/pull/1042)
-  - allow credential handling for remotes [#1039](https://github.com/FredrikNoren/ungit/issues/1039)
-  - add cancel button for empty commits and amends [#1029](https://github.com/FredrikNoren/ungit/issues/1029)
-  - cleanup clicktest output [#1035](https://github.com/FredrikNoren/ungit/pull/1035)
-- 1.4.10:
-  - hide / disable push option if there is no remote [#1050](https://github.com/FredrikNoren/ungit/issues/1050)
-  - add commit & push option [#1038](https://github.com/FredrikNoren/ungit/issues/1038)
-- 1.4.9:
-  - handle failed promises [#1017](https://github.com/FredrikNoren/ungit/issues/1017)
-  - empty commit [#1028](https://github.com/FredrikNoren/ungit/issues/1028)
-  - fix commit detail layout while hovering over commit node [#1025](https://github.com/FredrikNoren/ungit/issues/1025)
-- 1.4.8: fix remote branches display name and delete action [#1032](https://github.com/FredrikNoren/ungit/issues/1032), [#1031](https://github.com/FredrikNoren/ungit/issues/1031)
-- 1.4.7: add remote branches to the branch list. [#966](https://github.com/FredrikNoren/ungit/issues/966)
-- 1.4.6:
-  - dependency bump to fix dependency's security problem.
-  - Add emphasis if remote branch delete for confirmation dialog. [#947](https://github.com/FredrikNoren/ungit/issues/947)
-- 1.4.5: fix a bug where no diff wasn't properly showing [#969](https://github.com/FredrikNoren/ungit/issues/969)
-- 1.4.4:
-  - fix a bug where fetch is disabled after page load
-  - make `forceLaunchPath` to supersede `launchBrowser` [#1006](https://github.com/FredrikNoren/ungit/issues/1006)
-- 1.4.3: changing to path navigation to `nprogress` bar. [#1001](https://github.com/FredrikNoren/ungit/issues/1001)
-- 1.4.2:
-  - fix navigation redirection on git clone and adding xkcd image
-  - dependency bump
-- 1.4.1:
-  - fix the issue where browser opens before ungit start. [#994](https://github.com/FredrikNoren/ungit/issues/994)
-  - including xkcd art back [#999](https://github.com/FredrikNoren/ungit/issues/999)
-- 1.4.0: Revert to MIT [#947](https://github.com/FredrikNoren/ungit/issues/974)
-- 1.3.3: fix `tagsToDisplay` clearing issue. [#973](https://github.com/FredrikNoren/ungit/issues/973)
-- 1.3.2: Adding in ref search box and limit num of ref display [#973](https://github.com/FredrikNoren/ungit/issues/973)
-- 1.3.1: Add link to plans & license in header [#947](https://github.com/FredrikNoren/ungit/issues/974)
-- 1.3.0: Switch to Faircode paywall instead of license popup [#947](https://github.com/FredrikNoren/ungit/issues/974)
-- 1.2.3: Bump license text to v0.2.1 (fixes typo). [Faircode License changelog](https://github.com/faircodeio/faircode-license/blob/master/CHANGELOG.md)
-- 1.2.2: Bump license text to v0.2 to fix two small inconsistencies: Clarify currency (USD) and remove "no additional rights" clause as it's problematic and superfluous. License changelog at https://github.com/faircodeio/faircode-license/blob/master/CHANGELOG.md [#947](https://github.com/FredrikNoren/ungit/issues/974)
-- 1.2.1: fix for not launching browser when executed at the git repo [#986](https://github.com/FredrikNoren/ungit/issues/986)
-- 1.2.0:
-  - Show license notification on first start (license changed in 1.1.32) [#947](https://github.com/FredrikNoren/ungit/issues/974)
-  - fix potential memory leak with `express-session`[#977](https://github.com/FredrikNoren/ungit/issues/977)
-  - Fix document title on windows [#983](https://github.com/FredrikNoren/ungit/pull/983)
-  - parse local storage as json instead of regex [#981](https://github.com/FredrikNoren/ungit/pull/981)
-  - resolve path keywords such as `~` at server side [#980](https://github.com/FredrikNoren/ungit/issues/975)
-- 1.1.33:
-  - Make Logo and favicon HiDpi [#589](https://github.com/FredrikNoren/ungit/issues/589)
-  - Remove forever-monitor [#961](https://github.com/FredrikNoren/ungit/issues/961)
-- 1.1.32: Update license [#974](https://github.com/FredrikNoren/ungit/issues/974)
-- 1.1.31: Bump dependencies
-- 1.1.30:
-  - move unit tests to es6
-  - Add squash feature [#129](https://github.com/FredrikNoren/ungit/issues/129)
-- 1.1.29: move `Gruntfile.js` to es6
-- 1.1.28: please append your changes to here instead of new version.
-  - Refactoring to remove static data-ta tags from tests
-  - `grunt nmclicktest` -> `grunt clicktest`
-  - Stabilize ungit open test of clicktest via using a tag that is guaranteed to be generated
-  - Add click test bailout on tes failure
-  - Add parallel click test `grunt clickParallel`
-  - Remove deps to fix config init bug for the `credentials-helper`. [#838](https://github.com/FredrikNoren/ungit/issues/838)
-- 1.1.27: Add alert when moving back in time. [#914](https://github.com/FredrikNoren/ungit/issues/914)
-- 1.1.26:
-  - fix invalid path input for autocomplete causing front end crash [#942](https://github.com/FredrikNoren/ungit/issues/942)
-  - bump and checking in package-lock.json
-- 1.1.25: Change stash pop operation to stash apply [#919](https://github.com/FredrikNoren/ungit/issues/919)
-- 1.1.24: fix some commands not properly reporting git error [#933](https://github.com/FredrikNoren/ungit/issues/933)
-- 1.1.23: finalize nightmare click test
-- 1.1.22: Add a config setting to allow setting the default diff type. [#929](https://github.com/FredrikNoren/ungit/issues/929)
-- 1.1.21:
-  - Initial refactoring of click test using nightmare and mocha
-  - **Dropping support for node 4.x and 5.x!, 6.x and later is now supported.**
-- 1.1.20: Hide credentials in remote urls at home repo list
-- 1.1.19: Ask before deleting a stash
-- 1.1.18: Fix checking out remote refs (again)
-- 1.1.17: Fix checking out remote refs
-- 1.1.16:
-  - clicktests logging correction and using wait for within tests.
-  - Refactor filewatch and using normalized test path
-  - throttle parallel test's parellelization limit
-  - dependency bump
-  - Fix context issue for `gitSetUserConfig` [#912](https://github.com/FredrikNoren/ungit/issues/912)
-- 1.1.15: Updating crash page with instructions and adblock detection
-- 1.1.14: Disable strict mode for startup params and config [#890](https://github.com/FredrikNoren/ungit/issues/890)
-- 1.1.13: Fix startup args bug: [#896](https://github.com/FredrikNoren/ungit/issues/896)
-- 1.1.12:
-  - Retain commit messages when commit fails [#882](https://github.com/FredrikNoren/ungit/pull/882)
-  - Fix rare edge case where remote node is gone during reset op.
-  - rescursively resolve all promises before caching them. [#878](https://github.com/FredrikNoren/ungit/pull/878)
-- 1.1.11:
-    - Fix cli arguments [#871](https://github.com/FredrikNoren/ungit/pull/871)
-    - Stop if ~/.ungitrc contains syntax error
-    - Removed official support ini format of ~/.ungitrc, because internal API supports only JSON
-- 1.1.10: Fix broken diff out in some cases when diff contains table. [#881](https://github.com/FredrikNoren/ungit/pull/881)
-- 1.1.9: Fix around ubuntu's inability to cache promises. [#877](https://github.com/FredrikNoren/ungit/pull/878)
-- 1.1.8:
-    - Realtime text diff via invalidate diff on directory change [#867](https://github.com/FredrikNoren/ungit/pull/867)
-    - Promisify `./source/utils/cache.js` [#870](https://github.com/FredrikNoren/ungit/pull/870)
-    - Fix load more text diff button. [#876](https://github.com/FredrikNoren/ungit/pull/876)
-- 1.1.7:
-    - Fix diff flickering issue and optimization [#865](https://github.com/FredrikNoren/ungit/pull/865)
-    - Fix credential dialog issue [#864](https://github.com/FredrikNoren/ungit/pull/864)
-    - Fix HEAD branch order when redraw [#858](https://github.com/FredrikNoren/ungit/issues/858)
-- 1.1.6: Fix path auto complete [#861](https://github.com/FredrikNoren/ungit/issues/861)
-- 1.1.5: Update "Toggle all" button after commit or changing selected files [#859](https://github.com/FredrikNoren/ungit/issues/859)
-- 1.1.4: [patch] Promise refactoring
-- 1.1.3: [patch] Fix submodule navigation on windows [#577](https://github.com/FredrikNoren/ungit/issues/577)
-- 1.1.2: Fix a bug that prevented the new version dialog from being dismissed
-- 1.1.1: [patch] Fixed small spelling error for ignore whitespace feature [#853](https://github.com/FredrikNoren/ungit/pull/853)
-- 1.1.0: Added option to ignore ungit version checks [#851](https://github.com/FredrikNoren/ungit/issues/851)
-- 1.0.1: [patch] Fixed gravatar avatar fetch if email have different cases applied. [#847](https://github.com/FredrikNoren/ungit/issues/847)
-- 1.0.0: Introduced Continuous delivery. [#823](https://github.com/FredrikNoren/ungit/issues/823)
+## Unreleased
+- Updated Octicons [#1224](https://github.com/FredrikNoren/ungit/pull/1224)
+- Hide diff buttons on hover [#1225](https://github.com/FredrikNoren/ungit/pull/1225)
+- Fix stash tooltips [#1227](https://github.com/FredrikNoren/ungit/pull/1227)
+- Improve git-init experience [#1228](https://github.com/FredrikNoren/ungit/pull/1228)
+- Fix inconsistent diff options [#1229](https://github.com/FredrikNoren/ungit/issues/1229)
+- Fix clearing .gitignore [#1236](https://github.com/FredrikNoren/ungit/pull/1236)
+- Fix electron package [#1240](https://github.com/FredrikNoren/ungit/pull/1240)
+- Include file diff in merge commits [#1242](https://github.com/FredrikNoren/ungit/pull/1242)
+- Restore icons on graph actions using Octicons [#1245](https://github.com/FredrikNoren/ungit/pull/1245)
+- Minor fixes to remove warnings [#1235](https://github.com/FredrikNoren/ungit/pull/1235), [#1237](https://github.com/FredrikNoren/ungit/pull/1237), [#1238](https://github.com/FredrikNoren/ungit/pull/1238), [#1239](https://github.com/FredrikNoren/ungit/pull/1239)
+
+## [1.4.48](https://github.com/FredrikNoren/ungit/compare/v1.4.47...v1.4.48)
+
+### Fixed
+- fix the width value of the header logo [#1221](https://github.com/FredrikNoren/ungit/pull/1221)
+
+## [1.4.47](https://github.com/FredrikNoren/ungit/compare/v1.4.46...v1.4.47)
+
+### Fixed
+- make diff2html line numbers and +/- prefixes unselectable [#1214](https://github.com/FredrikNoren/ungit/issues/1214), [#1215](https://github.com/FredrikNoren/ungit/pull/1215)
+
+## [1.4.46](https://github.com/FredrikNoren/ungit/compare/v1.4.45...v1.4.46)
+
+### Fixed
+- force git out put to be in English within ungit [#1208](https://github.com/FredrikNoren/ungit/pull/1208)
+
+## [1.4.45](https://github.com/FredrikNoren/ungit/compare/v1.4.44...v1.4.45)
+
+### Fixed
+- Improve styling of .gitignore edit dialog [#1205](https://github.com/FredrikNoren/ungit/pull/1205)
+
+## [1.4.44](https://github.com/FredrikNoren/ungit/compare/v1.4.43...v1.4.44)
+
+### Added
+- add config to disable numstat in staged diff to better performance [#1193](https://github.com/FredrikNoren/ungit/issues/1193)
+
+## [1.4.43](https://github.com/FredrikNoren/ungit/compare/v1.4.42...v1.4.43)
+
+### Fixed
+- fix gitignore manual edit not being saved [#644](https://github.com/FredrikNoren/ungit/issues/644)
+- fix issue with detached git processes on some OS and timeout not being enforced.
+- simplify `maxSearchIteration` enforcement for git.log()
+- change `alwaysLoadActiveBranch` boolean config to `maxActiveBranchSearchIteration` numeric config
+- bumped node engine requirement to [10.14 Dubnium](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.14.2)
+
+## [1.4.42](https://github.com/FredrikNoren/ungit/compare/v1.4.41...v1.4.42)
+
+### Fixed
+- Add "Ignore white space" config [#1185](https://github.com/FredrikNoren/ungit/pull/1185)
+
+## [1.4.41](https://github.com/FredrikNoren/ungit/compare/v1.4.40...v1.4.41)
+
+### Removed
+- Remove Google Analytics [#1182](https://github.com/FredrikNoren/ungit/pull/1182)
+
+## [1.4.40](https://github.com/FredrikNoren/ungit/compare/v1.4.39...v1.4.40)
+
+### Removed
+- Remove Keen.io [#1180](https://github.com/FredrikNoren/ungit/pull/1180)
+
+## [1.4.39](https://github.com/FredrikNoren/ungit/compare/v1.4.38...v1.4.39)
+
+### Fixed
+- Add git bin path config. [#1151](https://github.com/FredrikNoren/ungit/issues/1151)
+
+## [1.4.38](https://github.com/FredrikNoren/ungit/compare/v1.4.37...v1.4.38)
+
+### Fixed
+- Fix: Highlight current branch in submodules
+
+## [1.4.37](https://github.com/FredrikNoren/ungit/compare/v1.4.36...v1.4.37)
+
+### Fixed
+- Sort modules by names
+
+## [1.4.36](https://github.com/FredrikNoren/ungit/compare/v1.4.35...v1.4.36)
+
+### Fixed
+- fix changing remotes in remotes dropdown [#1158](https://github.com/FredrikNoren/ungit/pull/1158)
+
+## [1.4.35](https://github.com/FredrikNoren/ungit/compare/v1.4.34...v1.4.35)
+
+### Fixed
+- allow disabling of nprogress bar [#1143](https://github.com/FredrikNoren/ungit/issues/1143)
+- set `ungitVersionCheckOverride` as boolean in config [#1102](https://github.com/FredrikNoren/ungit/issues/1102)
+
+## [1.4.34](https://github.com/FredrikNoren/ungit/compare/v1.4.33...v1.4.34)
+
+### Fixed
+- fix issues when remote tags doesn't show [#1139](https://github.com/FredrikNoren/ungit/issues/1139)
+
+## [1.4.33](https://github.com/FredrikNoren/ungit/compare/v1.4.32...v1.4.33)
+
+### Fixed
+- Bump getmac version [#1130](https://github.com/FredrikNoren/ungit/issues/1130)
+- Add config to disable animation [#1136](https://github.com/FredrikNoren/ungit/issues/1136)
+- dependency bumps
+- Remove node6. Add node8 and node9 explicitly.
+
+## [1.4.32](https://github.com/FredrikNoren/ungit/compare/v1.4.31...v1.4.32)
+
+### Fixed
+- Handle crashes with better logs
+- Wrap localStorage to support environments without access to it
+
+## [1.4.31](https://github.com/FredrikNoren/ungit/compare/v1.4.30...v1.4.31)
+
+### Fixed
+- Add error logging for npm publish
+
+## [1.4.30](https://github.com/FredrikNoren/ungit/compare/v1.4.29...v1.4.30)
+
+### Fixed
+- Add `ungitBindIp` config to allow default binding in some cases [#1112](https://github.com/FredrikNoren/ungit/issues/1112)
+
+## [1.4.29](https://github.com/FredrikNoren/ungit/compare/v1.4.28...v1.4.29)
+
+### Fixed
+- Add `--no-optional-locks` if git version is appropriate [#1105](https://github.com/FredrikNoren/ungit/issues/1105)
+- Ensure ungit server to bind to `127.0.0.1` [#988](https://github.com/FredrikNoren/ungit/issues/988)
+- Add node highlight on mouse hover on relationship path [#1093](https://github.com/FredrikNoren/ungit/issues/1093)
+
+## [1.4.28](https://github.com/FredrikNoren/ungit/compare/v1.4.27...v1.4.28)
+
+### Fixed
+- adding raven locally for offline access. [#1107](https://github.com/FredrikNoren/ungit/pull/1107)
+
+## [1.4.27](https://github.com/FredrikNoren/ungit/compare/v1.4.26...v1.4.27)
+
+### Fixed
+- logic change for the merge conflict resolution
+
+## [1.4.26](https://github.com/FredrikNoren/ungit/compare/v1.4.25...v1.4.26)
+
+### Added
+- add a way to preconfigure repo lists [#1106](https://github.com/FredrikNoren/ungit/issues/1106)
+
+## [1.4.25](https://github.com/FredrikNoren/ungit/compare/v1.4.24...v1.4.25)
+
+### Added
+- add git pgp signing docs and code [#740](https://github.com/FredrikNoren/ungit/issues/740)
+
+## [1.4.24](https://github.com/FredrikNoren/ungit/compare/v1.4.23...v1.4.24)
+
+### Fixed
+- change `/api/log` -> `/api/gitlog` as some ad blockers really hates This
+- Fix excessive error messaging when disconnected from internet
+- Fix Raven initialization error when disconnected from internet
+
+## [1.4.23](https://github.com/FredrikNoren/ungit/compare/v1.4.22...v1.4.23)
+
+### Fixed
+- add feature to do `--recurse-submodules` for git clone [#1080](https://www.gnupg.org/documentation/manpage.html
+- increase debounce 250->500 wait and 1000->2000 sec so UI can pick up server changes more accurately
+
+## [1.4.22](https://github.com/FredrikNoren/ungit/compare/v1.4.21...v1.4.22)
+
+### Fixed
+- Fix missing jQuery and jQuery UI references [#1086](https://github.com/FredrikNoren/ungit/issues/1086)
+
+## [1.4.21](https://github.com/FredrikNoren/ungit/compare/v1.4.20...v1.4.21)
+
+### Fixed
+- Treat remote fetch fail as an warning rather than error [#1081](https://github.com/FredrikNoren/ungit/issues/1081)
+
+## [1.4.20](https://github.com/FredrikNoren/ungit/compare/v1.4.19...v1.4.20)
+
+### Fixed
+- deleted checked in 3rd party codes and manage by npm.
+- remove dependencies on async lib
+
+## [1.4.19](https://github.com/FredrikNoren/ungit/compare/v1.4.18...v1.4.19)
+
+### Fixed
+- fix credential helper not fetching all the authentication data [#1078](https://github.com/FredrikNoren/ungit/pull/1078)
+
+## [1.4.18](https://github.com/FredrikNoren/ungit/compare/v1.4.17...v1.4.18)
+
+### Fixed
+- fix inaccurate git state issue when new branch name conflict and `autoCheckoutOnBranchCreate` is enabled.
+- Add content refresh on .gitignore file change
+- fix reference filtering
+
+## [1.4.17](https://github.com/FredrikNoren/ungit/compare/v1.4.16...v1.4.17)
+
+### Fixed
+- fix textarea with in dialog when editing .gitignore [#1068](https://github.com/FredrikNoren/ungit/pull/1068)
+
+## [1.4.16](https://github.com/FredrikNoren/ungit/compare/v1.4.15...v1.4.16)
+
+### Fixed
+- Move version number to below logo. [#1069](https://github.com/FredrikNoren/ungit/pull/1069)
+
+## [1.4.15](https://github.com/FredrikNoren/ungit/compare/v1.4.14...v1.4.15)
+
+### Fixed
+- fix not setting `pathToNavigateTo` properly when `launchBrowser` is false and `launchCommand` is set [#1065](https://github.com/FredrikNoren/ungit/issues/1065)
+
+## [1.4.14](https://github.com/FredrikNoren/ungit/compare/v1.4.13...v1.4.14)
+
+### Fixed
+- fix credential helper when ungit is used with rootpath [#1060](https://github.com/FredrikNoren/ungit/issues/1060)
+
+## [1.4.13](https://github.com/FredrikNoren/ungit/compare/v1.4.12...v1.4.13)
+
+### Fixed
+- Change raven web client source to CDN rather than local copy [#972](https://github.com/FredrikNoren/ungit/issues/972)
+- dependency bump
+
+## [1.4.12](https://github.com/FredrikNoren/ungit/compare/v1.4.11...v1.4.12)
+
+### Fixed
+- Adding internet disconnected state handling [#1014](https://github.com/FredrikNoren/ungit/issues/1014)
+- Allow editing .gitignore via ungit [#976](https://github.com/FredrikNoren/ungit/issues/1014)
+
+## [1.4.11](https://github.com/FredrikNoren/ungit/compare/v1.4.10...v1.4.11)
+
+### Added
+- add cancel button for empty commits and amends [#1029](https://github.com/FredrikNoren/ungit/issues/1029)
+
+### Fixed
+- differentiate remote vs local tag. [#1016](https://github.com/FredrikNoren/ungit/issues/1016)
+- fix push not throwing giterror
+- fix remote tag push not creating remote tag
+- change ref refresh logic
+- show error on incorrect credentials [#1042](https://github.com/FredrikNoren/ungit/pull/1042)
+- allow credential handling for remotes [#1039](https://github.com/FredrikNoren/ungit/issues/1039)
+- cleanup clicktest output [#1035](https://github.com/FredrikNoren/ungit/pull/1035)
+
+## [1.4.10](https://github.com/FredrikNoren/ungit/compare/v1.4.9...v1.4.10)
+
+### Added
+- add commit & push option [#1038](https://github.com/FredrikNoren/ungit/issues/1038)
+
+### Fixed
+- hide / disable push option if there is no remote [#1050](https://github.com/FredrikNoren/ungit/issues/1050)
+
+## [1.4.9](https://github.com/FredrikNoren/ungit/compare/v1.4.8...v1.4.9)
+
+### Fixed
+- handle failed promises [#1017](https://github.com/FredrikNoren/ungit/issues/1017)
+- empty commit [#1028](https://github.com/FredrikNoren/ungit/issues/1028)
+- fix commit detail layout while hovering over commit node [#1025](https://github.com/FredrikNoren/ungit/issues/1025)
+
+## [1.4.8](https://github.com/FredrikNoren/ungit/compare/v1.4.7...v1.4.8)
+
+### Fixed
+- fix remote branches display name and delete action [#1032](https://github.com/FredrikNoren/ungit/issues/1032), [#1031](https://github.com/FredrikNoren/ungit/issues/1031)
+
+## [1.4.7](https://github.com/FredrikNoren/ungit/compare/v1.4.6...v1.4.7)
+
+### Added
+- add remote branches to the branch list. [#966](https://github.com/FredrikNoren/ungit/issues/966)
+
+## [1.4.6](https://github.com/FredrikNoren/ungit/compare/v1.4.5...v1.4.6)
+
+### Fixed
+- dependency bump to fix dependency's security problem.
+- Add emphasis if remote branch delete for confirmation dialog. [#947](https://github.com/FredrikNoren/ungit/issues/947)
+
+## [1.4.5](https://github.com/FredrikNoren/ungit/compare/v1.4.4...v1.4.5)
+
+### Fixed
+- fix a bug where no diff wasn't properly showing [#969](https://github.com/FredrikNoren/ungit/issues/969)
+
+## [1.4.4](https://github.com/FredrikNoren/ungit/compare/v1.4.3...v1.4.4)
+
+### Fixed
+- fix a bug where fetch is disabled after page load
+- make `forceLaunchPath` to supersede `launchBrowser` [#1006](https://github.com/FredrikNoren/ungit/issues/1006)
+
+## [1.4.3](https://github.com/FredrikNoren/ungit/compare/v1.4.2...v1.4.3)
+
+### Fixed
+- changing to path navigation to `nprogress` bar. [#1001](https://github.com/FredrikNoren/ungit/issues/1001)
+
+## [1.4.2](https://github.com/FredrikNoren/ungit/compare/v1.4.1...v1.4.2)
+
+### Fixed
+- fix navigation redirection on git clone and adding xkcd image
+- dependency bump
+
+## [1.4.1](https://github.com/FredrikNoren/ungit/compare/v1.4.0...v1.4.1)
+
+### Fixed
+- fix the issue where browser opens before ungit start. [#994](https://github.com/FredrikNoren/ungit/issues/994)
+- including xkcd art back [#999](https://github.com/FredrikNoren/ungit/issues/999)
+
+## [1.4.0](https://github.com/FredrikNoren/ungit/compare/v1.3.3...v1.4.0)
+
+### Fixed
+- Revert to MIT [#947](https://github.com/FredrikNoren/ungit/issues/974)
+
+## [1.3.3](https://github.com/FredrikNoren/ungit/compare/v1.3.2...v1.3.3)
+
+### Fixed
+- fix `tagsToDisplay` clearing issue. [#973](https://github.com/FredrikNoren/ungit/issues/973)
+
+## [1.3.2](https://github.com/FredrikNoren/ungit/compare/v1.3.1...v1.3.2)
+
+### Added
+- Adding in ref search box and limit num of ref display [#973](https://github.com/FredrikNoren/ungit/issues/973)
+
+## [1.3.1](https://github.com/FredrikNoren/ungit/compare/v1.3.0...v1.3.1)
+
+### Added
+- Add link to plans & license in header [#947](https://github.com/FredrikNoren/ungit/issues/974)
+
+## [1.3.0](https://github.com/FredrikNoren/ungit/compare/v1.2.3...v1.3.0)
+
+### Fixed
+- Switch to Faircode paywall instead of license popup [#947](https://github.com/FredrikNoren/ungit/issues/974)
+
+## [1.2.3](https://github.com/FredrikNoren/ungit/compare/v1.2.2...v1.2.3)
+
+### Fixed
+- Bump license text to v0.2.1 (fixes typo). [Faircode License changelog](https://github.com/faircodeio/faircode-license/blob/master/CHANGELOG.md)
+
+## [1.2.2](https://github.com/FredrikNoren/ungit/compare/v1.2.1...v1.2.2)
+
+### Fixed
+-  Bump license text to v0.2 to fix two small inconsistencies: Clarify currency (USD) and remove "no additional rights" clause as it's problematic and superfluous. License changelog at https://github.com/faircodeio/faircode-license/blob/master/CHANGELOG.md [#947](https://github.com/FredrikNoren/ungit/issues/974)
+
+## [1.2.1](https://github.com/FredrikNoren/ungit/compare/v1.2.0...v1.2.1)
+
+### Fixed
+- fix for not launching browser when executed at the git repo [#986](https://github.com/FredrikNoren/ungit/issues/986)
+
+## [1.2.0](https://github.com/FredrikNoren/ungit/compare/v1.1.33...v1.2.0)
+
+### Fixed
+- Show license notification on first start (license changed in 1.1.32) [#947](https://github.com/FredrikNoren/ungit/issues/974)
+- fix potential memory leak with `express-session`[#977](https://github.com/FredrikNoren/ungit/issues/977)
+- Fix document title on windows [#983](https://github.com/FredrikNoren/ungit/pull/983)
+- parse local storage as json instead of regex [#981](https://github.com/FredrikNoren/ungit/pull/981)
+- resolve path keywords such as `~` at server side [#980](https://github.com/FredrikNoren/ungit/issues/975)
+
+## [1.1.33](https://github.com/FredrikNoren/ungit/compare/v1.1.32...v1.1.33)
+
+### Fixed
+- Make Logo and favicon HiDpi [#589](https://github.com/FredrikNoren/ungit/issues/589)
+- Remove forever-monitor [#961](https://github.com/FredrikNoren/ungit/issues/961)
+
+## [1.1.32](https://github.com/FredrikNoren/ungit/compare/v1.1.31...v1.1.32)
+
+### Fixed
+- Update license [#974](https://github.com/FredrikNoren/ungit/issues/974)
+
+## [1.1.31](https://github.com/FredrikNoren/ungit/compare/v1.1.30...v1.1.31)
+
+### Fixed
+- Bump dependencies
+
+## [1.1.30](https://github.com/FredrikNoren/ungit/compare/v1.1.29...v1.1.30)
+
+### Fixed
+- move unit tests to es6
+- Add squash feature [#129](https://github.com/FredrikNoren/ungit/issues/129)
+
+## [1.1.29](https://github.com/FredrikNoren/ungit/compare/v1.1.28...v1.1.29)
+
+### Fixed
+- move `Gruntfile.js` to es6
+
+## [1.1.28](https://github.com/FredrikNoren/ungit/compare/v1.1.27...v1.1.28)
+
+### Fixed
+- Refactoring to remove static data-ta tags from tests
+- `grunt nmclicktest` -> `grunt clicktest`
+- Stabilize ungit open test of clicktest via using a tag that is guaranteed to be generated
+- Add click test bailout on tes failure
+- Add parallel click test `grunt clickParallel`
+- Remove deps to fix config init bug for the `credentials-helper`. [#838](https://github.com/FredrikNoren/ungit/issues/838)
+
+## [1.1.27](https://github.com/FredrikNoren/ungit/compare/v1.1.26...v1.1.27)
+
+### Fixed
+- Add alert when moving back in time. [#914](https://github.com/FredrikNoren/ungit/issues/914)
+
+## [1.1.26](https://github.com/FredrikNoren/ungit/compare/v1.1.25...v1.1.26)
+
+### Fixed
+- fix invalid path input for autocomplete causing front end crash [#942](https://github.com/FredrikNoren/ungit/issues/942)
+- bump and checking in package-lock.json
+
+## [1.1.25](https://github.com/FredrikNoren/ungit/compare/v1.1.24...v1.1.25)
+
+### Fixed
+- Change stash pop operation to stash apply [#919](https://github.com/FredrikNoren/ungit/issues/919)
+
+## [1.1.24](https://github.com/FredrikNoren/ungit/compare/v1.1.23...v1.1.24)
+
+### Fixed
+- fix some commands not properly reporting git error [#933](https://github.com/FredrikNoren/ungit/issues/933)
+
+## [1.1.23](https://github.com/FredrikNoren/ungit/compare/v1.1.22...v1.1.23)
+
+### Fixed
+- finalize nightmare click test
+
+## [1.1.22](https://github.com/FredrikNoren/ungit/compare/v1.1.21...v1.1.22)
+
+### Fixed
+- Add a config setting to allow setting the default diff type. [#929](https://github.com/FredrikNoren/ungit/issues/929)
+
+## [1.1.21](https://github.com/FredrikNoren/ungit/compare/v1.1.20...v1.1.21)
+
+### Fixed
+- Initial refactoring of click test using nightmare and mocha
+- **Dropping support for node 4.x and 5.x!, 6.x and later is now supported.**
+
+## [1.1.20](https://github.com/FredrikNoren/ungit/compare/v1.1.19...v1.1.20)
+
+### Fixed
+- Hide credentials in remote urls at home repo list
+
+## [1.1.19](https://github.com/FredrikNoren/ungit/compare/v1.1.18...v1.1.19)
+
+### Fixed
+- Ask before deleting a stash
+
+## [1.1.18](https://github.com/FredrikNoren/ungit/compare/v1.1.17...v1.1.18)
+
+### Fixed
+- Fix checking out remote refs (again)
+
+## [1.1.17](https://github.com/FredrikNoren/ungit/compare/v1.1.16...v1.1.17)
+
+### Fixed
+- Fix checking out remote refs
+
+## [1.1.16](https://github.com/FredrikNoren/ungit/compare/v1.1.15...v1.1.16)
+
+### Fixed
+- clicktests logging correction and using wait for within tests.
+- Refactor filewatch and using normalized test path
+- throttle parallel test's parellelization limit
+- dependency bump
+- Fix context issue for `gitSetUserConfig` [#912](https://github.com/FredrikNoren/ungit/issues/912)
+
+## [1.1.15](https://github.com/FredrikNoren/ungit/compare/v1.1.14...v1.1.15)
+
+### Fixed
+- Updating crash page with instructions and adblock detection
+
+## [1.1.14](https://github.com/FredrikNoren/ungit/compare/v1.1.13...v1.1.14)
+
+### Fixed
+- Disable strict mode for startup params and config [#890](https://github.com/FredrikNoren/ungit/issues/890)
+
+## [1.1.13](https://github.com/FredrikNoren/ungit/compare/v1.1.12...v1.1.13)
+
+### Fixed
+- Fix startup args bug: [#896](https://github.com/FredrikNoren/ungit/issues/896)
+
+## [1.1.12](https://github.com/FredrikNoren/ungit/compare/v1.1.11...v1.1.12)
+
+### Fixed
+- Retain commit messages when commit fails [#882](https://github.com/FredrikNoren/ungit/pull/882)
+- Fix rare edge case where remote node is gone during reset op.
+- rescursively resolve all promises before caching them. [#878](https://github.com/FredrikNoren/ungit/pull/878)
+
+## [1.1.11](https://github.com/FredrikNoren/ungit/compare/v1.1.10...v1.1.11)
+
+### Fixed
+- Fix cli arguments [#871](https://github.com/FredrikNoren/ungit/pull/871)
+- Stop if ~/.ungitrc contains syntax error
+- Removed official support ini format of ~/.ungitrc, because internal API supports only JSON
+
+## [1.1.10](https://github.com/FredrikNoren/ungit/compare/v1.1.9...v1.1.10)
+
+### Fixed
+- Fix broken diff out in some cases when diff contains table. [#881](https://github.com/FredrikNoren/ungit/pull/881)
+
+## [1.1.9](https://github.com/FredrikNoren/ungit/compare/v1.1.8...v1.1.9)
+
+### Fixed
+- Fix around ubuntu's inability to cache promises. [#877](https://github.com/FredrikNoren/ungit/pull/878)
+
+## [1.1.8](https://github.com/FredrikNoren/ungit/compare/v1.1.7...v1.1.8)
+
+### Fixed
+- Realtime text diff via invalidate diff on directory change [#867](https://github.com/FredrikNoren/ungit/pull/867)
+- Promisify `./source/utils/cache.js` [#870](https://github.com/FredrikNoren/ungit/pull/870)
+- Fix load more text diff button. [#876](https://github.com/FredrikNoren/ungit/pull/876)
+
+## [1.1.7](https://github.com/FredrikNoren/ungit/compare/v1.1.6...v1.1.7)
+
+### Fixed
+- Fix diff flickering issue and optimization [#865](https://github.com/FredrikNoren/ungit/pull/865)
+- Fix credential dialog issue [#864](https://github.com/FredrikNoren/ungit/pull/864)
+- Fix HEAD branch order when redraw [#858](https://github.com/FredrikNoren/ungit/issues/858)
+
+## [1.1.6](https://github.com/FredrikNoren/ungit/compare/v1.1.5...v1.1.6)
+
+### Fixed
+- Fix path auto complete [#861](https://github.com/FredrikNoren/ungit/issues/861)
+
+## [1.1.5](https://github.com/FredrikNoren/ungit/compare/v1.1.4...v1.1.5)
+
+### Fixed
+- Update "Toggle all" button after commit or changing selected files [#859](https://github.com/FredrikNoren/ungit/issues/859)
+
+## [1.1.4](https://github.com/FredrikNoren/ungit/compare/v1.1.3...v1.1.4)
+
+### Fixed
+- [patch] Promise refactoring
+
+## [1.1.3](https://github.com/FredrikNoren/ungit/compare/v1.1.2...v1.1.3)
+
+### Fixed
+- [patch] Fix submodule navigation on windows [#577](https://github.com/FredrikNoren/ungit/issues/577)
+
+## [1.1.2](https://github.com/FredrikNoren/ungit/compare/v1.1.1...v1.1.2)
+
+### Fixed
+- Fix a bug that prevented the new version dialog from being dismissed
+
+## [1.1.1](https://github.com/FredrikNoren/ungit/compare/v1.1.0...v1.1.1)
+
+### Fixed
+- [patch] Fixed small spelling error for ignore whitespace feature [#853](https://github.com/FredrikNoren/ungit/pull/853)
+
+## [1.1.0](https://github.com/FredrikNoren/ungit/compare/v1.0.1...v1.1.0)
+
+### Added
+- Added option to ignore ungit version checks [#851](https://github.com/FredrikNoren/ungit/issues/851)
+
+## [1.0.1](https://github.com/FredrikNoren/ungit/compare/v1.0.0...v1.0.1)
+
+### Fixed
+- [patch] Fixed gravatar avatar fetch if email have different cases applied. [#847](https://github.com/FredrikNoren/ungit/issues/847)
 
 ## [1.0.0](https://github.com/FredrikNoren/ungit/compare/v0.10.3...v1.0.0)
 
@@ -206,6 +547,7 @@ Use the following format for additions: ` - VERSION: [feature/patch (if applicab
 - Fix for favorites linking in case rootPath is used @sebastianmay [#609](https://github.com/FredrikNoren/ungit/issues/609) and image diffing
 - Limit commit title to 72 characters, the rest is truncated and shown when inspecting the commit
 - Updated file watch logic to closely follow git commands in another process [#283](https://github.com/FredrikNoren/ungit/issues/283)
+- Introduced Continuous delivery. [#823](https://github.com/FredrikNoren/ungit/issues/823)
 
 ### Fixed
 - File diff firing increasing number of events longer it survives.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -208,6 +208,17 @@ module.exports = (grunt) => {
         }
       }
     },
+    zip_directories: {
+      electron: {
+        files: [{
+          filter: 'isDirectory',
+          expand: true,
+          cwd: './build',
+          dest: './dist',
+          src: '*'
+        }]
+      }
+    },
     mocha_istanbul: {
       unit: {
         src: './test',
@@ -343,6 +354,8 @@ module.exports = (grunt) => {
     });
   });
 
+  grunt.registerTask('electronpublish', ['zip_directories:electron']);
+
   /**
    * Run clicktest in parallel at test suite level.
    * This test does intermittently fails depends on the maxConcurrency level set
@@ -445,6 +458,7 @@ module.exports = (grunt) => {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-mocha-istanbul');
   grunt.loadNpmTasks('grunt-babel');
+  grunt.loadNpmTasks('grunt-zip-directories');
 
   // Default task, builds everything needed
   grunt.registerTask('default', ['clean:babel', 'less:production', 'jshint', 'babel:prod', 'browserify-common', 'browserify-components', 'lineending:production', 'imageEmbed:default', 'copy:main', 'imagemin:default']);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,9 @@ before_test:
 
 test_script:
   - npm test
+
+after_test:
+  - npm run electronpublish
+
+artifacts:
+  - path: dist\*.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,55 @@
         }
       }
     },
+    "archiver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.2.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.15",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -1693,7 +1742,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "got": {
           "version": "8.3.2",
@@ -1752,6 +1802,7 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -1870,13 +1921,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "boolean": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-2.0.2.tgz",
       "integrity": "sha512-ymsbJQlux/uogyEWfsXJUYzuyoOzPyp6NvEV71s6/ptQR7ptKO9uHF+WZL2GRATDeN52EFhNyrIu+exNZKh3Cw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "boom": {
       "version": "0.4.2",
@@ -2288,6 +2341,7 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "get-proxy": "^2.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -2594,6 +2648,18 @@
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2615,6 +2681,7 @@
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -2632,7 +2699,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true
     },
     "console-stream": {
       "version": "0.1.1",
@@ -2712,6 +2780,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "dev": true,
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -2983,6 +3070,7 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -3008,6 +3096,7 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -3018,7 +3107,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3027,6 +3117,7 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -3039,7 +3130,8 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
           "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3048,6 +3140,7 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -3058,7 +3151,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3067,6 +3161,7 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -3079,6 +3174,7 @@
           "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "pend": "~1.2.0"
           }
@@ -3087,13 +3183,15 @@
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
@@ -3104,6 +3202,7 @@
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
           "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-crc32": "~0.2.3",
             "fd-slicer": "~1.1.0"
@@ -4459,6 +4558,7 @@
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "^1.28.0"
       }
@@ -4468,6 +4568,7 @@
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -4692,13 +4793,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "filenamify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -5150,6 +5253,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "npm-conf": "^1.1.0"
       }
@@ -5403,7 +5507,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "growl": {
       "version": "1.10.5",
@@ -6069,6 +6174,33 @@
         }
       }
     },
+    "grunt-zip-directories": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-zip-directories/-/grunt-zip-directories-1.0.1.tgz",
+      "integrity": "sha512-ntZ/yR9eMAElOqDxdvmU8xupb3Y73jZtFgDLtHpfq/5DZ8y42iO9BGA43BdGGICh5CJQzDwNYFz4fyFBA3zijw==",
+      "dev": true,
+      "requires": {
+        "archiver": "^2.0.3",
+        "async": "^2.5.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
     "handlebars": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
@@ -6151,7 +6283,8 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -6164,6 +6297,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -6821,7 +6955,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -6847,13 +6982,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6896,7 +7033,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -7058,6 +7196,7 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
@@ -7264,6 +7403,15 @@
       "requires": {
         "inherits": "^2.0.1",
         "stream-splicer": "^2.0.0"
+      }
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
       }
     },
     "lcid": {
@@ -7541,7 +7689,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -8235,6 +8384,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         }
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-url": {
@@ -11328,6 +11486,7 @@
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
@@ -11337,7 +11496,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11767,6 +11927,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
+      "optional": true,
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -12224,7 +12385,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -12552,6 +12714,12 @@
         }
       }
     },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -12777,6 +12945,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.8.1"
       },
@@ -12786,6 +12955,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -13252,6 +13422,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
@@ -13261,6 +13432,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "sort-keys": "^1.0.0"
       }
@@ -13533,6 +13705,7 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-natural-number": "^4.0.1"
       }
@@ -13561,6 +13734,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -13840,13 +14014,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
       "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "tempfile": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
@@ -13884,7 +14060,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "timers-browserify": {
       "version": "1.4.2",
@@ -14048,6 +14225,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -14231,6 +14409,7 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
       "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -14375,7 +14554,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "use": {
       "version": "3.1.1",
@@ -14842,6 +15022,18 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "grunt",
     "watch": "grunt watch",
     "package": "grunt package",
-    "travisnpmpublish": "grunt travisnpmpublish"
+    "travisnpmpublish": "grunt travisnpmpublish",
+    "electronpublish": "grunt electronpublish"
   },
   "repository": {
     "type": "git",
@@ -90,6 +91,7 @@
     "grunt-mocha-test": "~0.13.3",
     "grunt-plato": "~1.4.0",
     "grunt-release": "~0.14.0",
+    "grunt-zip-directories": "^1.0.1",
     "istanbul": "~0.4.5",
     "mocha": "~6.1.4",
     "nightmare": "~3.0.2",


### PR DESCRIPTION
based on #1240 this will create a `dist` folder which contains all zipped builds from electron.
These zips are uploaded as artifacts on AppVeyor for every build and can be release by Travis if a commit in the `master` branch is tagged.

Maybe we want to automatically create tags during builds on master which then starts another build which creates the actual release.

fixes https://github.com/FredrikNoren/ungit/issues/1218
fixes https://github.com/FredrikNoren/ungit/issues/1222