### PR TITLE
Remove ansi-color devDependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,5 @@
 const browserify = require('browserify');
 const childProcess = require('child_process');
-const cliColor = require('ansi-color');
 const electronPackager = require('electron-packager');
 const path = require('path');
 const pkgVersions = require('pkg-versions');
@@ -336,7 +335,7 @@ module.exports = (grunt) => {
             let output = '';
             const outStream = (data) => (output += data);
 
-            grunt.log.writeln(cliColor.set(`Clicktest started! \t${file}`, 'blue'));
+            grunt.log.writeln(`Clicktest started! \t${file}`);
             return new Promise((resolve, reject) => {
               const child = childProcess.execFile(
                 './node_modules/mocha/bin/mocha',
@@ -351,11 +350,11 @@ module.exports = (grunt) => {
               });
             })
               .then(() => {
-                grunt.log.writeln(cliColor.set(`'Clicktest success! \t${file}`, 'green'));
+                grunt.log.ok(`'Clicktest success! \t${file}`);
                 return { name: file, output: output, isSuccess: true };
               })
               .catch(() => {
-                grunt.log.writeln(cliColor.set(`'Clicktest fail! \t'${file}`, 'red'));
+                grunt.log.error(`'Clicktest fail! \t'${file}`);
                 return { name: file, output: output, isSuccess: false };
               });
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,12 +185,6 @@
       "dev": true,
       "optional": true
     },
-    "ansi-color": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-color/-/ansi-color-0.2.1.tgz",
-      "integrity": "sha1-PnXAN0dSF1RO12Oo21cJ+prlv5o=",
-      "dev": true
-    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "yargs": "~15.3.1"
   },
   "devDependencies": {
-    "ansi-color": "~0.2.1",
     "browserify": "~16.5.1",
     "dedent": "~0.7.0",
     "electron": "~8.2.5",


### PR DESCRIPTION
The package is only used in one grunt task (parallel clicktests) to color output.
Grunt can achieve similar coloring [itself](https://gruntjs.com/api/grunt.log#grunt.log.ok-grunt.verbose.ok).

Additionally, when looking at the [ansi-color npm](https://www.npmjs.com/package/ansi-color) and [GitHub](https://github.com/loopj/commonjs-ansi-color) page I noticed that the license is [**not clearly Open Source**](https://github.com/loopj/commonjs-ansi-color/issues/13), so we might be better off without this particular package even if we want something to color console output.