### PR TITLE
force mocha tests to exit to avoid hangs

### DIFF
--- a/.mochaclicktest.json
+++ b/.mochaclicktest.json
@@ -2,5 +2,6 @@
   "spec": "clicktests/spec.*.js",
   "file": "./source/utils/winston.js",
   "timeout": 35000,
-  "bail": true
+  "bail": true,
+  "exit": true
 }

--- a/.mochatest.json
+++ b/.mochatest.json
@@ -1,5 +1,6 @@
 {
   "spec": "test/spec.*.js",
   "file": "./source/utils/winston.js",
-  "timeout": 5000
+  "timeout": 5000,
+  "exit": true
 }


### PR DESCRIPTION
> There are some CI cancellations now because of tests hangs: 
> - https://github.com/FredrikNoren/ungit/runs/685921173?check_suite_focus=true
> - https://ci.appveyor.com/project/FredrikNoren/ungit/builds/32943552/job/m2anlaiuae4owaw8
> 
> So we might need to add [`--exit`](https://mochajs.org/#-exit) for now because I haven't reproduced these hangs yet.

https://github.com/FredrikNoren/ungit/pull/1365#issuecomment-630683583