### PR TITLE
Prepare version 1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.7...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.8...master)
+
+## [1.5.8](https://github.com/FredrikNoren/ungit/compare/v1.5.7...v1.5.8)
 
 ### Fixed
 - Clear git-promise timeout when git command was successful [#1357](https://github.com/FredrikNoren/ungit/pull/1357)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
### Fixed
- Clear git-promise timeout when git command was successful [#1357](https://github.com/FredrikNoren/ungit/pull/1357)
- When autoFetch=false don't make remote repo calls automatically [#1381](https://github.com/FredrikNoren/ungit/pull/1381)
- Prevent commit message <textarea> from resizing horizontally [#1390](https://github.com/FredrikNoren/ungit/pull/1390)
- Diff out is not properly escaping [#1387](https://github.com/FredrikNoren/ungit/issues/1387)

### Changed
- Migrate clicktests from nightmare to puppeteer [#1336](https://github.com/FredrikNoren/ungit/pull/1336)
- Prettify code with prettier [#1316](https://github.com/FredrikNoren/ungit/pull/1316)
- Switch from JSHint to ESLint [#1360](https://github.com/FredrikNoren/ungit/pull/1360)
- Bump Dependencies [#1355](https://github.com/FredrikNoren/ungit/pull/1355), [#1385](https://github.com/FredrikNoren/ungit/pull/1385)

### Removed
- Remove bluebird dependency [#1350](https://github.com/FredrikNoren/ungit/pull/1350)
- Remove grunt [#895](https://github.com/FredrikNoren/ungit/issues/895)