### PR TITLE
Node watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.6...master)
 
+### Fixed
+- Recursive watch now works on Linux as well [#1164](https://github.com/FredrikNoren/ungit/issues/1164)
+
 ## [1.5.6](https://github.com/FredrikNoren/ungit/compare/v1.5.5...v1.5.6)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ Auto Refresh
 ------------
 Ungit will watch git directory recursively upon page view and automatically refresh contents on git operations or changes on files that are not configured to be ignored in `.gitignore`.
 
-One caveat is that node's [`fs.watch()`](https://nodejs.org/docs/latest/api/fs.html#fs_fs_watch_filename_options_listener) with `recursive: true` option is only available in Mac and Windows.  For non Mac and Windows machines, git operations will be automatically refreshed but file changes may require manual refreshes as `fs.watch()` is unable to detect changes within nested directory hierarchy.
-
 Text Editor Integrations
 -------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7261,6 +7261,11 @@
         }
       }
     },
+    "node-watch": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.3.tgz",
+      "integrity": "sha512-InVPsg51EemnMVH3fvrrSVgqVBMlksZ/mK7ZDWx/NuWdNQi28wcVJX1/BP38alraPFXbRi9jZ35OfK4Ra7l8Bg=="
+    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mkdirp": "~1.0.3",
     "moment": "~2.24.0",
     "node-cache": "~5.1.0",
+    "node-watch": "^0.6.3",
     "nprogress": "~0.2.0",
     "open": "~7.0.3",
     "passport": "~0.4.1",

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -106,6 +106,7 @@ ko.bindingHandlers.autocomplete = {
 
 // Used to catch when a user was tabbed away and re-visits the page.
 // If fs.watch worked better on Windows (i.e. on subdirectories) we wouldn't need this
+// TODO is this still needed?
 (function detectReActivity() {
   var lastMoved = Date.now();
   document.addEventListener('mousemove', function() {

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -103,22 +103,6 @@ ko.bindingHandlers.autocomplete = {
   }
 };
 
-
-// Used to catch when a user was tabbed away and re-visits the page.
-// If fs.watch worked better on Windows (i.e. on subdirectories) we wouldn't need this
-// TODO is this still needed?
-(function detectReActivity() {
-  var lastMoved = Date.now();
-  document.addEventListener('mousemove', function() {
-    // If the user didn't move for 3 sec and then moved again, it's likely it's a tab-back
-    if (Date.now() - lastMoved > 3000) {
-      console.log('Fire change event due to re-activity');
-      programEvents.dispatch({ event: 'working-tree-changed' });
-    }
-    lastMoved = Date.now();
-  });
-})();
-
 function WindowTitle() {
   this.path = 'ungit';
   this.crash = false;

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -56,9 +56,9 @@ exports.registerApi = (env) => {
         }
       }).then(() => {
         const watcher = watch(pathToWatch, options || {});
-        watcher.on('change', (event, filename) => {
-          if (!filename) return;
-          const filePath = path.join(subfolderPath, filename);
+        watcher.on('change', (event, changedPath) => {
+          if (!changedPath) return;
+          const filePath = path.relative(socket.watcherPath, changedPath);
           winston.debug(`File change: ${filePath}`);
           if (isFileWatched(filePath, socket.ignore)) {
             winston.info(`${filePath} triggered refresh for ${socket.watcherPath}`);


### PR DESCRIPTION
Use the node-watch drop-in replacement to provide recursive watching on Linux

Fixes #1164 