### PR TITLE
Remove Node 8 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - node
   - "12"
   - "10"
-  - "8"
 branches:
   only:
     - master
@@ -17,8 +16,6 @@ matrix:
     - node_js: "12"
       env: GIT_VERSION=edge
     - node_js: "10"
-      env: GIT_VERSION=edge
-    - node_js: "8"
       env: GIT_VERSION=edge
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   - nodejs_version: "" # latest
   - nodejs_version: "12"
   - nodejs_version: "10"
-  - nodejs_version: "8"
 
 branches:
   only:


### PR DESCRIPTION
The node requirement in `package.json` is at least Node 10. Skipping builds for Node 8 should speed up the CI checks.

https://github.com/FredrikNoren/ungit/blob/eac5134c90d9198857fdd46e8d1e88b05f82715a/package.json#L98