### PR TITLE
Format less files

### DIFF
--- a/components/commit/commit.less
+++ b/components/commit/commit.less
@@ -5,8 +5,9 @@
 
   &.highlighted {
     z-index: 2;
+
     .commit-box {
-      box-shadow: 5px 5px 0px rgba(0, 0, 0, 0.2);
+      box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.2);
       background: #4b5766;
       left: -5px;
 
@@ -19,20 +20,24 @@
       }
     }
   }
+
   &.hover {
     z-index: 3;
   }
+
   &.selected {
     .details {
       .diff-wrapper {
         margin-bottom: 5px;
         transition: width 0.1s, left 0.05s;
-        box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.15);
+
         .diff-inner {
-          box-shadow: 5px 5px 0px rgba(0, 0, 0, 0.2);
+          box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.2);
           padding: 10px;
-          padding-top: 0px;
+          padding-top: 0;
         }
+
         .btn-group {
           margin-top: 10px;
         }
@@ -57,9 +62,8 @@
 
   .commit-box > .panel-body {
     position: relative;
-
     padding: 10px;
-    margin-bottom: 0px;
+    margin-bottom: 0;
     width: @log-width-small;
     min-height: 85px;
 
@@ -73,12 +77,14 @@
       word-wrap: break-word;
       display: block;
     }
+
     .details {
       .body {
         white-space: pre-wrap;
         word-wrap: break-word;
         color: #8f9fa6;
       }
+
       .diff-wrapper {
         margin-top: 10px;
         background: #4b5766;
@@ -92,6 +98,7 @@
   .commit {
     .commit-box > .panel-body {
       width: @log-width-large;
+
       .gravatar {
         display: block;
       }

--- a/components/commitdiff/commitdiff.less
+++ b/components/commitdiff/commitdiff.less
@@ -1,9 +1,11 @@
 .commitdiff {
   width: 100%;
+
   .file {
     margin-top: 5px;
     background: rgba(255, 255, 255, 0.16);
     border-radius: 3px;
+
     .head {
       display: block;
       cursor: pointer;
@@ -12,29 +14,36 @@
       padding-right: 6px;
       color: rgba(255, 255, 255, 0.79);
       word-wrap: break-word;
+
       .file-stats {
         span:nth-of-type(1)::before {
           content: '+';
         }
+
         span:nth-of-type(1) {
           color: #9bf3a9;
         }
+
         span:nth-of-type(2)::before {
           content: '-';
         }
+
         span:nth-of-type(2) {
           color: #ec9d93;
         }
       }
     }
+
     .diff {
       background: rgba(0, 0, 0, 0.11);
+
       .textDiff {
         color: rgba(255, 255, 255, 0.3);
       }
     }
   }
 }
+
 .loadMore {
   .btn {
     display: block;

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -7,6 +7,7 @@
 
   .graphLog {
     left: 575px;
+
     .loadAhead {
       cursor: pointer;
       animation: throb 1s ease alternate infinite;
@@ -17,6 +18,7 @@
     50% {
       r: 20;
     }
+
     100% {
       r: 18;
     }
@@ -46,7 +48,7 @@
       display: inline-block;
       opacity: 0.6;
       cursor: move;
-      margin: 7px 0px 4px 0px;
+      margin: 7px 0 4px 0;
       outline: none;
       padding: 2px 5px 2px 5px;
       border: 3px solid transparent;
@@ -57,8 +59,9 @@
       &.dragging.focused {
         border-color: transparent;
       }
+
       &.focused {
-        border-color: #fff;
+        border-color: #ffffff;
       }
 
       &.current {
@@ -68,16 +71,18 @@
         margin-top: 2px;
         margin-bottom: -2px;
       }
+
       &.remote {
         color: #5db4ff;
       }
+
       &.tag {
         color: #eef266;
       }
     }
 
     .graphAction {
-      color: #fff;
+      color: #ffffff;
       cursor: pointer;
       transition: all 0.5s ease 0.2s;
       transition-property: opacity;
@@ -101,36 +106,47 @@
       &.push {
         background: rgba(61, 139, 255, 0.9);
       }
+
       &.pull {
         background: rgba(38, 189, 189, 0.9);
       }
+
       &.reset {
         background: rgba(255, 129, 31, 0.9);
       }
+
       &.rebase {
         background: rgba(65, 222, 60, 0.9);
       }
+
       &.squash {
         background: rgba(100, 60, 222, 0.9);
       }
+
       &.move {
         background: rgba(0, 0, 0, 0.1);
       }
+
       &.merge {
         background: rgba(208, 135, 212, 0.9);
       }
+
       &.checkout {
         background: rgba(205, 219, 55, 0.9);
       }
+
       &.delete {
         background: rgba(214, 77, 56, 0.9);
       }
+
       &.cherry-pick {
         background: rgba(110, 156, 110, 0.9);
       }
+
       &.uncommit {
         background: rgba(158, 53, 20, 0.9);
       }
+
       &.revert {
         background: rgba(179, 135, 43, 0.9);
       }
@@ -141,35 +157,41 @@
       padding-top: 2px;
       padding-bottom: 2px;
       margin-left: 5px;
+
       .showBranchingForm {
         background: transparent;
-        border: 0px;
+        border: 0;
         cursor: pointer;
-        padding: 0px;
-        margin: 0px;
+        padding: 0;
+        margin: 0;
         margin-top: 9px;
         -webkit-text-stroke-width: 1px;
         color: rgba(255, 255, 255, 0.3);
+
         &:hover {
           color: rgba(255, 255, 255, 0.8);
         }
       }
+
       .showSearchForm {
         background: transparent;
-        border: 0px;
+        border: 0;
         cursor: pointer;
-        padding: 0px;
-        margin: 0px;
+        padding: 0;
+        margin: 0;
         margin-top: 9px;
         -webkit-text-stroke-width: 1px;
         color: rgba(255, 255, 255, 0.3);
+
         &:hover {
           color: rgba(255, 255, 255, 0.8);
         }
       }
+
       .form-inline {
         display: inline-block;
       }
+
       input.name {
         width: 150px;
       }

--- a/components/header/header.less
+++ b/components/header/header.less
@@ -7,7 +7,7 @@
 .navbar {
   padding-top: 13px;
   z-index: 5;
-  box-shadow: 0px 15px 15px #252833;
+  box-shadow: 0 15px 15px #252833;
   height: 81px;
 
   .backlink {
@@ -15,6 +15,7 @@
     margin-top: 7px;
     position: absolute;
     color: #686868;
+
     &:hover {
       text-decoration: none;
       color: #a5a5a5;
@@ -31,23 +32,28 @@
       }
     }
   }
+
   .form-container {
     margin-left: 180px;
     margin-right: 72px;
+
     .path-input-form {
       width: 100%;
       position: relative;
+
       .form-control {
         font-size: 1.7em;
         width: 100%;
       }
+
       .add-to-repolist {
         position: absolute;
         right: 4px;
         top: 6px;
         background: transparent;
-        border: 0px;
+        border: 0;
         opacity: 0.3;
+
         &:hover {
           opacity: 0.8;
         }
@@ -56,7 +62,7 @@
   }
 
   .arrow {
-    bottom: 0px;
+    bottom: 0;
     left: 300px;
     border-bottom-color: @body-bg;
   }
@@ -68,6 +74,7 @@
     font-size: 12px;
   }
 }
+
 .toolbar {
   position: absolute;
   right: 10px;
@@ -78,6 +85,7 @@
   width: 100px;
   height: auto;
 }
+
 .version {
   padding-left: 140px;
 }

--- a/components/home/home.less
+++ b/components/home/home.less
@@ -1,14 +1,17 @@
 .home {
   .nux {
     text-align: center;
+
     .logo-large {
       margin-top: 20px;
       margin-bottom: 50px;
     }
   }
+
   .repository {
     position: relative;
     min-height: 62px;
+
     &.path-removed {
       .list-group-item-heading {
         color: #cf5353;

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -2,7 +2,7 @@
 
 .staging {
   background: #643a44;
-  box-shadow: 0px -1px 15px #252833;
+  box-shadow: 0 -1px 15px #252833;
   color: #b8a5a5;
   z-index: 5;
   position: relative;
@@ -33,12 +33,13 @@
     color: #d6542d;
     padding: 0.25em;
   }
+
   &:hover .validationError {
     display: inline-block;
   }
 
   .diffContainer {
-    margin-top: 0px;
+    margin-top: 0;
     border-radius: 3px;
     background: rgba(255, 255, 255, 0.1);
   }
@@ -54,7 +55,7 @@
 
     &:focus,
     &:hover {
-      background: #000;
+      background: #000000;
       color: rgba(255, 255, 255, 0.9);
     }
   }
@@ -71,7 +72,7 @@
 
     &:focus,
     &:hover {
-      background: #55f;
+      background: #5555ff;
       color: rgba(255, 255, 255, 0.9);
     }
   }
@@ -101,30 +102,34 @@
 
   .files {
     position: relative;
+
     .file {
+      padding: 0.3em;
+
       &.showingDiffs {
         .name {
           background: rgba(255, 255, 255, 0.1);
-          color: #000;
-          border-bottom-left-radius: 0px;
-          border-bottom-right-radius: 0px;
+          color: #000000;
+          border-bottom-left-radius: 0;
+          border-bottom-right-radius: 0;
         }
       }
+
       .checkmark {
         span {
           top: 5px;
         }
       }
+
       .name {
         background: transparent;
         font-size: 1.3em;
         cursor: pointer;
         padding: 3px;
-        border: 0px;
+        border: 0;
         border-radius: 3px;
         color: rgba(255, 255, 255, 0.8);
       }
-      padding: 0.3em;
 
       .new,
       .deleted,
@@ -135,55 +140,69 @@
         padding-left: 5px;
         padding-right: 5px;
       }
+
       .new,
       .additions {
         color: #949494;
         vertical-align: middle;
       }
+
       .deleted,
       .deletions {
         color: #7b7b7b;
         vertical-align: middle;
       }
+
       .conflict {
         color: #db12c0;
+
         .explanation {
           display: none;
         }
+
         &:hover {
           .explanation {
             display: inline;
           }
+
           .temporary {
             display: none;
           }
         }
       }
+
       .markresolved {
         color: #db12c0;
         cursor: pointer;
+
         .explanation {
           display: none;
         }
+
         &:hover {
           background: #a445ed;
-          color: #000;
+          color: #000000;
           border-radius: 3px;
+
           .explanation {
             display: inline;
           }
         }
       }
+
       .launchmergetool {
         color: #db55ff;
         cursor: pointer;
+
         .explanation {
           display: none;
         }
+
         &:hover {
           background: #a477ff;
-          color: #000;
+          color: #000000;
           border-radius: 3px;
+
           .explanation {
             display: inline;
           }
@@ -201,9 +220,6 @@
   }
 }
 
-@media (min-width: @screen-lg-min) {
-}
-
 .commit-message-title-counter {
   right: 20px;
   position: absolute;
@@ -211,6 +227,7 @@
 
 .amend-button {
   padding: 0;
+
   &:active,
   &:focus,
   &:hover {
@@ -219,10 +236,11 @@
 }
 
 .checkmark {
-  color: #fff;
+  color: #ffffff;
   display: inline-block;
   opacity: 0.3;
   cursor: pointer;
+
   &.checked {
     opacity: 0.8;
   }

--- a/components/stash/stash.less
+++ b/components/stash/stash.less
@@ -4,16 +4,20 @@
   margin-right: 20px;
   margin-bottom: -15px;
   background: #55323c;
+
   h4 {
-    margin-top: 0px;
+    margin-top: 0;
   }
+
   .toggle-show-commit-diffs {
     display: inline-block;
   }
+
   .diff-wrapper {
     margin-top: 5px;
   }
 }
+
 .stash-toggle {
   width: 120px;
   height: 30px;
@@ -24,6 +28,7 @@
   padding-top: 5px;
   text-align: center;
 }
+
 .stash-toggle-text {
   cursor: pointer;
 }

--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -15,6 +15,7 @@
 
   tbody > tr > td {
     padding: 0;
+
     &.d2h-code-side-linenumber {
       padding: 0 0.5em;
     }

--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -112,7 +112,7 @@ div.list-group-item {
   .list-link {
     float: right;
     margin-top: -23px;
-    padding: 0px 4px;
+    padding: 0 4px;
   }
 
   .list-url {


### PR DESCRIPTION
While prettier does some formatting of less files (double to single quotes, lowercase hex colors), it doesn't do others. 

Formatting in this PR that is not done by prettier:
- Empty line before rule
- Remove units for zero values (`0px` → `0`)
- Use long form for color declarations (`#ff5` → `#ffff55`)
  (This makes it easier to later regex all colors.)
- Remove empty rules