### PR TITLE
Support git 2.29 sha256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Fixed
 - branches - can't re-enable disabled groups [#1434](https://github.com/FredrikNoren/ungit/issues/1434)
+- Support git 2.29 sha256 [#1436](https://github.com/FredrikNoren/ungit/pull/1436)
 
 ## [1.5.11](https://github.com/FredrikNoren/ungit/compare/v1.5.10...v1.5.11)
 

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 const isWindows = /^win/.test(process.platform);
 const fs = require('fs').promises;
 const gitEmptyReproSha1 = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'; // https://stackoverflow.com/q/9765453
+const gitEmptyReproSha256 = '6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321'; // https://stackoverflow.com/q/9765453
 const gitConfigArguments = [
   '-c',
   'color.ui=false',
@@ -364,7 +365,12 @@ git.binaryFileContent = (repoPath, filename, version, outPipe) => {
 git.diffFile = (repoPath, filename, oldFilename, sha1, ignoreWhiteSpace) => {
   if (sha1) {
     return git(['rev-list', '--max-parents=0', sha1], repoPath).then((initialCommitSha1) => {
-      const prevSha1 = sha1 == initialCommitSha1.trim() ? gitEmptyReproSha1 : `${sha1}^`;
+      const prevSha1 =
+        sha1 == initialCommitSha1.trim()
+          ? sha1.length == 64
+            ? gitEmptyReproSha256
+            : gitEmptyReproSha1
+          : `${sha1}^`;
       if (oldFilename && oldFilename !== filename) {
         return git(
           [


### PR DESCRIPTION
I have done one [CI run](https://github.com/campersau/ungit/runs/1285422580?check_suite_focus=true) (only windows had the new git 2.29 version when I tested it) with [`--object-format=sha256`](https://github.com/campersau/ungit/commit/a8bdb97c20aedbb2c0dc8118b7192d0dc76297d7) and it looks like this is the only place which failed.

More information about git 2.29 https://github.blog/2020-10-19-git-2-29-released/