### PR TITLE
Fix git ignore settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 coverage/
 dist/
 node_modules/
+public/css/
+public/js/
 
 # Ignore compiled files
 components/**/*.bundle.js

--- a/public/css/.gitignore
+++ b/public/css/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/public/js/.gitignore
+++ b/public/js/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,12 +1,17 @@
 const fsSync = require('fs');
 const fs = fsSync.promises;
 const path = require('path');
-const less = require('less');
+
 const browserify = require('browserify');
+const less = require('less');
+const mkdirp = require('mkdirp');
 
 const baseDir = path.join(__dirname, '..');
 
 (async () => {
+  await mkdirp(path.join(baseDir, 'public', 'css'));
+  await mkdirp(path.join(baseDir, 'public', 'js'));
+
   const dir = await fs.readdir('components', { withFileTypes: true });
   const components = dir
     .filter((component) => component.isDirectory())


### PR DESCRIPTION
Version 1.5.8 has the `public/js/ungit.js` and `public/css/style.css` files missing on npm.
It seems that all `.gitignore` files get transformed to `.npmignore` (unless there is an actual `.npmignore` file), even when they are in subfolders. 

This PR removes the `.gitignore` files that are not in the root folder and creates the required folders in the build step.