### PR TITLE
Convert patch to button and remove old patch tooltip css

### DIFF
--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -91,8 +91,7 @@
             <span class="deletions" data-bind="text: deletions"></span>
             <span class="modified" data-bind="visible: modified">Modified</span>
             <span class="conflict" data-bind="visible: conflict"><span class="temporary">Conflicts</span><span class="launchmergetool explanation" data-bind="visible: mergeTool, click: launchMergeTool">Launch Merge Tool</span><span class="markresolved explanation" data-bind="click: resolveConflict">Mark as Resolved</span></span>
-            <span class="patch bootstrap-tooltip" data-bind="visible: isShowPatch(), click: patchClick"
-                data-toggle="tooltip" data-placement="top" title="Patch changes">Patch</span>
+            <button class="patch btn bootstrap-tooltip" data-bind="visible: isShowPatch(), click: patchClick" data-toggle="tooltip" data-placement="top" title="Patch changes">Patch</button>
             <button class="ignore btn bootstrap-tooltip" data-bind="html: $parent.ignoreIcon, click: ignoreFile" data-toggle="tooltip" data-placement="top" title="Add to .gitignore"></button>
             <button class="discard btn bootstrap-tooltip" data-bind="html: $parent.discardIcon, click: discardChanges" data-toggle="tooltip" data-placement="top" title="Discard changes"></button>
             <!-- ko if: isShowingDiffs -->

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -85,20 +85,6 @@
     }
   }
 
-  .ignore + .tooltip {
-    .tooltip-inner {
-      background: #55f;
-      color: rgba(255, 255, 255, 0.9);
-    }
-    .tooltip-arrow {
-      bottom: 0;
-      left: 50%;
-      margin-left: -5px;
-      border-width: 5px 5px 0;
-      border-top-color: #55f;
-    }
-  }
-
   .patch {
     background: #279124;
     color: rgba(255, 255, 255, 0.9);
@@ -108,22 +94,11 @@
     padding-right: 5px;
     cursor: pointer;
     font-weight: bold;
+
+    &:focus,
     &:hover {
       background: #279124;
       color: rgba(255, 255, 255, 0.9);
-    }
-  }
-  .patch + .tooltip {
-    .tooltip-inner {
-      background: #279124;
-      color: rgba(255, 255, 255, 0.9);
-    }
-    .tooltip-arrow {
-      bottom: 0;
-      left: 50%;
-      margin-left: -5px;
-      border-width: 5px 5px 0;
-      border-top-color: #279124;
     }
   }
 


### PR DESCRIPTION
To be inline with the `ignore` and `discard` buttons.