### PR TITLE
Prevent commit message <textarea> from resizing horizontally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 ### Fixed
 - Clear git-promise timeout when git command was successful [#1357](https://github.com/FredrikNoren/ungit/pull/1357)
 - When autoFetch=false don't make remote repo calls automatically [#1381](https://github.com/FredrikNoren/ungit/pull/1381)
+- Prevent commit message <textarea> from resizing horizontally [#1390](https://github.com/FredrikNoren/ungit/pull/1390)
 
 ### Changed
 - Migrate clicktests from nightmare to puppeteer [#1336](https://github.com/FredrikNoren/ungit/pull/1336)

--- a/components/staging/staging.html
+++ b/components/staging/staging.html
@@ -26,7 +26,7 @@
           data-bind="value: commitMessageTitle, valueUpdate: 'afterkeydown', enable: !inRebase(), event: {keypress: onEnter}"
         />
         <textarea
-          class="form-control"
+          class="form-control commit-body"
           rows="2"
           placeholder="Body"
           aria-label="Commit message body"

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -13,7 +13,7 @@
     }
   }
 
-  textarea.form-control {
+  textarea.commit-body {
     resize: vertical;
   }
 

--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -13,6 +13,10 @@
     }
   }
 
+  textarea.form-control {
+    resize: vertical;
+  }
+
   .arrow {
     border-top-color: #643a44;
     left: (@log-width-small + 45px);


### PR DESCRIPTION
> Resizing horizontally (typically by accident when trying to resize vertically only, in my case) screws up the staging panel layout.  This change prevents that.

This is an adequate solution (to my mind at least) to #315, which has been bothering me too.

~If the change is acceptable, would you like me to bump the patch version and update CHANGELOG.md?  The instructions at [CONTRIBUTING.md](https://github.com/FredrikNoren/ungit/blob/master/CONTRIBUTING.md#pull-requests) seem to be out-of-date w/r/t the current CHANGELOG.md style.  Perhaps just include a line under "Fixed" in the "Unreleased" section?~

Note: the Windows test which is failing below with a 404 fetching resources is currently passing on my fork.