### PR TITLE
Fix argument check for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 - Bump dependencies [#1283](https://github.com/FredrikNoren/ungit/pull/1283)
+- Running npm scripts on macOS [#1287](https://github.com/FredrikNoren/ungit/pull/1287)
 
 ## [1.5.4](https://github.com/FredrikNoren/ungit/compare/v1.5.3...v1.5.4)
 

--- a/source/config.js
+++ b/source/config.js
@@ -260,7 +260,7 @@ const argvConfig = argv.argv;
 
 // For testing, $0 is grunt.  For credential-parser test, $0 is node
 // When ungit is started normally, $0 == ungit, and non-hyphenated options exists, show help and exit.
-if (argvConfig.$0.indexOf('ungit') > -1 && argvConfig._ && argvConfig._.length > 0) {
+if (argvConfig.$0.endsWith('ungit') && argvConfig._ && argvConfig._.length > 0) {
   yargs.showHelp();
   process.exit(0);
 }


### PR DESCRIPTION
While playing around with github actions I ran into this issue where `npm test` just prints out the command line help from ungit https://github.com/campersau/ungit/runs/474664577?check_suite_focus=true#step:18:14

That's because on macOS the full path is provided as the first argument which contains `ungit` as a folder name:
```js
{ _: [ 'test' ], '$0': '/Users/runner/runners/2.165.2/work/ungit/ungit/node_modules/.bin/grunt' }
```
whereas on linux
```js
{ _: [ 'test' ], '$0': 'node_modules/.bin/grunt' }
```
and windows
```js
{ _: [ 'test' ], '$0': 'node_modules\\grunt\\bin\\grunt' }
```
only the relative path is provided.