### PR TITLE
Reduce jQuery UI imports and use Bootstrap tooltips

### DIFF
--- a/components/commit/commit.html
+++ b/components/commit/commit.html
@@ -12,11 +12,11 @@
             <span class="title" data-bind="text: (title().length > 72 ? title().substring(0, 72) + '...' : title)"></span>
             <span class="text-muted">by <a data-bind="text: authorName, attr: { href: 'mailto:' + authorEmail() }"></a></span>
             <!-- ko if: pgpVerifiedString() -->
-              <span class="text-muted" data-bind="html: pgpIcon, attr: { title: pgpVerifiedString() }" class="bootstrap-tooltip" data-toggle="tooltip" data-placement="top"></span>
+              <span class="text-muted bootstrap-tooltip" data-bind="html: pgpIcon, attr: { title: pgpVerifiedString() }" data-toggle="tooltip"></span>
             <!-- /ko -->
           </div>
           <div class="text-muted nodeSummaryContainer">
-            <span data-bind="text: authorDateFromNow, attr: { title: authorDate }" class="bootstrap-tooltip" data-toggle="tooltip" data-placement="bottom" data-delay='{"show":"2000", "hide":"0"}'></span> |
+            <span data-bind="text: authorDateFromNow, attr: { title: authorDate }" class="bootstrap-tooltip" data-toggle="tooltip" data-placement="bottom"></span> |
             +<span data-bind="text: numberOfAddedLines"></span>,
             -<span data-bind="text: numberOfRemovedLines"></span>
              |

--- a/components/commitdiff/commitdiff.html
+++ b/components/commitdiff/commitdiff.html
@@ -1,16 +1,16 @@
 <div class="btn-toolbar" data-bind="visible: showDiffButtons" >
   <div class="btn-group btn-group-xs">
-    <button class="btn btn-default bootstrap-tooltip commit-whitespace" data-bind="click: whiteSpace.toggle, css: {active: whiteSpace.isActive}" data-toggle="tooltip" data-placement="bottom" title="Hide whitespace changes in diff" data-delay='{"show":"2000", "hide":"0"}'>
+    <button class="btn btn-default bootstrap-tooltip commit-whitespace" data-bind="click: whiteSpace.toggle, css: {active: whiteSpace.isActive}" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Hide whitespace changes in diff">
       <span data-bind="text: whiteSpace.text"></span>
     </button>
   </div>
   <div class="btn-group btn-group-xs">
-    <button class="btn btn-default bootstrap-tooltip commit-sideBySideDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
+    <button class="btn btn-default bootstrap-tooltip commit-sideBySideDiff" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Show side by side diff view">
       <span data-bind="text: textDiffType.text"></span>
     </button>
   </div>
   <div class="btn-group btn-group-xs">
-    <button class="btn btn-default bootstrap-tooltip commit-wordwrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
+    <button class="btn btn-default bootstrap-tooltip commit-wordwrap" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Wrap words per line">
       <span data-bind="text: wordWrap.text"></span>
     </button>
   </div>

--- a/components/header/header.html
+++ b/components/header/header.html
@@ -1,5 +1,5 @@
 <div class="navbar navbar-default navbar-fixed-top">
-  <a class="backlink bootstrap-tooltip" href="#/" data-toggle="tooltip" data-placement="bottom" title="Navigate to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'>
+  <a class="backlink bootstrap-tooltip" href="#/" data-toggle="tooltip" data-placement="bottom" title="Navigate to ungit home page">
     <span class="back-icon octicon-circled" data-bind="html: backIcon, css: { 'back-icon-shown': showBackButton }"></span>
     <img class="headerLogo" src="images/logoLarge.png" alt="Ungit Logo" />
   </a>
@@ -7,7 +7,7 @@
   <div class="form-container">
     <form class="path-input-form" data-bind="submit: submitPath">
       <input class="form-control input-lg" type="text" data-bind="value: path, autocomplete: path" placeholder="Enter path to repository" aria-label="Path to repository" />
