### PR TITLE
Fix for commit component with empty args object

### DIFF
--- a/components/commit/commit.js
+++ b/components/commit/commit.js
@@ -55,8 +55,8 @@ class CommitViewModel {
     this.authorDateFromNow(this.authorDate().fromNow());
     this.authorName(args.authorName);
     this.authorEmail(args.authorEmail);
-    this.numberOfAddedLines(args.total.additions);
-    this.numberOfRemovedLines(args.total.deletions);
+    this.numberOfAddedLines(args.additions);
+    this.numberOfRemovedLines(args.deletions);
     this.fileLineDiffs(args.fileLineDiffs);
     this.isInited = true;
     this.commitDiff = ko.observable(components.create('commitDiff', {

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -118,7 +118,7 @@ exports.parseGitLog = (data) => {
   let currentCommmit;
   const parseCommitLine = (row) => {
     if (!row.trim()) return;
-    currentCommmit = { refs: [], fileLineDiffs: [], total: { additions: 0, deletions: 0 } };
+    currentCommmit = { refs: [], fileLineDiffs: [], additions: 0, deletions: 0 };
     const refStartIndex = row.indexOf('(');
     const sha1s = row.substring(0, refStartIndex < 0 ? row.length : refStartIndex).split(' ').slice(1).filter((sha1) => { return sha1 && sha1.length; });
     currentCommmit.sha1 = sha1s[0];
@@ -186,10 +186,10 @@ exports.parseGitLog = (data) => {
     const nextRow = row.slice(fileChangeRegex.lastIndex + 1);
     for (let fileLineDiff of currentCommmit.fileLineDiffs) {
       if (!isNaN(parseInt(fileLineDiff.additions, 10))) {
-        currentCommmit.total.additions += fileLineDiff.additions = parseInt(fileLineDiff.additions, 10);
+        currentCommmit.additions += fileLineDiff.additions = parseInt(fileLineDiff.additions, 10);
       }
       if (!isNaN(parseInt(fileLineDiff.deletions, 10))) {
-        currentCommmit.total.deletions += fileLineDiff.deletions = parseInt(fileLineDiff.deletions, 10);
+        currentCommmit.deletions += fileLineDiff.deletions = parseInt(fileLineDiff.deletions, 10);
       }
     }
     parser = parseCommitLine;

--- a/test/spec.git-api.conflict.js
+++ b/test/spec.git-api.conflict.js
@@ -210,7 +210,8 @@ describe('git-api conflict merge', function () {
     return common.get(req, '/gitlog', { path: testDir }).then((res) => {
       expect(res.nodes).to.be.a('array');
       expect(res.nodes.length).to.be(4);
-      expect(res.nodes[0].total).to.eql({additions: 1, deletions: 1});
+      expect(res.nodes[0].additions).to.eql(1);
+      expect(res.nodes[0].deletions).to.eql(1);
       expect(res.nodes[0].fileLineDiffs.length).to.be(1);
       expect(res.nodes[0].fileLineDiffs[0]).to.eql({
         additions: 1,

--- a/test/spec.git-parser.js
+++ b/test/spec.git-parser.js
@@ -170,10 +170,8 @@ describe('git-parser parseGitLog', () => {
     expect(gitParser.parseGitLog(gitLog)[0]).to.eql({
       authorName: "Test ungit",
       committerName: "Test ungit",
-      total: {
-        "additions": 0,
-        "deletions": 0
-      },
+      additions: 0,
+      deletions: 0,
       fileLineDiffs: [],
       isHead: true,
       message: "",
@@ -232,10 +230,8 @@ describe('git-parser parseGitLog', () => {
       commitDate: "Fri Jan 4 14:54:06 2019 +0100",
       committerEmail: "test@example.com",
       committerName: "Test ungit",
-      total: {
-        "additions": 176,
-        "deletions": 1
-      },
+      additions: 176,
+      deletions: 1,
       fileLineDiffs: [
         {
           "additions": 1,
@@ -272,10 +268,8 @@ describe('git-parser parseGitLog', () => {
       commitDate: "Fri Jan 4 14:03:56 2019 +0100",
       committerEmail: "test@example.com",
       committerName: "Test ungit",
-      total: {
-        "additions": 32,
-        "deletions": 0
-      },
+      additions: 32,
+      deletions: 0,
       fileLineDiffs: [
         {
           "additions": 32,
@@ -302,10 +296,8 @@ describe('git-parser parseGitLog', () => {
       commitDate: "Fri Jan 4 14:02:56 2019 +0100",
       committerEmail: "test@example.com",
       committerName: "Test ungit",
-      total: {
-        "additions": 0,
-        "deletions": 0
-      },
+      additions: 0,
+      deletions: 0,
       fileLineDiffs: [],
       isHead: false,
       message: "empty commit",
@@ -323,10 +315,8 @@ describe('git-parser parseGitLog', () => {
       commitDate: "Fri Jan 4 14:01:56 2019 +0100",
       committerEmail: "test@example.com",
       committerName: "Test ungit",
-      total: {
-        "additions": 14,
-        "deletions": 9
-      },
+      additions: 14,
+      deletions: 9,
       fileLineDiffs: [
         {
           "additions": 4,
@@ -392,10 +382,8 @@ describe('git-parser parseGitLog', () => {
       commitDate: "Fri Jan 4 14:03:56 2019 +0100",
       committerEmail: "test@example.com",
       committerName: "Test ungit",
-      total: {
-        "additions": 32,
-        "deletions": 0
-      },
+      additions: 32,
+      deletions: 0,
       fileLineDiffs: [
         {
           "additions": 32,
@@ -442,10 +430,8 @@ describe('git-parser parseGitLog', () => {
       commitDate: "Fri Jan 4 14:03:56 2019 +0100",
       committerEmail: "test@example.com",
       committerName: "Test ungit",
-      total: {
-        "additions": 32,
-        "deletions": 0
-      },
+      additions: 32,
+      deletions: 0,
       fileLineDiffs: [
         {
           "additions": 32,
@@ -485,10 +471,8 @@ describe('git-parser parseGitLog', () => {
     expect(gitParser.parseGitLog(gitLog)[0]).to.eql({
       authorEmail: "test@example.com",
       authorName: "Test Ungit",
-      total: {
-        "additions": 0,
-        "deletions": 0
-      },
+      additions: 0,
+      deletions: 0,
       fileLineDiffs: [],
       isHead: true,
       message: "",
@@ -515,10 +499,8 @@ describe('git-parser parseGitLog', () => {
     expect(gitParser.parseGitLog(gitLog)[0]).to.eql({
       authorEmail: "test@example.com",
       authorName: "Test Ungit",
-      total: {
-        "additions": 0,
-        "deletions": 0
-      },
+      additions: 0,
+      deletions: 0,
       fileLineDiffs: [],
       isHead: true,
       message: "",
@@ -549,10 +531,8 @@ describe('git-parser parseGitLog', () => {
     expect(gitParser.parseGitLog(gitLog)[0]).to.eql(
       {
         refs: [ 'HEAD', 'refs/heads/git-parser-specs' ],
-        total: {
-          "additions": 32,
-          "deletions": 0
-        },
+        additions: 32,
+        deletions: 0,
         fileLineDiffs: [
           {
             "additions": 32,


### PR DESCRIPTION
Flatten total-lines-changed object to allow the commit object to not error when passed an empty object. 