### PR TITLE
Prevent selection of leading space in diffs when copying and pasting

### DIFF
--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -55,6 +55,14 @@
   color: #000000;
 }
 
+.d2h-code-line {
+  user-select: none;
+}
+
+.d2h-code-line-ctn {
+  user-select: text;
+}
+
 .d2h-code-line del,
 .d2h-code-side-line del {
   background-color: rgba(255, 255, 255, 0.2);

--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -58,10 +58,13 @@
 .d2h-code-line,
 .d2h-code-side-line {
   user-select: none;
+  width: 100%;
 }
 
 .d2h-code-line-ctn {
+  display: inline-block;
   user-select: text;
+  width: 100%;
 }
 
 .d2h-code-line del,

--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -55,7 +55,8 @@
   color: #000000;
 }
 
-.d2h-code-line {
+.d2h-code-line,
+.d2h-code-side-line {
   user-select: none;
 }
 


### PR DESCRIPTION
I ([and, it seems, at least some others](https://github.com/FredrikNoren/ungit/issues/1421#issuecomment-696916968)!) often find myself wanting to copy text from diffs in the commit history or in the staging area.  In fact, I had a PR merged last year that prevented selection of line number to make this process easier (#1215, thanks!).

This PR just adds a little to that idea, by preventing the selection of the leading space that still gets copied when selecting multiple lines (this is not generally a problem when using JS and Prettier on paste, for example, but for copying Python code, for example, it's a pain).

Hopefully this proves to be more straightforward than my other recent PR!  Thanks!