-      <button class="btn btn-default bootstrap-tooltip add-to-repolist" type="button" data-bind="html: addIcon, visible: showAddToRepoListButton, click: addCurrentPathToRepoList" data-toggle="tooltip" data-placement="bottom" title="Add current git directory to Ungit home page" data-delay='{"show":"2000", "hide":"0"}'></button>
+      <button class="btn btn-default bootstrap-tooltip add-to-repolist" type="button" data-bind="html: addIcon, visible: showAddToRepoListButton, click: addCurrentPathToRepoList" data-toggle="tooltip" data-placement="bottom" title="Add current git directory to Ungit home page"></button>
     </form>
   </div>
   <div class="toolbar">

--- a/components/refreshbutton/refreshbutton.html
+++ b/components/refreshbutton/refreshbutton.html
@@ -1,1 +1,1 @@
-<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="html: refreshIcon, css: { 'btn-lg': isLarge }, click: refresh" data-toggle="tooltip" data-placement="bottom" title="Refresh changes" data-delay='{"show":"2000", "hide":"0"}'></button>
+<button class="btn btn-default refresh-button bootstrap-tooltip" data-bind="html: refreshIcon, css: { 'btn-lg': isLarge }, click: refresh" data-toggle="tooltip" data-placement="bottom" title="Refresh changes"></button>

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -46,31 +46,31 @@
         <div class="btn-toolbar">
           <div class="commands btn-group btn-group-sm">
             <button class="btn btn-default" disabled data-bind="text: stats"></button>
-            <button class="btn btn-default bootstrap-tooltip" data-bind="click: toggleAllStages" data-toggle="tooltip" data-placement="bottom" title="Toggle all uncommitted files for commit" data-delay='{"show":"1000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: toggleAllStages" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Toggle all uncommitted files for commit">
               <span class="glyphicon" data-bind="css: toggleSelectAllGlyphClass"></span>
               Toggle all
             </button>
-            <button class="btn btn-default bootstrap-tooltip" data-bind="click: discardAllChanges" data-toggle="tooltip" data-placement="bottom" title="Discard all uncommitted file changes, including not showing files" data-delay='{"show":"1000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: discardAllChanges" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Discard all uncommitted file changes, including not showing files">
               <span data-bind="html: discardAllIcon"></span>
               Discard all
             </button>
-            <button class="btn btn-default bootstrap-tooltip stash-all" data-bind="click: stashAll, css: { disabled: !canStashAll() }" data-toggle="tooltip" data-placement="bottom" title="Stash all uncommitted file changes, including not showing files" data-delay='{"show":"1000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip stash-all" data-bind="click: stashAll, css: { disabled: !canStashAll() }" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Stash all uncommitted file changes, including not showing files">
               <span data-bind="html: stashIcon"></span>
               Stash all
             </button>
           </div>
           <div class="btn-group btn-group-sm pull-right">
-            <button class="btn btn-default bootstrap-tooltip" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" title="Wrap words per line" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: wordWrap.toggle, css: {active: wordWrap.isActive}" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Wrap words per line">
               <span data-bind="text: wordWrap.text"></span>
             </button>
           </div>
           <div class="btn-group btn-group-sm pull-right">
-            <button class="btn btn-default bootstrap-tooltip" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" title="Show side by side diff view" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: textDiffType.toggle, css: {active: textDiffType.isActive}" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Show side by side diff view">
               <span data-bind="text: textDiffType.text"></span>
             </button>
           </div>
           <div class="btn-group btn-group-sm pull-right">
-            <button class="btn btn-default bootstrap-tooltip" data-bind="click: whiteSpace.toggle, css: {active: whiteSpace.isActive}" data-toggle="tooltip" data-placement="bottom" title="Hide whitespace changes in diff" data-delay='{"show":"2000", "hide":"0"}'>
+            <button class="btn btn-default bootstrap-tooltip" data-bind="click: whiteSpace.toggle, css: {active: whiteSpace.isActive}" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Hide whitespace changes in diff">
               <span data-bind="text: whiteSpace.text"></span>
             </button>
           </div>
