### PR TITLE
Fix plugin loading in electron

### DIFF
--- a/source/server.js
+++ b/source/server.js
@@ -263,36 +263,48 @@ gitApi.registerApi(apiEnvironment);
 
 // Init plugins
 const loadPlugins = (plugins, pluginBasePath) => {
-  return fs.readdir(pluginBasePath, { withFileTypes: true }).then((files) => {
-    return Promise.all(
-      files
-        // Only look at directories.
-        .filter((pluginDir) => pluginDir.isDirectory())
-        .map((pluginDir) => {
-          const pluginPath = path.join(pluginBasePath, pluginDir.name);
+  // Only look at directories.
+  return fs
+    .readdir(pluginBasePath)
+    .then((files) => {
+      const pluginDirs = [];
+      return Promise.all(
+        files.map((file) => {
+          return fs.stat(path.join(pluginBasePath, file)).then((stat) => {
+            if (stat.isDirectory()) {
+              pluginDirs.push(file);
+            }
+          });
+        })
+      ).then(() => pluginDirs);
+    })
+    .then((pluginDirs) => {
+      return Promise.all(
+        pluginDirs.map((pluginDir) => {
+          const pluginPath = path.join(pluginBasePath, pluginDir);
           return fs
             .access(path.join(pluginPath, 'ungit-plugin.json'))
             .then(() => {
               winston.info('Loading plugin: ' + pluginPath);
               const plugin = new UngitPlugin({
-                dir: pluginDir.name,
-                httpBasePath: 'plugins/' + pluginDir.name,
+                dir: pluginDir,
+                httpBasePath: 'plugins/' + pluginDir,
                 path: pluginPath,
               });
               if (plugin.manifest.disabled || plugin.config.disabled) {
-                winston.info('Plugin disabled: ' + pluginDir.name);
+                winston.info('Plugin disabled: ' + pluginDir);
                 return;
               }
               plugin.init(apiEnvironment);
               plugins.push(plugin);
-              winston.info('Plugin loaded: ' + pluginDir.name);
+              winston.info('Plugin loaded: ' + pluginDir);
             })
             .catch(() => {
               // Skip direcories that don't contain an "ungit-plugin.json".
             });
         })
-    );
-  });
+      );
+    });
 };
 const pluginsCacheKey = cache.registerFunc(() => {
   const plugins = [];


### PR DESCRIPTION
I made a mistake in https://github.com/FredrikNoren/ungit/pull/1350 which prevented ungit from beeing loaded in electron. I assumend that `fs.readdir(..., { withFileTypes: true })` would just work in electron but since we are using asar it apparently does not. See https://github.com/electron/electron/issues/19074

First commit refactors the code to the `fs.readdir` and `fs.stat` equivalent.
The second commit gets rid of the directory check completely because we already catch and ignore all errors 😄 