### PR TITLE
Prepare version 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.1...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.2...master)
+
+## [1.5.2](https://github.com/FredrikNoren/ungit/compare/v1.5.1...v1.5.2)
 
 ### Fixed
 - Diff does not work for first commit [#1124](https://github.com/FredrikNoren/ungit/issues/1124)
@@ -11,6 +13,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 - Bare repositories don't work with git 2.25 [#1265](https://github.com/FredrikNoren/ungit/issues/1265)
 - ungit crashes if current directory is deleted [#1266](https://github.com/FredrikNoren/ungit/issues/1266)
 - Make clicktests more reliable [#1263](https://github.com/FredrikNoren/ungit/pull/1263)
+- Rename + changes only show rename [#1175](https://github.com/FredrikNoren/ungit/issues/1175)
 
 ### Removed
 - Remove Node 8 from build matrix [#1256](https://github.com/FredrikNoren/ungit/pull/1256)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -3,19 +3,21 @@ const fileType = require('./utils/file-type.js');
 const _ = require('lodash');
 
 exports.parseGitStatus = (text, args) => {
-  const lines = text.split('\x00');
-  const files = {};
+  let lines = text.split('\x00');
+  const branch = lines[0].split(' ').pop();
   // skipping first line...
-  let lineIterator = lines.slice(1).values();
+  lines = lines.slice(1);
+  const files = {};
 
-  for(let line of lineIterator){
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
     if (line == '') continue;
     const status = line.slice(0, 2);
     const newFileName = line.slice(3).trim();
     let oldFileName;
     let displayName;
     if (status[0] == 'R') {
-      oldFileName = lineIterator.next().value
+      oldFileName = lines[++i]
       displayName = `${oldFileName} → ${newFileName}`;
     } else {
       oldFileName = newFileName;
@@ -36,7 +38,7 @@ exports.parseGitStatus = (text, args) => {
 
   return {
     isMoreToLoad: false,
-    branch: lines[0].split(' ').pop(),
+    branch: branch,
     inited: true,
     files: files
   };


### PR DESCRIPTION
### Fixed
- Diff does not work for first commit [#1124](https://github.com/FredrikNoren/ungit/issues/1124)
- `--no-launchBrowser` is ignored when ungit already running [#1259](https://github.com/FredrikNoren/ungit/issues/1259)
- Bare repositories don't work with git 2.25 [#1265](https://github.com/FredrikNoren/ungit/issues/1265)
- ungit crashes if current directory is deleted [#1266](https://github.com/FredrikNoren/ungit/issues/1266)
- Make clicktests more reliable [#1263](https://github.com/FredrikNoren/ungit/pull/1263)
- Rename + changes only show rename [#1175](https://github.com/FredrikNoren/ungit/issues/1175)

### Removed
- Remove Node 8 from build matrix [#1256](https://github.com/FredrikNoren/ungit/pull/1256)