### PR TITLE
Change how textdiff settings changes are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 ### Fixed
 - Bump dependencies [#1283](https://github.com/FredrikNoren/ungit/pull/1283)
 - Running npm scripts on macOS [#1287](https://github.com/FredrikNoren/ungit/pull/1287)
+- Reduce CPU and Memory consumption in textdiff. addresses part of [#1091](https://github.com/FredrikNoren/ungit/issues/1091)
 
 ## [1.5.4](https://github.com/FredrikNoren/ungit/compare/v1.5.3...v1.5.4)
 

--- a/components/textdiff/textdiff.html
+++ b/components/textdiff/textdiff.html
@@ -3,8 +3,8 @@
   <!-- ko if: isParsed -->
   <div data-bind="template: {nodes: ko.utils.parseHtmlFragment(htmlSrc)}, css: {'word-wrap': wordWrap.value}"></div>
   <!-- /ko -->
-  <div class="btn-load-more" data-bind="visible: loadMoreCount() > 0">
-    <span class="btn btn-warning" data-bind="click: loadMore, text: 'Load ' + loadMoreCount() + ' more lines'"></span>
+  <div class="btn-load-more" data-bind="visible: hasMore">
+    <span class="btn btn-warning" data-bind="click: loadMore, text: 'Load more'"></span>
   </div>
 </div>
 <!-- /ko -->


### PR DESCRIPTION
Fixes performance issues with `signal` and should use less memory.
This is the PR for one of my proposals from https://github.com/FredrikNoren/ungit/issues/1091#issuecomment-586589079