@@ -90,9 +90,9 @@
             <span class="deletions" data-bind="text: deletions"></span>
             <span class="modified" data-bind="visible: modified">Modified</span>
             <span class="conflict" data-bind="visible: conflict"><span class="temporary">Conflicts</span><span class="launchmergetool explanation" data-bind="visible: mergeTool, click: launchMergeTool">Launch Merge Tool</span><span class="markresolved explanation" data-bind="click: resolveConflict">Mark as Resolved</span></span>
-            <button class="patch btn bootstrap-tooltip" data-bind="visible: isShowPatch(), click: patchClick" data-toggle="tooltip" data-placement="top" title="Patch changes">Patch</button>
-            <button class="ignore btn bootstrap-tooltip" data-bind="html: $parent.ignoreIcon, click: ignoreFile" data-toggle="tooltip" data-placement="top" title="Add to .gitignore"></button>
-            <button class="discard btn bootstrap-tooltip" data-bind="html: $parent.discardIcon, click: discardChanges" data-toggle="tooltip" data-placement="top" title="Discard changes"></button>
+            <button class="patch btn bootstrap-tooltip" data-bind="visible: isShowPatch(), click: patchClick" data-toggle="tooltip" title="Patch changes">Patch</button>
+            <button class="ignore btn bootstrap-tooltip" data-bind="html: $parent.ignoreIcon, click: ignoreFile" data-toggle="tooltip" title="Add to .gitignore"></button>
+            <button class="discard btn bootstrap-tooltip" data-bind="html: $parent.discardIcon, click: discardChanges" data-toggle="tooltip" title="Discard changes"></button>
             <!-- ko if: isShowingDiffs -->
             <div class="diffContainer" data-bind="component: diff"></div>
             <!-- /ko -->

--- a/components/stash/stash.html
+++ b/components/stash/stash.html
@@ -20,7 +20,7 @@
           <div class="diff-inner" data-bind="component: commitDiff"></div>
         </div>
         <!-- /ko -->
-        <button type="button" class="btn btn-default list-item-remove bootstrap-tooltip" data-bind="html: dropIcon, click: drop" data-toggle="tooltip" data-placement="top" title="Drop this stash"></button>
+        <button type="button" class="btn btn-default list-item-remove bootstrap-tooltip" data-bind="html: dropIcon, click: drop" data-toggle="tooltip" title="Drop this stash"></button>
       </div>
     </div>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6096,10 +6096,10 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
