### PR TITLE
Better focus handling when creating branches and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 - Bump dependencies [#1283](https://github.com/FredrikNoren/ungit/pull/1283)
+- Better focus handling when creating branches and tags
 
 ## [1.5.4](https://github.com/FredrikNoren/ungit/compare/v1.5.3...v1.5.4)
 

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -75,14 +75,6 @@ class GitNodeViewModel extends Animateable {
     this.newBranchName = ko.observable();
     this.newBranchNameHasFocus = ko.observable(true);
     this.branchingFormVisible = ko.observable(false);
-    this.newBranchNameHasFocus.subscribe(newValue => {
-      if (!newValue) {
-        // Small timeout because in ff the form is hidden before the submit click event is registered otherwise
-        setTimeout(() => {
-          this.branchingFormVisible(false);
-        }, 200);
-      }
-    });
     this.canCreateRef = ko.computed(() => this.newBranchName() && this.newBranchName().trim() && !this.newBranchName().includes(' '));
     this.branchOrder = ko.observable();
     this.aboveNode = undefined;

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -41,11 +41,11 @@
         <span class="newRef" data-bind="css: { editing: branchingFormVisible }">
           <button class="showBranchingForm bootstrap-tooltip" data-bind="html: $parent.plusIcon, click: showBranchingForm, visible: !branchingFormVisible()" data-toggle="tooltip" data-placement="bottom" title="Create a branch or tag"></button>
           <!-- ko if: branchingFormVisible -->
-          <div class="form-inline">
+          <form class="form-inline" data-bind="hasfocus2: branchingFormVisible, submit: createBranch">
             <input class="name form-control" type="text" data-bind="value: newBranchName, hasfocus: newBranchNameHasFocus, valueUpdate: 'afterkeydown'"/>
             <button class="btn btn-primary" type="submit" value="Branch" data-bind="click: createBranch, enable: canCreateRef">Branch</button>
             <button class="btn btn-default" data-bind="click: createTag, enable: canCreateRef">Tag</button>
-          </div>
+          </form>
           <!-- /ko -->
         </span>
         <!-- /ko -->

--- a/nmclicktests/environment.js
+++ b/nmclicktests/environment.js
@@ -134,10 +134,29 @@ Nightmare.action('ug', {
   },
   '_createRef': function(type, name, done) {
     this.ug.click('.current ~ .newRef button.showBranchingForm')
-      .insert('.newRef.editing input', name)
+      // nightmare insert calls blur... (https://github.com/segmentio/nightmare/blob/b230e85375bb084007a54c6a1bf698d81b5f2feb/lib/actions.js#L347)
+      .evaluate(function(selector, value) {
+        var element = document.querySelector(selector);
+        if (!element) {
+          throw new Error(`Element not found ${selector}`);
+        }
+        element.value = value;
+        /* jshint ignore:start */
+        element.dispatchEvent(new KeyboardEvent('keydown'));
+        /* jshint ignore:end */
+      }, '.newRef.editing input', name)
       .wait(100)
+      // nightmare click calls blur... (https://github.com/segmentio/nightmare/blob/b230e85375bb084007a54c6a1bf698d81b5f2feb/lib/actions.js#L107)
+      .evaluate(function(selector) {
+        var element = document.querySelector(selector);
+        if (!element) {
+          throw new Error(`Element not found ${selector}`);
+        }
+        /* jshint ignore:start */
+        element.dispatchEvent(new MouseEvent('click'));
+        /* jshint ignore:end */
+      }, `.newRef ${type === 'branch' ? '.btn-primary' : '.btn-default'}`)
       // cannot use .ug.click as wait op will defocus and doms will disappear
-      .click(`.newRef ${type === 'branch' ? '.btn-primary' : '.btn-default'}`)
       .wait(`.ref.${type}[data-ta-name="${name}"]`)
       .wait(300)
       .then(done.bind(null, null), done);

--- a/public/source/knockout-bindings.js
+++ b/public/source/knockout-bindings.js
@@ -183,14 +183,28 @@ ko.bindingHandlers.modal = {
 };
 
 
-// For some reason the standard hasFocus binder doesn't fire events on div objects with tabIndex's
-ko.bindingHandlers.hasFocus2 = {
+// handle focus for this element and all children. only when this element or all of its chlidren have lost focus set the value to false.
+ko.bindingHandlers.hasfocus2 = {
   init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-    element.addEventListener('focus', function() {
+    var hasFocus = false;
+    var timeout;
+
+    ko.utils.registerEventHandler(element, "focusin", handleElementFocusIn);
+    ko.utils.registerEventHandler(element, "focusout",  handleElementFocusOut);
+
+    function handleElementFocusIn() {
+      hasFocus = true;
       valueAccessor()(true);
-    });
-    element.addEventListener('blur', function() {
-      valueAccessor()(false);
-    });
+    }
+    function handleElementFocusOut() {
+      hasFocus = false;
+
+      clearTimeout(timeout);
+      timeout = setTimeout(function() {
+        if (!hasFocus) {
+          valueAccessor()(false);
+        }
+      }, 50);
+    }
   }
 };


### PR DESCRIPTION
- The focus handling when creating a new branch or tag wasn't very user friendly because the form go closed after the name input lost focus + 200ms. E.g. using the keyboard to tab through the buttons wasn't possible and also sometimes a direct click wasn't recognised because of the losing focus.

- The branching form now is a form again so it is possible to create branches by just pressing enter. It got lost during the refactoring in https://github.com/FredrikNoren/ungit/pull/630

- The clicktest has been updated to use a custom `insert` and `click` function because the standard nightmare methods call blur methods which interfered with the focus logic. This was reliable reproduceable on macOS: [before](https://github.com/campersau/ungit/runs/474826569?check_suite_focus=true#step:19:331)  [after](https://github.com/campersau/ungit/runs/475287075?check_suite_focus=true)