### PR TITLE
fix bumpdependencies by not relying on Object.keys order

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -295,10 +295,8 @@ module.exports = (grunt) => {
     let currentVersion = packageJson[dependencyType][packageName];
     if (currentVersion[0] == '~' || currentVersion[0] == '^') currentVersion = currentVersion.slice(1);
     return pkgVersions(packageName).then((versionSet) => {
-      const versions = Array.from(versionSet).reverse();
-      const latestVersion = versions.find((version) => {
-        return semver.prerelease(version) === null;
-      });
+      const versions = Array.from(versionSet);
+      const latestVersion = semver.maxSatisfying(versions, '*');
       if (semver.gt(latestVersion, currentVersion)) {
         packageJson[dependencyType][packageName] = '~' + latestVersion;
       }


### PR DESCRIPTION
[`pkg-versions` uses `Object.keys`](https://github.com/sindresorhus/pkg-versions/blob/d548b95001574add793f5059be74c41c0942a608/index.js#L6) which does not return the keys in order (at least for big objects).