### PR TITLE
Fix: init tooltips from the app start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.6...master)
 
 ### Fixed
+- Init tooltips from the app start [#1343](https://github.com/FredrikNoren/ungit/pull/1343)
 - Fixing some accessibility issues [#1318](https://github.com/FredrikNoren/ungit/pull/1318)
 
 ### Changed

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -124,7 +124,6 @@ class GraphViewModel {
           this.graphHeight(nodes[nodes.length - 1].cy() + 80);
         }
         this.graphWidth(1000 + (this.heighstBranchOrder * 90));
-        programEvents.dispatch({ event: 'init-tooltip' });
       }).catch((e) => this.server.unhandledRejection(e))
       .finally(() => {
         if (window.innerHeight - this.graphHeight() > 0 && nodeSize != this.nodes().length) {

--- a/components/staging/staging.js
+++ b/components/staging/staging.js
@@ -188,7 +188,6 @@ class StagingViewModel {
       newFiles.push(fileViewModel);
     }
     this.files(newFiles);
-    programEvents.dispatch({ event: 'init-tooltip' });
   }
 
   toggleAmend() {

--- a/public/source/main.js
+++ b/public/source/main.js
@@ -16,7 +16,7 @@ var navigation = require('ungit-navigation');
 var storage = require('ungit-storage');
 var adBlocker = require('just-detect-adblock');
 
-// Request animation frame polyfill
+// Request animation frame polyfill and init tooltips
 (function() {
   var lastTime = 0;
   var vendors = ['ms', 'moz', 'webkit', 'o'];
@@ -41,12 +41,9 @@ var adBlocker = require('just-detect-adblock');
       clearTimeout(id);
     };
 
-  programEvents.add(function(event) {
-    if (event.event === 'init-tooltip') {
-      $('.bootstrap-tooltip').tooltip().removeClass('bootstrap-tooltip');
-    }
+  $(document).tooltip({
+    selector: '.bootstrap-tooltip'
   });
-
 }());
 
 ko.bindingHandlers.autocomplete = {


### PR DESCRIPTION
**Before**
Base on @campersau comment here : https://github.com/FredrikNoren/ungit/pull/1340#issuecomment-622092861

Tooltip are not loaded until a repo is opened

![80755823-c7cd4b80-8b31-11ea-970d-9e9c7e892f68](https://user-images.githubusercontent.com/1866809/80843597-f9fbad80-8c04-11ea-8b5d-96c8a1a1c692.png)

**Fix**

Instead of relying on some hand made event to init tooltips, this PR uses the event-delegation method provided by bootstrap tooltip (based on jquery.on) to init tooltips on existing elements and new elements.

https://getbootstrap.com/docs/4.0/components/tooltips/

![Screenshot_2020-05-01_23-36-05](https://user-images.githubusercontent.com/1866809/80843412-8c4f8180-8c04-11ea-9f44-b45c3eef5e21.png)
