### PR TITLE
Prepare version 1.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,17 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.9...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.10...master)
+
+## [1.5.10](https://github.com/FredrikNoren/ungit/compare/v1.5.9...v1.5.10)
+
+### Fixed
+- Add copyright to electron executable [#1411](https://github.com/FredrikNoren/ungit/issues/1411)
+
+### Changed
+- Generate and extract source maps [#1394](https://github.com/FredrikNoren/ungit/pull/1394)
+- Import Bootstrap from npm and upgrade to latest 3.x [#1395](https://github.com/FredrikNoren/ungit/pull/1395)
+- Bump Dependencies upgrading from electron 9.x to 10.x [#1392](https://github.com/FredrikNoren/ungit/pull/1392), [#1406](https://github.com/FredrikNoren/ungit/pull/1406)
 
 ## [1.5.9](https://github.com/FredrikNoren/ungit/compare/v1.5.8...v1.5.9)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
### Fixed
- Add copyright to electron executable [#1411](https://github.com/FredrikNoren/ungit/issues/1411)

### Changed
- Generate and extract source maps [#1394](https://github.com/FredrikNoren/ungit/pull/1394)
- Import Bootstrap from npm and upgrade to latest 3.x [#1395](https://github.com/FredrikNoren/ungit/pull/1395)
- Bump Dependencies upgrading from electron 9.x to 10.x [#1392](https://github.com/FredrikNoren/ungit/pull/1392), [#1406](https://github.com/FredrikNoren/ungit/pull/1406)