### PR TITLE
Restore icons on graph actions using Octicons

### DIFF
--- a/components/graph/git-graph-actions.js
+++ b/components/graph/git-graph-actions.js
@@ -1,4 +1,5 @@
 const ko = require('knockout');
+const octicons = require('octicons');
 const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
 const RefViewModel = require('./git-ref.js');
@@ -59,7 +60,7 @@ class ActionBase {
 
 class Move extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Move', 'move', 'glyph_icon glyph_icon-move');
+    super(graph, 'Move', 'move', octicons['arrow-left'].toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -76,7 +77,7 @@ class Move extends ActionBase {
 
 class Reset extends ActionBase {
   constructor (graph, node) {
-    super(graph, 'Reset', 'reset', 'glyph_icon glyph_icon-trash');
+    super(graph, 'Reset', 'reset', octicons.trashcan.toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -115,7 +116,7 @@ class Reset extends ActionBase {
 
 class Rebase extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Rebase', 'rebase', 'oct_icon oct_icon-repo-forked flip');
+    super(graph, 'Rebase', 'rebase', octicons['repo-forked'].toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -143,7 +144,7 @@ class Rebase extends ActionBase {
 
 class Merge extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Merge', 'merge', 'oct_icon oct_icon-git-merge');
+    super(graph, 'Merge', 'merge', octicons['git-merge'].toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -170,7 +171,7 @@ class Merge extends ActionBase {
 
 class Push extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Push', 'push', 'oct_icon oct_icon-cloud-upload');
+    super(graph, 'Push', 'push', octicons['repo-push'].toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -207,7 +208,7 @@ class Push extends ActionBase {
 
 class Checkout extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Checkout', 'checkout', 'oct_icon oct_icon-desktop-download');
+    super(graph, 'Checkout', 'checkout', octicons['desktop-download'].toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -227,7 +228,7 @@ class Checkout extends ActionBase {
 
 class Delete extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Delete', 'delete', 'glyph_icon glyph_icon-remove');
+    super(graph, 'Delete', 'delete', octicons.x.toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -256,7 +257,7 @@ class Delete extends ActionBase {
 
 class CherryPick extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Cherry pick', 'cherry-pick', 'oct_icon oct_icon-circuit-board');
+    super(graph, 'Cherry pick', 'cherry-pick', octicons['circuit-board'].toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -274,7 +275,7 @@ class CherryPick extends ActionBase {
 
 class Uncommit extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Uncommit', 'uncommit', 'oct_icon oct_icon-zap');
+    super(graph, 'Uncommit', 'uncommit', octicons.zap.toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -299,7 +300,7 @@ class Uncommit extends ActionBase {
 
 class Revert extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Revert', 'revert', 'oct_icon oct_icon-history');
+    super(graph, 'Revert', 'revert', octicons.history.toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
@@ -315,7 +316,7 @@ class Revert extends ActionBase {
 
 class Squash extends ActionBase {
   constructor(graph, node) {
-    super(graph, 'Squash', 'squash', 'oct_icon oct_icon-fold');
+    super(graph, 'Squash', 'squash', octicons.fold.toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;

--- a/components/graph/git-graph-actions.js
+++ b/components/graph/git-graph-actions.js
@@ -1,35 +1,33 @@
-
 const ko = require('knockout');
-const inherits = require('util').inherits;
 const components = require('ungit-components');
+const programEvents = require('ungit-program-events');
 const RefViewModel = require('./git-ref.js');
 const HoverActions = require('./hover-actions');
-const programEvents = require('ungit-program-events');
+
 const RebaseViewModel = HoverActions.RebaseViewModel;
 const MergeViewModel = HoverActions.MergeViewModel;
 const ResetViewModel = HoverActions.ResetViewModel;
 const PushViewModel = HoverActions.PushViewModel;
-const SquashViewModel = HoverActions.SquashViewModel
+const SquashViewModel = HoverActions.SquashViewModel;
 
 class ActionBase {
   constructor(graph, text, style, icon) {
     this.graph = graph;
     this.server = graph.server;
     this.isRunning = ko.observable(false);
-    this.isHighlighted = ko.computed(() => {
-      return !graph.hoverGraphAction() || graph.hoverGraphAction() == this;
-    });
+    this.isHighlighted = ko.computed(() => !graph.hoverGraphAction() || graph.hoverGraphAction() == this);
     this.text = text;
     this.style = style;
     this.icon = icon;
     this.cssClasses = ko.computed(() => {
       if (!this.isHighlighted() || this.isRunning()) {
-        return `${this.style} dimmed`
+        return `${this.style} dimmed`;
       } else {
-        return this.style
+        return this.style;
       }
     });
   }
+
   doPerform() {
     if (this.isRunning()) return;
     this.graph.hoverGraphAction(null);
@@ -38,21 +36,26 @@ class ActionBase {
       .catch((e) => this.server.unhandledRejection(e))
       .finally(() => { this.isRunning(false); });
   }
+
   dragEnter() {
     if (!this.visible()) return;
     this.graph.hoverGraphAction(this);
   }
+
   dragLeave() {
     if (!this.visible()) return;
     this.graph.hoverGraphAction(null);
   }
+
   mouseover() {
     this.graph.hoverGraphAction(this);
   }
+
   mouseout() {
     this.graph.hoverGraphAction(null);
   }
 }
+
 
 class Move extends ActionBase {
   constructor(graph, node) {
@@ -64,10 +67,12 @@ class Move extends ActionBase {
         this.graph.currentActionContext().node() != this.node;
     });
   }
+
   perform() {
     return this.graph.currentActionContext().moveTo(this.node.sha1);
   }
 }
+
 
 class Reset extends ActionBase {
   constructor (graph, node) {
@@ -93,6 +98,7 @@ class Reset extends ActionBase {
     const nodes = context.node().getPathToCommonAncestor(remoteRef.node()).slice(0, -1);
     return new ResetViewModel(nodes);
   }
+
   perform() {
     const context = this.graph.currentActionContext();
     const remoteRef = context.getRemoteRef(this.graph.currentRemote());
@@ -105,6 +111,7 @@ class Reset extends ActionBase {
       }).closePromise;
   }
 }
+
 
 class Rebase extends ActionBase {
   constructor(graph, node) {
@@ -126,9 +133,10 @@ class Rebase extends ActionBase {
     const path = onto.getPathToCommonAncestor(this.node);
     return new RebaseViewModel(this.node, path);
   }
+
   perform() {
     return this.server.postPromise('/rebase', { path: this.graph.repoPath(), onto: this.node.sha1 })
-      .catch((err) => { if (err.errorCode != 'merge-failed') this.server.unhandledRejection(err); })
+      .catch((err) => { if (err.errorCode != 'merge-failed') this.server.unhandledRejection(err); });
   }
 }
 
@@ -145,15 +153,17 @@ class Merge extends ActionBase {
         this.graph.checkedOutRef().node() == this.node;
     });
   }
+
   createHoverGraphic() {
     let node = this.graph.currentActionContext();
     if (!node) return null;
     if (node instanceof RefViewModel) node = node.node();
     return new MergeViewModel(this.graph, this.node, node);
   }
+
   perform() {
     return this.server.postPromise('/merge', { path: this.graph.repoPath(), with: this.graph.currentActionContext().localRefName })
-      .catch((err) => { if (err.errorCode != 'merge-failed') this.server.unhandledRejection(err); })
+      .catch((err) => { if (err.errorCode != 'merge-failed') this.server.unhandledRejection(err); });
   }
 }
 
@@ -177,6 +187,7 @@ class Push extends ActionBase {
     if (!remoteRef) return null;
     return new PushViewModel(remoteRef.node(), context.node());
   }
+
   perform() {
     const ref = this.graph.currentActionContext();
     const remoteRef = ref.getRemoteRef(this.graph.currentRemote());
@@ -193,6 +204,7 @@ class Push extends ActionBase {
   }
 }
 
+
 class Checkout extends ActionBase {
   constructor(graph, node) {
     super(graph, 'Checkout', 'checkout', 'oct_icon oct_icon-desktop-download');
@@ -206,10 +218,12 @@ class Checkout extends ActionBase {
         this.graph.currentActionContext() == this.node;
     });
   }
+
   perform() {
     return this.graph.currentActionContext().checkout();
   }
 }
+
 
 class Delete extends ActionBase {
   constructor(graph, node) {
@@ -222,11 +236,12 @@ class Delete extends ActionBase {
         !this.graph.currentActionContext().current();
     });
   }
+
   perform() {
     const context = this.graph.currentActionContext();
     let details = `"${context.refName}"`;
     if (context.isRemoteBranch) {
-      details = `<code _style='font-size: 100%'>REMOTE</code> ${details}`;
+      details = `<code _style="font-size: 100%">REMOTE</code> ${details}`;
     }
     details = `Deleting ${details} branch or tag cannot be undone with ungit.`;
 
@@ -238,6 +253,7 @@ class Delete extends ActionBase {
   }
 }
 
+
 class CherryPick extends ActionBase {
   constructor(graph, node) {
     super(graph, 'Cherry pick', 'cherry-pick', 'oct_icon oct_icon-circuit-board');
@@ -245,14 +261,16 @@ class CherryPick extends ActionBase {
     this.visible = ko.computed(() => {
       if (this.isRunning()) return true;
       const context = this.graph.currentActionContext();
-      return context === this.node && this.graph.HEAD() && context.sha1 !== this.graph.HEAD().sha1
+      return context === this.node && this.graph.HEAD() && context.sha1 !== this.graph.HEAD().sha1;
     });
   }
+
   perform() {
     return this.server.postPromise('/cherrypick', { path: this.graph.repoPath(), name: this.node.sha1 })
-      .catch((err) => { if (err.errorCode != 'merge-failed') this.server.unhandledRejection(err); })
+      .catch((err) => { if (err.errorCode != 'merge-failed') this.server.unhandledRejection(err); });
   }
 }
+
 
 class Uncommit extends ActionBase {
   constructor(graph, node) {
@@ -264,6 +282,7 @@ class Uncommit extends ActionBase {
         this.graph.HEAD() == this.node;
     });
   }
+
   perform() {
     return this.server.postPromise('/reset', { path: this.graph.repoPath(), to: 'HEAD^', mode: 'mixed' })
       .then(() => {
@@ -277,6 +296,7 @@ class Uncommit extends ActionBase {
   }
 }
 
+
 class Revert extends ActionBase {
   constructor(graph, node) {
     super(graph, 'Revert', 'revert', 'oct_icon oct_icon-history');
@@ -286,10 +306,12 @@ class Revert extends ActionBase {
       return this.graph.currentActionContext() == this.node;
     });
   }
+
   perform() {
     return this.server.postPromise('/revert', { path: this.graph.repoPath(), commit: this.node.sha1 });
   }
 }
+
 
 class Squash extends ActionBase {
   constructor(graph, node) {
@@ -302,6 +324,7 @@ class Squash extends ActionBase {
         this.graph.currentActionContext().node() != this.node;
     });
   }
+
   createHoverGraphic() {
     let onto = this.graph.currentActionContext();
     if (!onto) return;
@@ -309,6 +332,7 @@ class Squash extends ActionBase {
 
     return new SquashViewModel(this.node, onto);
   }
+
   perform() {
     let onto = this.graph.currentActionContext();
     if (!onto) return;
@@ -334,10 +358,11 @@ class Squash extends ActionBase {
       //                ->     \
       //                        [bc]
       return this.graph.currentActionContext().moveTo(this.node.sha1, true)
-        .then(() => this.server.postPromise('/squash', { path: this.graph.repoPath(), target: onto.sha1 }))
+        .then(() => this.server.postPromise('/squash', { path: this.graph.repoPath(), target: onto.sha1 }));
     }
   }
 }
+
 
 const GraphActions = {
   Move: Move,

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -31,7 +31,7 @@
 
         <!-- ko foreach: dropareaGraphActions -->
         <span class="graphAction droparea" data-bind="css: cssClasses, visible: visible, attr: { 'data-ta-action': style }, event: { mouseover: mouseover, mouseout: mouseout }">
-          <!-- ko if: icon --><span data-bind="css: icon" class="icon"></span><!-- /ko -->
+          <span data-bind="html: icon"></span>
           <span data-bind="text: text"></span>
           <div class="dropmask" tabIndex="0" role="button" data-bind="dropOver: visible, drop: doPerform, dragEnter: dragEnter, dragLeave: dragLeave, click: doPerform"></div>
         </span>

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -90,24 +90,7 @@
       margin-right: 2.5px;
       margin-left: 2.5px;
       overflow: hidden;
-      .icon {
-        &.flip {
-          -webkit-transform:rotate(-180deg);
-          -moz-transform:rotate(-180deg);
-          -o-transform:rotate(-180deg);
-          transform:rotate(-180deg);
-        }
-        &.octicon-git-merge,&.octicon-repo-forked, &.octicon-zap {
-          margin-left: 3px;
-        }
-        &.octicon-history {
-          margin-left: 2px;
-        }
-        &.glyphicon-remove,&.octicon-circuit-board {
-          margin-left: 1px;
-        }
-        margin-right: 6px;
-      }
+
       &.droparea {
         padding-left: 7px;
       }
@@ -194,27 +177,6 @@
 
   .graphFooter {
     height: 60px;
-  }
-
-  .remote-icon {
-    background: url('images/remoteIcon.png');
-    width: 12px;
-    height: 10px;
-    display: inline-block;
-  }
-
-  .branch-icon {
-    background: url('images/branchIcon.png');
-    width: 9px;
-    height: 10px;
-    display: inline-block;
-  }
-
-  .tag-icon {
-    background: url('images/tagIcon.png');
-    width: 5px;
-    height: 10px;
-    display: inline-block;
   }
 }
 

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -113,24 +113,3 @@
     }
   }
 }
-
-.remote-icon {
-	background: url('../plugins/graph/images/remoteIcon.png');
-	width: 12px;
-	height: 10px;
-	display: inline-block;
-}
-
-.branch-icon {
-	background: url('../plugins/graph/images/branchIcon.png');
-	width: 9px;
-	height: 10px;
-	display: inline-block;
-}
-
-.tag-icon {
-	background: url('../plugins/graph/images/tagIcon.png');
-	width: 5px;
-	height: 10px;
-	display: inline-block;
-}


### PR DESCRIPTION
Even before switching to the latest version of Octicons in #1224 these icons were not showing up for me.
This PR replaces the broken references to the old octicons and glyphicons with the SVG Octicons.
The icons should look the same as before with the exception of the Move icon. Instead of arrows in all directions, the new one points to the target of the move.

![image](https://user-images.githubusercontent.com/2564094/68258452-9a24a100-ffeb-11e9-9c76-0389c3bfdce1.png)

Also removes CSS classes for the very old image icons used before #605.