### PR TITLE
Clear git-promise timeout when git command was successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.7...master)
 
+### Fixed
+- Clear git-promise timeout when git command was successful [#1357](https://github.com/FredrikNoren/ungit/pull/1357)
+
 ### Changed
 - Migrate clicktests from nightmare to puppeteer [#1336](https://github.com/FredrikNoren/ungit/pull/1336)
 


### PR DESCRIPTION
While trying to migrate from grunt to script files, I noticed that the mocha unittest weren't existing right away. I tracked the problem down with [`wtfnode`](https://github.com/myndzi/wtfnode) to our git-promise timeout (introduced in https://github.com/FredrikNoren/ungit/pull/1192) which wasn't cancelled if the git call was successful and didn't timed out.