### PR TITLE
Prepare version 1.5.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,12 @@ before_deploy:
   - npm run electronzip
 deploy:
   provider: releases
-  api_key: ${GITHUB_TOKEN}
+  token: ${GITHUB_TOKEN}
   name: ${TRAVIS_TAG}
   file_glob: true
   file: dist/*.zip
   overwrite: true
-  skip_cleanup: true
-  body: "[Changelog](https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md#${TRAVIS_TAG//[v\\.]})"
+  release_notes: "[Changelog](https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md#${TRAVIS_TAG//[v\\.]})"
   on:
     tags: true
     condition: $TRAVIS_OS_NAME = "linux" && $TRAVIS_NODE_VERSION = "10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.11...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.12...master)
+
+## [1.5.12](https://github.com/FredrikNoren/ungit/compare/v1.5.11...v1.5.12)
 
 ### Fixed
 - branches - can't re-enable disabled groups [#1434](https://github.com/FredrikNoren/ungit/issues/1434)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
### Fixed
- branches - can't re-enable disabled groups [#1434](https://github.com/FredrikNoren/ungit/issues/1434)
- Support git 2.29 sha256 [#1436](https://github.com/FredrikNoren/ungit/pull/1436)

### Changed
- Bump Dependencies [#1427](https://github.com/FredrikNoren/ungit/pull/1427)