### PR TITLE
run bump dependency workflow manually

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,6 +6,7 @@ on:
       - master
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   bump:


### PR DESCRIPTION
It is now possible to trigger workflows manually: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/