-    "jquery-ui-bundle": {
+    "jquery-ui": {
       "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui-bundle/-/jquery-ui-bundle-1.12.1.tgz",
-      "integrity": "sha1-1r4uTDd0lOI3ixyuKSCpHRGC2MQ="
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
     "js-yaml": {
       "version": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "hasher": "~1.2.0",
     "ignore": "~5.1.4",
     "jquery": "~3.4.1",
-    "jquery-ui-bundle": "~1.12.1",
+    "jquery-ui": "~1.12.1",
     "just-detect-adblock": "~1.0.0",
     "knockout": "~3.5.1",
     "latest-version": "~5.1.0",

--- a/public/less/generic.less
+++ b/public/less/generic.less
@@ -4,6 +4,7 @@
 
 @import "../vendor/less/bootstrap/bootstrap.less";
 @import (inline) "../../node_modules/nprogress/nprogress.css";
+@import (inline) "../../node_modules/jquery-ui/themes/base/core.css";
 @import (inline) "../../node_modules/diff2html/bundles/css/diff2html.min.css";
 @import (inline) "../../node_modules/@primer/octicons/build/build.css";
 @import "variables.less";

--- a/public/less/generic.less
+++ b/public/less/generic.less
@@ -4,7 +4,6 @@
 
 @import "../vendor/less/bootstrap/bootstrap.less";
 @import (inline) "../../node_modules/nprogress/nprogress.css";
-@import (inline) "../../node_modules/jquery-ui-bundle/jquery-ui.min.css";
 @import (inline) "../../node_modules/diff2html/bundles/css/diff2html.min.css";
 @import (inline) "../../node_modules/@primer/octicons/build/build.css";
 @import "variables.less";

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -20,25 +20,14 @@
 
 // -- Application specific styling ----
 .ui-autocomplete {
-  padding: 5px 0;
-  margin: 2px 0 0 0;
+  .ui-menu-item-wrapper {
+    cursor: pointer;
 
-  &.ui-widget-content {
-    border: @dropdown-border;
-  }
-
-  .ui-menu-item {
-    list-style: none;
-
-    .ui-menu-item-wrapper {
-      padding: 3px 20px;
-
-      &.ui-state-active {
-        color: @dropdown-link-hover-color;
-        background-color: @dropdown-link-hover-bg;
-        border: none;
-        margin: 0;
-      }
+    &.ui-state-active {
+      color: @dropdown-link-hover-color;
+      background-color: @dropdown-link-hover-bg;
+      border: none;
+      margin: 0;
     }
   }
 }

--- a/public/less/variables.less
+++ b/public/less/variables.less
@@ -33,6 +33,11 @@
 // Navbar
 @navbar-default-bg: #2b3844;
 
+// Tooltips
+@tooltip-color: @text-color;
+@tooltip-bg: #3c4653;
+@tooltip-arrow-width: 8px;
+
 // Modals
 @modal-content-bg: @panel-bg;
 @modal-header-border-color: @list-group-border;

--- a/public/source/jquery-ui.js
+++ b/public/source/jquery-ui.js
@@ -1,0 +1,20 @@
+/**
+ * Import the autocomplete widget and its dependencies.
+ * The current order of the imports is required.
+ */
+
+// All files require version, has to go first
+require('jquery-ui/ui/version');
+
+// Shared files, used by menu and autocomplete, in alphabetical order
+require('jquery-ui/ui/keycode');
+require('jquery-ui/ui/position');
+require('jquery-ui/ui/safe-active-element');
+require('jquery-ui/ui/unique-id');
+require('jquery-ui/ui/widget');
+
+// Required by autocomplete, so has to go before
+require('jquery-ui/ui/widgets/menu');
+
+// The autocomplete widget we use
+require('jquery-ui/ui/widgets/autocomplete');

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -1,4 +1,3 @@
-
 var _ = require('lodash');
 var $ = require('jquery');
 jQuery = $; // this is for old backward compatability of bootrap modules
@@ -7,7 +6,7 @@ var dndPageScroll = require('dnd-page-scroll');
 require('../vendor/js/bootstrap/modal');
 require('../vendor/js/bootstrap/dropdown');
 require('../vendor/js/bootstrap/tooltip');
-require('jquery-ui-bundle');
+require('./jquery-ui');
 require('./knockout-bindings');
 var components = require('ungit-components');
 var Server = require('./server');


### PR DESCRIPTION
This PR has two changes that are not easily possible to split.

Currently, ungit is (unintentionally probably) using the jQuery UI tooltips instead of the bootstrap ones.

1. Only import the jQuery UI widgets that are used, i.e. `autocomplete`
   - Switch from `jquery-ui-bundle` to `jquery-ui` package
   - Add a new file that managest the jQuery UI import
   - ~Remove jQuery UI styles import as we use our own (see #1327)~
   - Replace jQuery UI styles import with only core styles, thanks for the hint @ylecuyer 

2. Add custom styling to bootstrap tooltips
3. Fix placement of tooltips in button groups

---

![image](https://user-images.githubusercontent.com/2564094/80745029-79d62a80-8ad4-11ea-874d-9430609ff071.png) ![image](https://user-images.githubusercontent.com/2564094/80744990-6a56e180-8ad4-11ea-94c9-c7dbe1efcf72.png)


