### PR TITLE
Set git core.editor=: to prevent opening git editor

### DIFF
--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -9,7 +9,7 @@ const isWindows = /^win/.test(process.platform);
 const Bluebird = require('bluebird');
 const fs = require('./utils/fs-async');
 const gitEmptyReproSha1 = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'; // https://stackoverflow.com/q/9765453
-const gitConfigArguments = ['-c', 'color.ui=false', '-c', 'core.quotepath=false', '-c', 'core.pager=cat'];
+const gitConfigArguments = ['-c', 'color.ui=false', '-c', 'core.quotepath=false', '-c', 'core.pager=cat', '-c', 'core.editor=:'];
 const gitSem = require('locks').createSemaphore(config.maxConcurrentGitOperations);
 const gitOptionalLocks = config.isGitOptionalLocks ? '--no-optional-locks' : '';
 const gitBin = (() => {
@@ -42,7 +42,6 @@ const gitExecutorProm = (args, retryCount) => {
       let stderr = '';
       let env = JSON.parse(JSON.stringify(process.env));
       env['LC_ALL'] = 'C';
-      env['GIT_EDITOR'] = ':';
       const procOpts = { cwd: args.repoPath, maxBuffer: 1024 * 1024 * 100, detached: false, env: env }
       const gitProcess = child_process.spawn(gitBin, args.commands, procOpts);
       if (args.timeout) {

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -9,7 +9,7 @@ const isWindows = /^win/.test(process.platform);
 const Bluebird = require('bluebird');
 const fs = require('./utils/fs-async');
 const gitEmptyReproSha1 = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'; // https://stackoverflow.com/q/9765453
-const gitConfigArguments = ['-c', 'color.ui=false', '-c', 'core.quotepath=false', '-c', 'core.pager=cat', '-c', 'rebase.backend=apply' /* fix for #1301 */];
+const gitConfigArguments = ['-c', 'color.ui=false', '-c', 'core.quotepath=false', '-c', 'core.pager=cat'];
 const gitSem = require('locks').createSemaphore(config.maxConcurrentGitOperations);
 const gitOptionalLocks = config.isGitOptionalLocks ? '--no-optional-locks' : '';
 const gitBin = (() => {
@@ -41,7 +41,8 @@ const gitExecutorProm = (args, retryCount) => {
       let stdout = '';
       let stderr = '';
       let env = JSON.parse(JSON.stringify(process.env));
-      env['LC_ALL'] = 'C'
+      env['LC_ALL'] = 'C';
+      env['GIT_EDITOR'] = ':';
       const procOpts = { cwd: args.repoPath, maxBuffer: 1024 * 1024 * 100, detached: false, env: env }
       const gitProcess = child_process.spawn(gitBin, args.commands, procOpts);
       if (args.timeout) {


### PR DESCRIPTION
Follow up to https://github.com/FredrikNoren/ungit/pull/1305 after [I have asked on the git mailing list](http://public-inbox.org/git/CAJTX9qQUDr6qywMjN0=2OL7AFdbkwGRB1zpKj_fi2_=LEdVGBg@mail.gmail.com/T/). The recommendation there was to set the `GIT_EDITOR=:` environment variable but the `core.editor=:` config option also works to prevent opening the git editor in general.

Fixes https://github.com/FredrikNoren/ungit/issues/1301