### PR TITLE
Split up grunt less task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,17 +15,23 @@ module.exports = (grunt) => {
     .filter((component) => component.isDirectory())
     .map((component) => component.name);
 
-  const lessFiles = {
-    'public/css/styles.css': ['public/less/styles.less'],
-  };
-  components
-    .map((component) => `components/${component}/${component}`)
-    .forEach((str) => (lessFiles[`${str}.css`] = `${str}.less`));
-
   grunt.initConfig({
     pkg: packageJson,
     less: {
-      production: { files: lessFiles },
+      common: {
+        files: {
+          'public/css/styles.css': ['public/less/styles.less'],
+        },
+      },
+      components: {
+        files: components
+          .map((component) => `components/${component}/${component}`)
+          .filter((componentPath) => fs.existsSync(`${componentPath}.less`))
+          .reduce((files, componentPath) => {
+            files[`${componentPath}.css`] = `${componentPath}.less`;
+            return files;
+          }, {}),
+      },
     },
     watch: {
       scripts: {
@@ -36,8 +42,15 @@ module.exports = (grunt) => {
         },
       },
       less: {
-        files: ['public/less/*.less', 'public/styles/*.less', 'components/**/*.less'],
-        tasks: ['less:production'],
+        files: ['public/less/*.less'],
+        tasks: ['less:common'],
+        options: {
+          spawn: false,
+        },
+      },
+      componentsLess: {
+        files: ['components/**/*.less'],
+        tasks: ['less:components'],
         options: {
           spawn: false,
         },


### PR DESCRIPTION
Split up the grunt less task into `common` and `components` following the `browserify` tasks for the following benefits:
- Clearer structure
- Nicer output
- More granular watching

*Output before*
![image](https://user-images.githubusercontent.com/2564094/82129952-b3b55b00-977b-11ea-89d9-6a5be33986e8.png)

*Output now*
![image](https://user-images.githubusercontent.com/2564094/82129954-badc6900-977b-11ea-8485-de21b852ddb2.png)
