### PR TITLE
remove window information from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,17 +94,5 @@
     "node": ">=10.18"
   },
   "license": "MIT",
-  "main": "public/main.js",
-  "window": {
-    "title": "Ungit",
-    "icon": "icon.png",
-    "toolbar": false,
-    "frame": false,
-    "show": false,
-    "width": 1000,
-    "height": 600,
-    "position": "center",
-    "min_width": 400,
-    "min_height": 200
-  }
+  "main": "public/main.js"
 }


### PR DESCRIPTION
This was added a long time ago  when node-webkit was used instead of electron. https://github.com/FredrikNoren/ungit/commit/68cd534c0e8a60125fbd513660485e3c41f614b5