### PR TITLE
Include file diff in merge commits (see #1167)

### DIFF
--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -437,7 +437,7 @@ git.revParse = (repoPath) => {
 }
 
 git.log = (path, limit, skip, maxActiveBranchSearchIteration) => {
-  return git(['log', '--decorate=full', '--show-signature', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${limit}`, `--skip=${skip}`], path)
+  return git(['log', '--cc', '--decorate=full', '--show-signature', '--date=default', '--pretty=fuller', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${limit}`, `--skip=${skip}`], path)
     .then(gitParser.parseGitLog)
     .then((log) => {
       log = log ? log : [];

--- a/test/spec.git-api.conflict.js
+++ b/test/spec.git-api.conflict.js
@@ -200,6 +200,16 @@ describe('git-api conflict merge', function () {
     return common.post(req, '/merge/continue', { path: testDir, message: 'something' });
   });
 
+  it('log should show changes on the merge commit', () => {
+    return common.get(req, '/gitlog', { path: testDir }).then((res) => {
+      expect(res.nodes).to.be.a('array');
+      expect(res.nodes.length).to.be(4);
+      expect(res.nodes[0].fileLineDiffs.length).to.be(2);
+      expect(res.nodes[0].fileLineDiffs[0]).to.eql([1, 1, 'Total']);
+      expect(res.nodes[0].fileLineDiffs[1]).to.eql([1, 1, testFile1, 'text']);
+    });
+  });
+
 });
 
 


### PR DESCRIPTION
This PR takes the change from #1167 by @ylecuyer and adds a simpler test.

I am using the existing merge-conflict test, which doesn't fit perfectly, but is the only one I found that uses merging.