### PR TITLE
Update author date again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 - Reduce CPU and Memory consumption in textdiff. Addresses part of [#1091](https://github.com/FredrikNoren/ungit/issues/1091)
 - Better focus handling when creating branches and tags [#1288](https://github.com/FredrikNoren/ungit/pull/1288)
 - Don't show error page when reloading the page [#1289](https://github.com/FredrikNoren/ungit/issues/1289)
+- Periodically update author date of commits again [#1286](https://github.com/FredrikNoren/ungit/pull/1286)
 
 ## [1.5.4](https://github.com/FredrikNoren/ungit/compare/v1.5.3...v1.5.4)
 

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -264,6 +264,10 @@ class GitNodeViewModel extends Animateable {
     }
   }
 
+  updateAnimationFrame(deltaT) {
+    this.commitComponent.updateAnimationFrame(deltaT);
+  }
+
   getPathToCommonAncestor(node) {
     const path = [];
     let thisNode = this;

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -265,6 +265,12 @@ class GraphViewModel {
     }
   }
 
+  updateAnimationFrame(deltaT) {
+    this.nodes().forEach(node => {
+      node.updateAnimationFrame(deltaT);
+    });
+  }
+
   updateBranches() {
     this.server.getPromise('/checkout', { path: this.repoPath() })
       .then(res => { this.checkedOutBranch(res); })


### PR DESCRIPTION
This code for updating the author date after some time wasn't called any more
https://github.com/FredrikNoren/ungit/blob/4147fd0eba9622731032475116d7105196ad8765/components/commit/commit.js#L71-L82

Because `updateAnimationFrame` was removed from `git-node` and `graph` in https://github.com/FredrikNoren/ungit/pull/630 which wasn't noted because of this check
https://github.com/FredrikNoren/ungit/blob/4147fd0eba9622731032475116d7105196ad8765/components/repository/repository.js#L54

Since updating the author date is the **only** thing that is done inside of [`window.requestAnimationFrame`](https://github.com/FredrikNoren/ungit/blob/4147fd0eba9622731032475116d7105196ad8765/public/source/main.js#L182-L190) we could also consider changing it to a `setTimeout`.