### PR TITLE
[fix #1091] performance boost for big repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.3...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.4...master)
+
+## [1.5.4](https://github.com/FredrikNoren/ungit/compare/v1.5.3...v1.5.4)
+
+### Fixed
+- Performance optimizations for the big org [#1091](https://github.com/FredrikNoren/ungit/issues/1091)
+    - ignore 'rename' filewatch event as it can cause constant update and refresh loop
+    - Prevent full gitlog history from server to client and load only what is needed
+    - Prevent redundant ref and node calculations per each `/gitlog` api call
 
 ## [1.5.3](https://github.com/FredrikNoren/ungit/compare/v1.5.2...v1.5.3)
 

--- a/components/graph/git-graph-actions.js
+++ b/components/graph/git-graph-actions.js
@@ -76,7 +76,7 @@ class Move extends ActionBase {
 
 
 class Reset extends ActionBase {
-  constructor (graph, node) {
+  constructor(graph, node) {
     super(graph, 'Reset', 'reset', octicons.trashcan.toSVG({ 'height': 18 }));
     this.node = node;
     this.visible = ko.computed(() => {
@@ -88,7 +88,7 @@ class Reset extends ActionBase {
       return remoteRef && remoteRef.node() &&
         context && context.node() &&
         remoteRef.node() != context.node() &&
-        remoteRef.node().date < context.node().date;
+        remoteRef.node().timestamp < context.node().timestamp;
     });
   }
 
@@ -103,7 +103,7 @@ class Reset extends ActionBase {
   perform() {
     const context = this.graph.currentActionContext();
     const remoteRef = context.getRemoteRef(this.graph.currentRemote());
-    return components.create('yesnodialog', { title: 'Are you sure?', details: 'Resetting to ref: ' + remoteRef.name + ' cannot be undone with ungit.'})
+    return components.create('yesnodialog', { title: 'Are you sure?', details: 'Resetting to ref: ' + remoteRef.name + ' cannot be undone with ungit.' })
       .show()
       .closeThen((diag) => {
         if (!diag.result()) return;
@@ -197,10 +197,10 @@ class Push extends ActionBase {
       return remoteRef.moveTo(ref.node().sha1);
     } else {
       return ref.createRemoteRef().then(() => {
-          if (this.graph.HEAD().name == ref.name) {
-            this.grah.HEADref().node(ref.node());
-          }
-        }).finally(() => programEvents.dispatch({ event: 'request-fetch-tags' }));
+        if (this.graph.HEAD().name == ref.name) {
+          this.grah.HEADref().node(ref.node());
+        }
+      }).finally(() => programEvents.dispatch({ event: 'request-fetch-tags' }));
     }
   }
 }

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -4,6 +4,7 @@ const components = require('ungit-components');
 const programEvents = require('ungit-program-events');
 const Animateable = require('./animateable');
 const GraphActions = require('./git-graph-actions');
+const _ = require('lodash');
 
 const maxBranchesToDisplay = parseInt(ungit.config.numRefsToShow / 5 * 3);  // 3/5 of refs to show to branches
 const maxTagsToDisplay = ungit.config.numRefsToShow - maxBranchesToDisplay; // 2/5 of refs to show to tags
@@ -106,6 +107,34 @@ class GitNodeViewModel extends Animateable {
       new GraphActions.Revert(this.graph, this),
       new GraphActions.Squash(this.graph, this)
     ];
+
+    this.render = _.debounce(() => {
+      this.refSearchFormVisible(false);
+      if (!this.isInited) return;
+      if (this.ancestorOfHEAD()) {
+        this.r(30);
+        this.cx(610);
+
+        if (!this.aboveNode) {
+          this.cy(120);
+        } else if (this.aboveNode.ancestorOfHEAD()) {
+          this.cy(this.aboveNode.cy() + 120);
+        } else {
+          this.cy(this.aboveNode.cy() + 60);
+        }
+      } else {
+        this.r(15);
+        this.cx(610 + (90 * this.branchOrder()));
+        this.cy(this.aboveNode && !isNaN(this.aboveNode.cy()) ? this.aboveNode.cy() + 60 : 120);
+      }
+
+      if (this.aboveNode && this.aboveNode.selected()) {
+        this.cy(this.aboveNode.cy() + this.aboveNode.commitComponent.element().offsetHeight + 30);
+      }
+
+      this.color(this.ideologicalBranch() ? this.ideologicalBranch().color : '#666');
+      this.animate();
+    }, 500, {leading: true})
   }
 
   getGraphAttr() {
@@ -115,34 +144,6 @@ class GitNodeViewModel extends Animateable {
   setGraphAttr(val) {
     this.element().setAttribute('x', val[0] - 30);
     this.element().setAttribute('y', val[1] - 30);
-  }
-
-  render() {
-    this.refSearchFormVisible(false);
-    if (!this.isInited) return;
-    if (this.ancestorOfHEAD()) {
-      this.r(30);
-      this.cx(610);
-
-      if (!this.aboveNode) {
-        this.cy(120);
-      } else if (this.aboveNode.ancestorOfHEAD()) {
-        this.cy(this.aboveNode.cy() + 120);
-      } else {
-        this.cy(this.aboveNode.cy() + 60);
-      }
-    } else {
-      this.r(15);
-      this.cx(610 + (90 * this.branchOrder()));
-      this.cy(this.aboveNode && !isNaN(this.aboveNode.cy()) ? this.aboveNode.cy() + 60 : 120);
-    }
-
-    if (this.aboveNode && this.aboveNode.selected()) {
-      this.cy(this.aboveNode.cy() + this.aboveNode.commitComponent.element().offsetHeight + 30);
-    }
-
-    this.color(this.ideologicalBranch() ? this.ideologicalBranch().color : '#666');
-    this.animate();
   }
 
   setData(logEntry) {

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -134,7 +134,7 @@ class GitNodeViewModel extends Animateable {
     } else {
       this.r(15);
       this.cx(610 + (90 * this.branchOrder()));
-      this.cy(this.aboveNode ? this.aboveNode.cy() + 60 : 120);
+      this.cy(this.aboveNode && !isNaN(this.aboveNode.cy()) ? this.aboveNode.cy() + 60 : 120);
     }
 
     if (this.aboveNode && this.aboveNode.selected()) {

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -63,7 +63,7 @@ class RefViewModel extends Selectable {
     // This optimization is for autocomplete display
     this.value = splitedName[splitedName.length - 1];
     this.label = this.localRefName;
-    this.dom = `${this.localRefName}<span>${octicons[(this.isTag ? 'tag': 'git-branch')].toSVG({ 'height': 18 })}</span>`;
+    this.dom = `${this.localRefName}<span>${octicons[(this.isTag ? 'tag' : 'git-branch')].toSVG({ 'height': 18 })}</span>`;
 
     this.displayHtml = (largeCurrent) => {
       const size = (largeCurrent && this.current()) ? 26 : 18;
@@ -109,8 +109,8 @@ class RefViewModel extends Selectable {
         operation = '/branches';
       }
 
-      if (!rewindWarnOverride && this.node().date > toNode.date) {
-        promise = components.create('yesnodialog', { title: 'Are you sure?', details: 'This operation potentially going back in history.'})
+      if (!rewindWarnOverride && this.node().timestamp > toNode.timestamp) {
+        promise = components.create('yesnodialog', { title: 'Are you sure?', details: 'This operation potentially going back in history.' })
           .show()
           .closeThen(diag => {
             if (diag.result()) {
@@ -208,15 +208,15 @@ class RefViewModel extends Selectable {
     const isLocalCurrent = this.getLocalRef() && this.getLocalRef().current();
 
     return promise.resolve().then(() => {
-        if (isRemote && !isLocalCurrent) {
-          return this.server.postPromise('/branches', {
-            path: this.graph.repoPath(),
-            name: this.refName,
-            sha1: this.name,
-            force: true
-          });
-        }
-      }).then(() => this.server.postPromise('/checkout', { path: this.graph.repoPath(), name: this.refName }))
+      if (isRemote && !isLocalCurrent) {
+        return this.server.postPromise('/branches', {
+          path: this.graph.repoPath(),
+          name: this.refName,
+          sha1: this.name,
+          force: true
+        });
+      }
+    }).then(() => this.server.postPromise('/checkout', { path: this.graph.repoPath(), name: this.refName }))
       .then(() => {
         if (isRemote && isLocalCurrent) {
           return this.server.postPromise('/reset', { path: this.graph.repoPath(), to: this.name, mode: 'hard' });

--- a/components/graph/graph-graphics.html
+++ b/components/graph/graph-graphics.html
@@ -18,12 +18,9 @@
   </defs>
   <g>
     <!-- ko if: commitNodeEdge -->
-      <g class="load-ahead-button" data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}, click: loadAhead">
+      <g class="load-ahead-button" data-bind="attr: { opacity: commitOpacity, visible: commitNodeEdge}">
         <path data-bind="attr: { d: commitNodeEdge }", stroke="#4A4A4A" stroke-width="8" stroke-dasharray="10, 5" />
         <circle data-bind="attr: { stroke: commitNodeColor }" cx="610" cy="35" r="30" data-bind="attr: { stroke: '#4A4A4A' }"  stroke-dasharray="10, 7" stroke-width="10" fill="transparent"/>
-        <!-- ko if: skip() > 0 -->
-          <circle class="loadAhead" data-bind="attr: { fill: commitNodeColor }" cx="610" cy="35" r="15" />
-        <!-- /ko -->
       </g>
     <!-- /ko -->
 

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -1,5 +1,5 @@
 
-<div class="graph" data-bind="scrolledToEnd: scrolledToEnd, click: handleBubbledClick">
+<div class="graph" data-bind="scrolledToEnd: loadNodesFromApiThrottled, click: handleBubbledClick">
 
   <!-- ko template: { name: 'graphGraphics' } --><!-- /ko -->
 

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -15,7 +15,6 @@ class GraphViewModel {
   constructor(server, repoPath) {
     this._markIdeologicalStamp = 0;
     this.repoPath = repoPath;
-    this.limit = ko.observable(numberOfNodesPerLoad);
     this.skip = ko.observable(0);
     this.server = server;
     this.currentRemote = ko.observable();
@@ -37,12 +36,6 @@ class GraphViewModel {
     this.currentActionContext = ko.observable();
     this.edgesById = {};
     this.scrolledToEnd = _.debounce(() => {
-      this.limit(numberOfNodesPerLoad + this.limit());
-      this.loadNodesFromApi();
-    }, 500, true);
-    this.loadAhead = _.debounce(() => {
-      if (this.skip() <= 0) return;
-      this.skip(Math.max(this.skip() - numberOfNodesPerLoad, 0));
       this.loadNodesFromApi();
     }, 500, true);
     this.commitOpacity = ko.observable(1.0);
@@ -101,28 +94,23 @@ class GraphViewModel {
     this.isLoadNodesRunning = true
 
     const nodeSize = this.nodes().length;
-    return this.server.getPromise('/gitlog', { path: this.repoPath(), limit: this.limit(), skip: this.skip() })
+    return this.server.getPromise('/gitlog', { path: this.repoPath(), skip: this.skip(), lookForHead: this.HEAD() ? "false" : "true" })
       .then(log => {
         // set new limit and skip
-        this.limit(parseInt(log.limit));
         this.skip(parseInt(log.skip));
         return log.nodes || [];
-      }).then(nodes => // create and/or calculate nodes
-        this.computeNode(nodes.map((logEntry) => {
-          return this.getNode(logEntry.sha1, logEntry);     // convert to node object
+      }).then(nodes => {// create and/or calculate nodes
+        return this.computeNode(nodes.map((logEntry) => {
+          return this.getNode(logEntry.sha1, logEntry)
         }))
-      ).then(nodes => {
+      }).then(nodes => {
         // create edges
-        const edges = [];
         nodes.forEach(node => {
           node.parents().forEach(parentSha1 => {
-            edges.push(this.getEdge(node.sha1, parentSha1));
+            this.edges.push(this.getEdge(node.sha1, parentSha1));
           });
-          node.render();
         });
 
-        this.edges(edges);
-        this.nodes(nodes);
         if (nodes.length > 0) {
           this.graphHeight(nodes[nodes.length - 1].cy() + 80);
         }
@@ -178,16 +166,18 @@ class GraphViewModel {
     }
 
     this.heighstBranchOrder = branchSlotCounter - 1;
-    let prevNode;
+    let prevNode = this.nodes() ? this.nodes()[this.nodes().length - 1] : null;
     nodes.forEach(node => {
       node.ancestorOfHEAD(node.ancestorOfHEADTimeStamp == updateTimeStamp);
       if (node.ancestorOfHEAD()) node.branchOrder(0);
       node.aboveNode = prevNode;
       if (prevNode) prevNode.belowNode = node;
       prevNode = node;
+      node.render();
+      this.nodes.push(node);
     });
 
-    return nodes;
+    return this.nodes();
   }
 
   getEdge(nodeAsha1, nodeBsha1) {

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -201,8 +201,14 @@ class GraphViewModel {
   }
 
   markNodesIdeologicalBranches(refs) {
-    refs = refs.filter(r => !!r.node().timestamp);
-    refs = refs.sort((a, b) => {
+    const refNodeMap = {};
+    refs.forEach(r => {
+      if (!r.node()) return;
+      if (!r.node().timestamp) return;
+      if (refNodeMap[r.node().sha1]) return;
+      refNodeMap[r.node().sha1] = r;
+    });
+    refs = Object.values(refNodeMap).sort((a, b) => {
       if (a.isLocal && !b.isLocal) return -1;
       if (b.isLocal && !a.isLocal) return 1;
       if (a.isBranch && !b.isBranch) return -1;

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -8,10 +8,6 @@
 
   .graphLog {
     left: 575px;
-    .loadAhead {
-      cursor: pointer;
-      animation: throb 1s ease alternate infinite;
-    }
   }
 
   @keyframes throb {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",

--- a/source/config.js
+++ b/source/config.js
@@ -126,8 +126,8 @@ const defaultConfig = {
   // Always load with active checkout branch (deprecated: use `maxActiveBranchSearchIteration`)
   alwaysLoadActiveBranch: false,
 
-  // Max search iterations for active branch.  ( value means not searching for active branch)
-  maxActiveBranchSearchIteration: -1,
+  // Max search iterations for active branch.
+  maxActiveBranchSearchIteration: 25,
 
   // number of nodes to load for each git.log call
   numberOfNodesPerLoad: 25,

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -71,9 +71,8 @@ exports.registerApi = (env) => {
           });
         }
       }).then(() => {
-        const watcher = fs.watch(pathToWatch, options || {});
-        watcher.on('change', (event, filename) => {
-          if (!filename) return;
+        const watcher = fs.watch(pathToWatch, options || {}, (event, filename) => {
+          if (event === 'rename' || !filename) return;
           const filePath = path.join(subfolderPath, filename);
           winston.debug(`File change: ${filePath}`);
           if (isFileWatched(filePath, socket.ignore)) {
@@ -81,9 +80,6 @@ exports.registerApi = (env) => {
             emitGitDirectoryChanged(socket.watcherPath);
             emitWorkingTreeChanged(socket.watcherPath);
           }
-        });
-        watcher.on('error', (err) => {
-          winston.warn(`Error watching ${pathToWatch}: `, JSON.stringify(err));
         });
         socket.watcher.push(watcher);
       });

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -309,16 +309,15 @@ exports.registerApi = (env) => {
   });
 
   app.get(`${exports.pathPrefix}/gitlog`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const limit = getNumber(req.query.limit, config.numberOfNodesPerLoad || 25);
     const skip = getNumber(req.query.skip, 0);
-    const task = gitPromise.log(req.query.path, limit, skip, config.maxActiveBranchSearchIteration)
+    const task = gitPromise.log(req.query.path, skip, req.query.lookForHead === "true", config.maxActiveBranchSearchIteration)
       .catch((err) => {
         if (err.stderr && err.stderr.indexOf('fatal: bad default revision \'HEAD\'') == 0) {
-          return { "limit": limit, "skip": skip, "nodes": []};
+          return { "skip": skip, "nodes": []};
         } else if (/fatal: your current branch \'.+\' does not have any commits yet.*/.test(err.stderr)) {
-          return { "limit": limit, "skip": skip, "nodes": []};
+          return { "skip": skip, "nodes": []};
         } else if (err.stderr && err.stderr.indexOf('fatal: Not a git repository') == 0) {
-          return { "limit": limit, "skip": skip, "nodes": []};
+          return { "skip": skip, "nodes": []};
         } else {
           throw err;
         }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -442,23 +442,23 @@ git.revParse = (repoPath) => {
     }).catch((err) => ({ type: 'uninited', gitRootPath: path.normalize(repoPath) }));
 }
 
-git.log = (path, limit, skip, maxActiveBranchSearchIteration) => {
-  return git(['log', '--cc', '--decorate=full', '--show-signature', '--date=default', '--pretty=fuller', '-z', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${limit}`, `--skip=${skip}`], path)
+git.log = (path, skip, lookForHead, maxActiveBranchSearchIteration) => {
+  return git(['log', '--cc', '--decorate=full', '--show-signature', '--date=default', '--pretty=fuller', '-z', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${config.numberOfNodesPerLoad}`, `--skip=${skip}`], path)
     .then(gitParser.parseGitLog)
     .then((log) => {
       log = log ? log : [];
-      if (maxActiveBranchSearchIteration > 0 && !log.isHeadExist && log.length > 0) {
-        return git.log(path, config.numberOfNodesPerLoad + limit, config.numberOfNodesPerLoad + skip, maxActiveBranchSearchIteration - 1)
+      skip = skip + log.length
+      if (lookForHead && maxActiveBranchSearchIteration > 0 && !log.isHeadExist && log.length > 0) {
+        return git.log(path, skip, maxActiveBranchSearchIteration - 1)
           .then(innerLog => {
             return {
-              "limit": limit + (innerLog.isHeadExist ? 0 : config.numberOfNodesPerLoad),
-              "skip": skip + (innerLog.isHeadExist ? 0 : config.numberOfNodesPerLoad),
+              "skip": skip,
               "nodes": log.concat(innerLog.nodes),
               "isHeadExist": innerLog.isHeadExist
             }
           });
       } else {
-        return { "limit": limit, "skip": skip, "nodes": log, "isHeadExist": log.isHeadExist };
+        return { "skip": skip, "nodes": log, "isHeadExist": log.isHeadExist };
       }
     });
 }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -442,23 +442,17 @@ git.revParse = (repoPath) => {
     }).catch((err) => ({ type: 'uninited', gitRootPath: path.normalize(repoPath) }));
 }
 
-git.log = (path, skip, lookForHead, maxActiveBranchSearchIteration) => {
-  return git(['log', '--cc', '--decorate=full', '--show-signature', '--date=default', '--pretty=fuller', '-z', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${config.numberOfNodesPerLoad}`, `--skip=${skip}`], path)
+git.log = (path, skip, limit, lookForHead, maxActiveBranchSearchIteration) => {
+  return git(['log', '--cc', '--decorate=full', '--show-signature', '--date=default', '--pretty=fuller', '-z', '--branches', '--tags', '--remotes', '--parents', '--no-notes', '--numstat', '--date-order', `--max-count=${limit}`, `--skip=${skip}`], path)
     .then(gitParser.parseGitLog)
     .then((log) => {
       log = log ? log : [];
-      skip = skip + log.length
+      skip = skip + log.length;
       if (lookForHead && maxActiveBranchSearchIteration > 0 && !log.isHeadExist && log.length > 0) {
         return git.log(path, skip, maxActiveBranchSearchIteration - 1)
-          .then(innerLog => {
-            return {
-              "skip": skip,
-              "nodes": log.concat(innerLog.nodes),
-              "isHeadExist": innerLog.isHeadExist
-            }
-          });
+          .then(innerLog => log.concat(innerLog.nodes));
       } else {
-        return { "skip": skip, "nodes": log, "isHeadExist": log.isHeadExist };
+        return log;
       }
     });
 }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -450,7 +450,7 @@ git.log = (path, skip, limit, lookForHead, maxActiveBranchSearchIteration) => {
       skip = skip + log.length;
       if (lookForHead && maxActiveBranchSearchIteration > 0 && !log.isHeadExist && log.length > 0) {
         return git.log(path, skip, maxActiveBranchSearchIteration - 1)
-          .then(innerLog => log.concat(innerLog.nodes));
+          .then(innerLog => log.concat(innerLog));
       } else {
         return log;
       }

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -254,8 +254,8 @@ git.resolveConflicts = (repoPath, files) => {
       }
     });
   })).then(() => {
-    const addExec = toAdd.length > 0 ? git(['add', toAdd ], repoPath) : null;
-    const removeExec = toRemove.length > 0 ? git(['rm', toRemove ], repoPath) : null;
+    const addExec = toAdd.length > 0 ? git(['add', toAdd], repoPath) : null;
+    const removeExec = toRemove.length > 0 ? git(['rm', toRemove], repoPath) : null;
     return Bluebird.join(addExec, removeExec);
   });
 }
@@ -414,7 +414,7 @@ git.commit = (repoPath, amend, emptyCommit, message, files) => {
     return Bluebird.join(commitPromiseChain, Bluebird.all(diffPatchPromises));
   }).then(() => {
     const ammendFlag = (amend ? '--amend' : '');
-    const allowedEmptyFlag = ((emptyCommit ||amend) ? '--allow-empty' : '');
+    const allowedEmptyFlag = ((emptyCommit || amend) ? '--allow-empty' : '');
     const isGPGSign = (config.isForceGPGSign ? '-S' : '');
     return git(['commit', ammendFlag, allowedEmptyFlag, isGPGSign, '--file=-'], repoPath, null, null, message);
   }).catch((err) => {
@@ -435,7 +435,7 @@ git.revParse = (repoPath) => {
       return git(['rev-parse', '--show-toplevel'], repoPath).then((topLevel) => {
         const rootPath = path.normalize(topLevel.trim() ? topLevel.trim() : repoPath);
         if (resultLines[0].indexOf('true') > -1) {
-            return { type: 'inited', gitRootPath: rootPath };
+          return { type: 'inited', gitRootPath: rootPath };
         }
         return { type: 'uninited', gitRootPath: rootPath };
       });


### PR DESCRIPTION
Few things are done here.

- ignore 'rename' filewatch event as it can cause constant update and refresh loop
- Prevent full gitlog history from server to client and load only what is needed
- Prevent redundant ref and node calculations per each `/gitlog` api call

### ignore 'rename' filewatch event as it can cause constant update and refresh loop
This one is bit tricky as some OS, git and node version behave differently and the [`fs.watch()` doc](https://nodejs.org/docs/latest/api/fs.html#fs_fs_watch_filename_options_listener) itself does describe very inconsistent behavior.  

> On most platforms, 'rename' is emitted whenever a filename appears or disappears in the directory.

Here is a problem with that for some combination of OS, git and node versions:

1.  with `/refs` git api call, git operations would continuously delete and create some files such as `.git/refs/remotes/origin/master`
2. Which triggers `fs.watch()` remote event
3. Which emits `git-directory-changed` socket io event
4. Which front end picks up and does many things but most importantly makes two api calls, `/gitlog` and `/refs`
    - `/gitlog` will seriously bog down entire performance both and back end and frontend as it is more compute intense operation to recalculate and draw
    - `/refs` will trigger everything back to step 1 and entire thing repeats

There is no way to test and prepare for all combinations.  We should stick with latest doc and latest API.

So, adopted to latest API and ignoring `rename` event.

### Prevent full gitlog history from server to client and load only what is needed

Upon page load, client will make and API call to get list of git nodes.  However, this call gets list of ALL nodes every time.  i.e. if a pages is showing 300 nodes and user scrolls down asking for 25 more nodes, backend will return 325 nodes, not just the 25 nodes needed.

This is now fixed and backend will return only the nodes client needs.

### Prevent redundant ref and node calculations per each `/gitlog` api call

One of the biggest performance hit for big repos was due to git refs calculations because ungit loads ALL refs, local and remote branches and tags of it's history.

This is needed to some degree to display them in the branch drop down and etc, but there were some inefficiencies on logic that thinking these refs had valid nodes and did unnecessary calculations.  


### todo
- [ ] fix tests

-----

https://github.com/git/git page load with old code: https://recordit.co/O1lzQO62Z2

![with old code](http://g.recordit.co/O1lzQO62Z2.gif)
-----

https://github.com/git/git page load with new code: https://recordit.co/bHmV8QiA0I

![with new code](http://g.recordit.co/bHmV8QiA0I.gif)
