### PR TITLE
Fix ref-search button display

### DIFF
--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -51,8 +51,8 @@ class GitNodeViewModel extends Animateable {
       if (newValue) {
         this.branches(newValue.filter((r) => r.isBranch));
         this.tags(newValue.filter((r) => r.isTag));
-        this.tagsToDisplay(this.tags.slice(0, maxTagsToDisplay));
-        this.branchesToDisplay(this.branches.slice(0, ungit.config.numRefsToShow - this.tagsToDisplay().length));
+        this.branchesToDisplay(this.branches.slice(0, ungit.config.numRefsToShow - Math.min(this.tags().length, maxTagsToDisplay)));
+        this.tagsToDisplay(this.tags.slice(0, ungit.config.numRefsToShow - this.branchesToDisplay().length));
       } else {
         this.branches.removeAll();
         this.tags.removeAll();
@@ -72,6 +72,7 @@ class GitNodeViewModel extends Animateable {
       programEvents.dispatch({ event: 'graph-render' });
     });
     this.showNewRefAction = ko.computed(() => !graph.currentActionContext());
+    this.showRefSearch = ko.computed(() => (this.branches().length + this.tags().length) > ungit.config.numRefsToShow);
     this.newBranchName = ko.observable();
     this.newBranchNameHasFocus = ko.observable(true);
     this.branchingFormVisible = ko.observable(false);

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -50,7 +50,7 @@
         </span>
         <!-- /ko -->
 
-        <!-- ko if: refs().length > 0 -->
+        <!-- ko if: showRefSearch -->
         <span class="ref-icons" data-bind="css: { editing: branchingFormVisible }">
           <button class="showSearchForm bootstrap-tooltip" type="button" data-bind="html: $parent.searchIcon, click: showRefSearchForm, visible: !refSearchFormVisible()" data-toggle="tooltip" data-placement="bottom" title="Search for a branch or tag"></button>
           <div class="form-inline" data-bind="visible: refSearchFormVisible()">


### PR DESCRIPTION
Fix what @jung-kim intended to fix in #1311, but got lost in the whitespace-refactor:
Only show search button if there are hidden refs.

It was included in the first commit of that PR, but subsequently lost:
https://github.com/FredrikNoren/ungit/blob/80fb354caba0c9d316a4a7960994afc10dad6ad9/components/graph/graph.html#L44

---

Also fixes an issue with the selection of tags and branches to display:
For `numRefsToShow` = 5, `numBranchesToShow` = 3, and `numTagsToShow` = 2,
only enforce the branch and tag numbers if the total number of refs exceeds the limit.
Examples: 
- 3 branches and 2 tags -> 3 branches and 2 tags
- 5 branches and 1 tag -> 4 branches and 1 tag
- 5 branches and 2 tags -> 3 branches and 2 tags
- 2 branches and 5 tags -> 2 branches and 3 tags
  (Previously, the tag limit would have been enforced in this case leading to only 2 tags being displayed, and with the search button change, the 3. tag being not discoverable.)