### PR TITLE
prevent tests hangs in credentials-helper

### DIFF
--- a/test/spec.credentials-helper.js
+++ b/test/spec.credentials-helper.js
@@ -22,15 +22,19 @@ describe('credentials-helper', () => {
       res.end(JSON.stringify(payload));
     });
 
+    // to avoid tests hanging after they finished
+    // set a low timeout so when an exception occurs inside of the request handler
+    // it times out faster because no response will be generated
+    server.timeout = 200;
     server.listen(config.port, '127.0.0.1');
 
     const command = `node bin/credentials-helper ${socketId} ${config.port} ${remote} get`;
     child_process.exec(command, (err, stdout, stderr) => {
+      server.close();
       expect(err).to.not.be.ok();
       const ss = stdout.split('\n');
       expect(ss[0]).to.be(`username=${payload.username}`);
       expect(ss[1]).to.be(`password=${payload.password}`);
-      server.close();
       done();
     });
   });

--- a/test/spec.credentials-helper.js
+++ b/test/spec.credentials-helper.js
@@ -11,21 +11,24 @@ describe('credentials-helper', () => {
     const remote = 'origin';
     const payload = { username: 'testuser', password: 'testpassword' };
     const server = http.createServer((req, res) => {
-      const reqUrl = url.parse(req.url);
-      expect(reqUrl.pathname).to.be('/api/credentials');
+      try {
+        const reqUrl = url.parse(req.url);
+        expect(reqUrl.pathname).to.be('/api/credentials');
 
-      const params = querystring.parse(reqUrl.query);
-      expect(params['remote']).to.be(`${remote}`);
-      expect(params['socketId']).to.be(`${socketId}`);
+        const params = querystring.parse(reqUrl.query);
+        expect(params['remote']).to.be(`${remote}`);
+        expect(params['socketId']).to.be(`${socketId}`);
 
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(payload));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      } finally {
+        if (!res.finished) {
+          res.statusCode = 500;
+          res.end();
+        }
+      }
     });
 
-    // to avoid tests hanging after they finished
-    // set a low timeout so when an exception occurs inside of the request handler
-    // it times out faster because no response will be generated
-    server.timeout = 200;
     server.listen(config.port, '127.0.0.1');
 
     const command = `node bin/credentials-helper ${socketId} ${config.port} ${remote} get`;


### PR DESCRIPTION
> The credentials-helper tests sometimes don't pass when I am having a crashed ungit instance opened in chrome because I stopped the server and the crashed ungit pages tries to reconnect by sending polling requests with socket.io which then the node server in the credentials-helper test picks up and throws inside of the request handler which means that the server does not a response and eventually times out. So to prevent this edge case we could add a timeout to the node response so it times out faster.

See https://github.com/FredrikNoren/ungit/pull/1365#issuecomment-629758116y