### PR TITLE
When autoFetch=false don't make remote repo calls automatically

### DIFF
--- a/components/branches/branches.js
+++ b/components/branches/branches.js
@@ -27,6 +27,7 @@ class BranchesViewModel {
       this.updateRefs();
       return value;
     };
+    this.shouldAutoFetch = ungit.config.autoFetch;
     this.isShowRemote.subscribe(setLocalStorageAndUpdate.bind(null, showRemote));
     this.isShowBranch.subscribe(setLocalStorageAndUpdate.bind(null, showBranch));
     this.isShowTag.subscribe(setLocalStorageAndUpdate.bind(null, showTag));
@@ -44,7 +45,7 @@ class BranchesViewModel {
     ko.renderTemplate('branches', this, {}, parentElement);
   }
   clickFetch() {
-    this.updateRefs();
+    this.updateRefs(true);
   }
   onProgramEvent(event) {
     if (
@@ -56,7 +57,9 @@ class BranchesViewModel {
       this.updateRefsDebounced();
     }
   }
-  updateRefs() {
+  updateRefs(forceRemoteFetch) {
+    forceRemoteFetch = forceRemoteFetch || this.shouldAutoFetch || '';
+
     const currentBranchProm = this.server
       .getPromise('/branches', { path: this.repoPath() })
       .then((branches) =>
@@ -72,7 +75,7 @@ class BranchesViewModel {
 
     // refreshes tags branches and remote branches
     const refsProm = this.server
-      .getPromise('/refs', { path: this.repoPath() })
+      .getPromise('/refs', { path: this.repoPath(), remoteFetch: forceRemoteFetch })
       .then((refs) => {
         const version = Date.now();
         const sorted = refs

--- a/components/remotes/remotes.js
+++ b/components/remotes/remotes.js
@@ -45,7 +45,11 @@ class RemotesViewModel {
       event.event === 'request-fetch-tags' ||
       event.event === 'git-directory-changed'
     ) {
-      this.fetchDebounced();
+      if (
+        (event.event != 'working-tree-changed' && event.event != 'git-directory-changed') ||
+        this.shouldAutoFetch
+      )
+        this.fetchDebounced();
     }
   }
 

--- a/source/config.js
+++ b/source/config.js
@@ -58,7 +58,7 @@ const defaultConfig = {
   // Don't fast forward git mergers. See git merge --no-ff documentation
   noFFMerge: true,
 
-  // Automatically fetch from remote when entering a repository using ungit
+  // Automatically fetch from remote when entering a repository using ungit, periodically on activity detection, or on directory change
   autoFetch: true,
 
   // Used for development purposes.
@@ -234,7 +234,10 @@ const argv = yargs
   )
   .describe('noFFMerge', "Don't fast forward git mergers. See git merge --no-ff documentation")
   .boolean('noFFMerge')
-  .describe('autoFetch', 'Automatically fetch from remote when entering a repository using ungit')
+  .describe(
+    'autoFetch',
+    'Automatically fetch from remote when entering a repository using ungit, periodically on activity detection, or on directory change'
+  )
   .boolean('autoFetch')
   .describe('dev', 'Used for development purposes')
   .boolean('dev')

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -440,22 +440,27 @@ exports.registerApi = (env) => {
   app.get(`${exports.pathPrefix}/refs`, ensureAuthenticated, ensurePathExists, (req, res) => {
     if (res.setTimeout) res.setTimeout(tenMinTimeoutMs);
 
-    const task = gitPromise(['remote'], req.query.path)
-      .then((remoteText) => {
-        const remotes = remoteText.trim().split('\n');
+    let task = Promise.resolve();
+    if (req.query.remoteFetch) {
+      task = task.then(() =>
+        gitPromise(['remote'], req.query.path).then((remoteText) => {
+          const remotes = remoteText.trim().split('\n');
 
-        // making calls serially as credential helpers may get confused to which cred to get.
-        return remotes.reduce((promise, remote) => {
-          if (!remote || remote === '') return promise;
-          return promise.then(() => {
-            return gitPromise({
-              commands: credentialsOption(req.query.socketId, remote).concat(['fetch', remote]),
-              repoPath: req.query.path,
-              timeout: tenMinTimeoutMs,
-            }).catch((e) => winston.warn('err during remote fetch for /refs', e)); // ignore fetch err as it is most likely credential
-          });
-        }, Promise.resolve());
-      })
+          // making calls serially as credential helpers may get confused to which cred to get.
+          return remotes.reduce((promise, remote) => {
+            if (!remote || remote === '') return promise;
+            return promise.then(() => {
+              return gitPromise({
+                commands: credentialsOption(req.query.socketId, remote).concat(['fetch', remote]),
+                repoPath: req.query.path,
+                timeout: tenMinTimeoutMs,
+              }).catch((e) => winston.warn('err during remote fetch for /refs', e)); // ignore fetch err as it is most likely credential
+            });
+          }, Promise.resolve());
+        })
+      );
+    }
+    task = task
       .then(() => gitPromise(['show-ref', '-d'], req.query.path))
       // On new fresh repos, empty string is returned but has status code of error, simply ignoring them
       .catch((e) => {


### PR DESCRIPTION
closes #1380

Note the discardchanges test does fail with this due to:
` Error: Timeout of 5000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (ungit\test\spec.git-api.discardchanges.js)`
however I didn't see the specific reason is failing and it fails in master on my machine so ignored that.

An alternative would be to add an offline option (with a config setting to default start in this) that takes a step further to not hit remote repos and allow local work.

Review and let me know whats best.