### PR TITLE
use node 10 for publishing artifacts and releasing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,66 +63,66 @@ jobs:
 
       # publish artifacts
       - run: npm run electronpublish
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
 
       - name: Upload ungit-darwin-x64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-darwin-x64
           path: dist/ungit-darwin-x64.zip
 
       - name: Upload ungit-linux-arm64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-linux-arm64
           path: dist/ungit-linux-arm64.zip
 
       - name: Upload ungit-linux-armv7l
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-linux-armv7l
           path: dist/ungit-linux-armv7l.zip
 
       - name: Upload ungit-linux-ia32
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-linux-ia32
           path: dist/ungit-linux-ia32.zip
 
       - name: Upload ungit-linux-x64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-linux-x64
           path: dist/ungit-linux-x64.zip
 
       - name: Upload ungit-mas-x64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-mas-x64
           path: dist/ungit-mas-x64.zip
 
       - name: Upload ungit-win32-arm64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-win32-arm64
           path: dist/ungit-win32-arm64.zip
 
       - name: Upload ungit-win32-ia32
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-win32-ia32
           path: dist/ungit-win32-ia32.zip
 
       - name: Upload ungit-win32-x64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '*'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: ungit-win32-x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ deploy:
   body: "[Changelog](https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md#${TRAVIS_TAG//[v\\.]})"
   on:
     tags: true
-    condition: $TRAVIS_OS_NAME = "linux" && $GIT_VERSION = "edge"
+    condition: $TRAVIS_OS_NAME = "linux" && $TRAVIS_NODE_VERSION = "10"


### PR DESCRIPTION
node 14 (the current latest version) breaks clicktests on linux, not sure why exactly yet.

Examples:
https://travis-ci.org/github/FredrikNoren/ungit/builds/679684386
https://github.com/FredrikNoren/ungit/runs/619568794