### PR TITLE
Only watch recursive on mac and windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.12...master)
 
+### Fixed
+- Unhandled rejection ERR_FEATURE_NOT_AVAILABLE_ON_PLATFORM (recursive watch) [#1389](https://github.com/FredrikNoren/ungit/issues/1389)
+
 ## [1.5.12](https://github.com/FredrikNoren/ungit/compare/v1.5.11...v1.5.12)
 
 ### Fixed

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -41,7 +41,7 @@ exports.registerApi = (env) => {
           .catch(() => {})
           .then(() => {
             socket.watcher = [];
-            return watchPath(socket, '.', { recursive: true });
+            return watchPath(socket, '.', { recursive: isMac || isWindows });
           })
           .then(() => {
             if (!isMac && !isWindows) {


### PR DESCRIPTION
Since node 14 passing `recursive` on linux will throw an exception.
https://nodejs.org/docs/latest/api/fs.html#fs_caveats

https://github.com/nodejs/node/commit/67e067eb06

Fixes https://github.com/FredrikNoren/ungit/issues/1389

cc @jung-kim 