### PR TITLE
Generate and extract source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ public/js/
 
 # Ignore compiled files
 components/**/*.bundle.js
+components/**/*.bundle.js.map
 components/**/*.css
+components/**/*.css.map
 
 # Ignore potential files
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3193,6 +3193,49 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "exorcist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exorcist/-/exorcist-1.0.1.tgz",
+      "integrity": "sha1-eTFuPEiFhFSQ97tAXA5bXbEWfFI=",
+      "dev": true,
+      "requires": {
+        "is-stream": "~1.1.0",
+        "minimist": "0.0.5",
+        "mkdirp": "~0.5.1",
+        "mold-source-map": "~0.4.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "expect.js": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
@@ -5917,6 +5960,24 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
+        }
+      }
+    },
+    "mold-source-map": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
+      "integrity": "sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "^1.1.0",
+        "through": "~2.2.7"
+      },
+      "dependencies": {
+        "through": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-mocha": "^7.0.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "~3.1.4",
+    "exorcist": "~1.0.1",
     "expect.js": "~0.3.1",
     "less": "~3.11.3",
     "mocha": "~8.0.1",


### PR DESCRIPTION
Generate source maps for less and extract both less and browserify source maps to separate `.map` files.

This also reduces the size of the `ungit.js` bundle from 4.55mb to 1.76mb.