### PR TITLE
use process.exit instead of none existing app.quit

### DIFF
--- a/source/server.js
+++ b/source/server.js
@@ -20,7 +20,7 @@ const Bluebird = require('bluebird');
 process.on('uncaughtException', (err) => {
   winston.error(err.stack ? err.stack.toString() : err.toString());
   bugtracker.notify.bind(bugtracker, err, 'ungit-launcher');
-  app.quit();
+  process.exit();
 });
 
 console.log('Setting log level to ' + config.logLevel);


### PR DESCRIPTION
I guess this was a copy and paste error in https://github.com/FredrikNoren/ungit/commit/543449e16ac83e1635d300c4e66b9121536e815e#diff-71e7385fb3d187340c7741bf6d4f82ffL28-R27