### PR TITLE
Remove unused color dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -239,7 +239,6 @@ module.exports = (grunt) => {
     b.require('async', { expose: 'async' });
     b.require('moment', { expose: 'moment' });
     b.require('blueimp-md5', { expose: 'blueimp-md5' });
-    b.require('color', { expose: 'color' });
     b.require('signals', { expose: 'signals' });
     b.require('util', { expose: 'util' });
     b.require('path', { expose: 'path' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1744,15 +1744,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-      "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "bluebird": "~3.7.2",
     "blueimp-md5": "~2.13.0",
     "body-parser": "~1.19.0",
-    "color": "~3.1.2",
     "cookie-parser": "~1.4.5",
     "crossroads": "~0.12.2",
     "dedent": "~0.7.0",


### PR DESCRIPTION
Even though the `color` package is required and exposed during browserify, I could not find any usage of it.