### PR TITLE
Add dev and prod build options

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "unittest": "grunt unittest",
     "clicktest": "grunt clicktest",
     "build": "grunt",
-    "watch": "grunt watch",
+    "dev": "grunt --dev",
+    "watch": "grunt watch --dev",
     "package": "grunt package",
     "travisnpmpublish": "grunt travisnpmpublish",
     "electronpublish": "grunt electronpublish"
@@ -87,7 +88,8 @@
     "pkg-versions": "~2.1.0",
     "puppeteer": "~3.0.3",
     "superagent": "~5.2.2",
-    "supertest": "~4.0.2"
+    "supertest": "~4.0.2",
+    "tinyify": "~2.5.2"
   },
   "engines": {
     "node": ">=10.18"


### PR DESCRIPTION
This PR adds a flag to the grunt build to switch between `dev` and `prod` mode.
The build is changed to compress and optimize the less and js bundles, buts adds inline source maps to the files in dev mode.

File size comparison after including #1350, #1351, and #1352 comparing to latest release:
```
                 1.5.7     prod     dev   
styles.css        191kb    129kb     474kb
ungit.js         4882kb    500kb    3506kb
components        357kb     96kb     665kb
component js      344kb     85kb     624kb
component css      13kb     11kb      41kb
```
*Note, that css only have sourcemaps in the new dev build.*

I tried to create source maps as separate files to be loaded when required, but couldn't get it to work correctly with less. (Source map path has to adapted to future server serving location.)

Running the browserify optimizations (from the [`tinyify`](https://www.npmjs.com/package/tinyify) plugin) increases the time that task takes significantly. For development, we might want to look into better watch-options, for example [`watchify`](https://www.npmjs.com/package/watchify), which in turn might be difficult to integrate into the current grunt workflow, especially since we are not using any grunt-browserify. (Longer term, a shift from grunt to npm scripts might be the best way. It already seems to be the way the community is going.)

@campersau @jung-kim @wmertens Would love some feedback on this.