### PR TITLE
add copyright to electron executable

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2013-2019 Fredrik Norén
+Copyright (c) 2013-2020 Fredrik Norén
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/electronpackage.js
+++ b/scripts/electronpackage.js
@@ -11,6 +11,7 @@ electronPackager({
   all: process.argv.includes('--all'),
   asar: true,
   overwrite: true,
+  appCopyright: 'Copyright (c) 2013-2020 Fredrik Norén',
   ignore: [
     /^\/(?:[^/]+?\/)*(?:\..+|.+\.less)$/, // dot-files and less files anywhere
     /^\/(?:\..+|assets|clicktests|coverage|dist|scripts|test)\//, // folders in root


### PR DESCRIPTION
https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#appcopyright

![image](https://user-images.githubusercontent.com/4009570/91440041-459a2d00-e86e-11ea-90a6-de8b4eab4d4d.png)

fixes https://github.com/FredrikNoren/ungit/issues/1411