### PR TITLE
Style autocompletes like dropdowns

### DIFF
--- a/components/branches/branches.less
+++ b/components/branches/branches.less
@@ -1,24 +1,30 @@
 @import "public/less/variables.less";
 
-.branch .options {
-  font-size: inherit;
-  color: @gray-dark;
-  white-space: nowrap; // Remove with bootstrap 3.4
+.branch {
+  .options {
+    font-size: inherit;
+    color: @gray-dark;
+    white-space: nowrap; // Remove with bootstrap 3.4
 
-  label {
-    cursor: pointer;
-    font-weight: normal;
-    margin: 0 15px 0 0;
+    label {
+      cursor: pointer;
+      font-weight: normal;
+      margin: 0 15px 0 0;
 
-    &:last-child {
-      margin: 0;
+      &:last-child {
+        margin: 0;
+      }
+    }
+
+    input {
+      -moz-appearance: none;
+      -webkit-appearance: none;
+      appearance: none;
+      cursor: pointer;
     }
   }
 
-  input {
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    appearance: none;
-    cursor: pointer;
+  .dropdown-menu.octicon {
+    width: 18px;
   }
 }

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -167,6 +167,9 @@ class GitNodeViewModel extends Animateable {
     if (!$textBox.autocomplete('instance')) {
       const renderItem = (ul, item) => $(`<li><a>${item.dom}</a></li>`).appendTo(ul);
       $textBox.autocomplete({
+        classes: {
+          'ui-autocomplete': 'dropdown-menu'
+        },
         source: this.refs().filter(ref => !ref.isHEAD),
         minLength: 0,
         create: (event) => {

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -165,7 +165,7 @@ class GitNodeViewModel extends Animateable {
     const $textBox = $(textBox);
 
     if (!$textBox.autocomplete('instance')) {
-      const renderItem = (ul, item) => $(`<li><a>${item.dom}</a></li>`).appendTo(ul);
+      const renderItem = (ul, item) => $(`<li><a>${item.displayHtml()}</a></li>`).appendTo(ul);
       $textBox.autocomplete({
         classes: {
           'ui-autocomplete': 'dropdown-menu'

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -63,7 +63,6 @@ class RefViewModel extends Selectable {
     // This optimization is for autocomplete display
     this.value = splitedName[splitedName.length - 1];
     this.label = this.localRefName;
-    this.dom = `${this.localRefName}<span>${octicons[(this.isTag ? 'tag': 'git-branch')].toSVG({ 'height': 18 })}</span>`;
 
     this.displayHtml = (largeCurrent) => {
       const size = (largeCurrent && this.current()) ? 26 : 18;

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -184,6 +184,6 @@
   min-width: 150px;
 
   .octicon {
-    float: right;
+    width: 18px;
   }
 }

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -181,6 +181,8 @@
 }
 
 .ui-autocomplete {
+  min-width: 150px;
+
   .octicon {
     float: right;
   }

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -41,35 +41,27 @@
 }
 
 .ui-autocomplete {
-	background: rgba(200, 210, 230, 1);
-	box-shadow: 13px 13px 0px rgba(0, 0, 0, 0.2);
-	border-radius: 5px;
-	margin-top: 3px;
-	position: absolute;
-	display: block;
-	left: 0px;
-	top: 0px;
-	z-index: 100;
-	list-style: none;
-	padding-left: 0px;
-	margin-left: 0px;
-	padding: 3px;
-	.ui-menu-item {
-		list-style-type: none;
-		a {
-			padding: 2px;
-			padding-left: 4px;
-			border-radius: 3px;
-			display: block;
-			color: rgba(0, 0, 0, 0.6);
-			cursor: pointer;
-			text-decoration: none;
-			&.ui-state-focus, &.ui-state-active {
-				background: rgba(11, 26, 51, 1);
-				color: #fff;
-			}
-		}
-	}
+  padding: 5px 0;
+  margin: 2px 0 0 0;
+
+  &.ui-widget-content {
+    border: @dropdown-border;
+  }
+
+  .ui-menu-item {
+    list-style: none;
+
+    .ui-menu-item-wrapper {
+      padding: 3px 20px;
+
+      &.ui-state-active {
+        color: @dropdown-link-hover-color;
+        background-color: @dropdown-link-hover-bg;
+        border: none;
+        margin: 0;
+      }
+    }
+  }
 }
 
 .app-top-margin {

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -53,6 +53,9 @@ ko.bindingHandlers.autocomplete = {
   init: (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) => {
     const setAutoCompleteOptions = (sources) => {
       $(element).autocomplete({
+        classes: {
+          'ui-autocomplete': 'dropdown-menu'
+        },
         source: sources,
         minLength: 0,
         messages: {


### PR DESCRIPTION
This PR contains three separate, but related changes.
The screenshots build on top of each other, but the commits are independent.

- Style autocomplete like dropdowns
  ![image](https://user-images.githubusercontent.com/2564094/80324028-82341a00-87e3-11ea-9c61-76f53b48fafc.png) ![image](https://user-images.githubusercontent.com/2564094/80324031-85c7a100-87e3-11ea-9f5d-5a84ff3b3127.png)

- Align autocomplete ref icons with dropdown ref icons
  ![image](https://user-images.githubusercontent.com/2564094/80324048-9d068e80-87e3-11ea-8d75-309d901a2694.png)

- Fixed width for dropdown/autocomplete icons,
  so that the branch and tag names are aligned
  ![image](https://user-images.githubusercontent.com/2564094/80324074-bf001100-87e3-11ea-888c-b07b968b28a1.png) ![image](https://user-images.githubusercontent.com/2564094/80324076-c1fb0180-87e3-11ea-9adb-a975ef58ee5a.png)


