### PR TITLE
Prepare version 1.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-sudo: required
+os:
+  - linux
+  - osx
+#  - windows
 language: node_js
 node_js:
   - node
@@ -9,14 +12,16 @@ branches:
     - master
     - /^v\d+\.\d+\.\d+$/
 env:
-  matrix:
+  jobs:
     - GIT_VERSION=edge
     - GIT_VERSION=default
-matrix:
+jobs:
   exclude:
     - node_js: "12"
       env: GIT_VERSION=edge
     - node_js: "10"
+      env: GIT_VERSION=edge
+    - os: windows
       env: GIT_VERSION=edge
 addons:
   apt:
@@ -24,16 +29,32 @@ addons:
       - xvfb
       - libgconf-2-4
       - wine
+  homebrew:
+    update: true
+    casks:
+      - xquartz
+      - wine-stable
+before_install:
+  # linux
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then export DISPLAY=':99.0'; fi
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & fi
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then wine --version; fi
+  - if [[ $TRAVIS_OS_NAME = "linux" && $GIT_VERSION = "edge" ]]; then sudo add-apt-repository ppa:git-core/ppa -y && sudo apt-get update -q && sudo apt-get install -y git; fi
+  # osx
+  - if [[ $TRAVIS_OS_NAME = "osx" ]]; then export WINEDLLOVERRIDES='mscoree,mshtml='; fi
+  - if [[ $TRAVIS_OS_NAME = "osx" ]]; then wine64 --version; fi
+  - if [[ $TRAVIS_OS_NAME = "osx" && $GIT_VERSION = "edge" ]]; then brew reinstall git; fi
+  # windows
+  # required for git clone ("git-receive-pack") and submodule ("git-submodule") tests
+  - if [[ $TRAVIS_OS_NAME = "windows" ]]; then export "PATH=$PATH:/c/Program Files/Git/mingw64/libexec/git-core/"; fi
+  # currently fails with Exit code was '1'
+  - if [[ $TRAVIS_OS_NAME = "windows" && $GIT_VERSION = "edge" ]]; then choco install git; fi
 install:
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-  - if [ "$GIT_VERSION" = "edge" ]; then sudo add-apt-repository ppa:git-core/ppa -y && sudo apt-get update -q && sudo apt-get install -y git; fi
   - npm ci
 before_script:
-  - wine --version
   - git config --global user.email "test@testy.com"
   - git config --global user.name "Test testy"
-  - git version
+  - git --version
   - DISPLAY= npm run package
 after_success:
   - npm run travisnpmpublish
@@ -50,4 +71,4 @@ deploy:
   body: "[Changelog](https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md#${TRAVIS_TAG//[v\\.]})"
   on:
     tags: true
-    condition: $GIT_VERSION = edge
+    condition: $TRAVIS_OS_NAME = "linux" && $GIT_VERSION = "edge"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.4...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.5...master)
+
+## [1.5.5](https://github.com/FredrikNoren/ungit/compare/v1.5.4...v1.5.5)
 
 ### Fixed
 - Bump dependencies [#1283](https://github.com/FredrikNoren/ungit/pull/1283)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
### Fixed
- Bump dependencies [#1283](https://github.com/FredrikNoren/ungit/pull/1283)
- Running npm scripts on macOS [#1287](https://github.com/FredrikNoren/ungit/pull/1287)
- Reduce CPU and Memory consumption in textdiff. Addresses part of [#1091](https://github.com/FredrikNoren/ungit/issues/1091)
- Better focus handling when creating branches and tags [#1288](https://github.com/FredrikNoren/ungit/pull/1288)
- Don't show error page when reloading the page [#1289](https://github.com/FredrikNoren/ungit/issues/1289)
- Periodically update author date of commits again [#1286](https://github.com/FredrikNoren/ungit/pull/1286)

Since some of the issues were found on macOS I am going to enable osx tests on travis. I have also prepared everything for windows tests on travis but commented it out for now.