### PR TITLE
fix tests for git 2.28

### DIFF
--- a/clicktests/spec.generic.js
+++ b/clicktests/spec.generic.js
@@ -187,7 +187,7 @@ describe('[GENERIC]', () => {
     await environment.waitForElementVisible('[data-ta-action="revert"]');
     await environment.click('[data-ta-action="revert"]');
     await environment.waitForElementVisible(
-      '[data-ta-node-title="Revert \\"Merge branch \'testbranch\'\\""]'
+      '[data-ta-node-title^="Revert \\"Merge branch \'testbranch\'"]'
     );
   });
 


### PR DESCRIPTION
merging now automatically appends the target branch name to the commit message

Before git 2.28:
```
Revert "Merge branch 'testbranch'"
```

After git 2.28:
```
Revert "Merge branch 'testbranch' into master"
```