### PR TITLE
add copy and paste menu items in electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## Unreleased
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.0...master)
+- Fix copy and paste in electron on macOS [#1251](https://github.com/FredrikNoren/ungit/issues/1251)
 
 ## [1.5.0](https://github.com/FredrikNoren/ungit/compare/v1.4.48...v1.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.0...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.1...master)
+
+
+## [1.5.1](https://github.com/FredrikNoren/ungit/compare/v1.5.0...v1.5.1)
+
+### Fixed
 - Fix copy and paste in electron on macOS [#1251](https://github.com/FredrikNoren/ungit/issues/1251)
 
 ## [1.5.0](https://github.com/FredrikNoren/ungit/compare/v1.4.48...v1.5.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/public/main.js
+++ b/public/main.js
@@ -58,6 +58,20 @@ var menuTemplate = [
       { role: 'quit' }
     ]
   },
+  {  
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'delete' },
+      { type: 'separator' },
+      { role: 'selectAll' }
+    ]
+  },
   {
     label: 'View',
     submenu: [


### PR DESCRIPTION
Apparently macOS requires copy & paste menu items in order to copy and paste text from and to applications.
In #1250 I left them out, because I didn't know that at that time.

![image](https://user-images.githubusercontent.com/4009570/69250297-b6117080-0baf-11ea-9cfa-a99da5b38eb1.png)

fixes #1251 