### PR TITLE
CI add node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['10', '12', '*']
+        node-version: ['10', '12', '14', '*']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 #    env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 language: node_js
 node_js:
   - node
+  - '14'
   - '12'
   - '10'
 branches:
@@ -17,6 +18,8 @@ env:
     - GIT_VERSION=default
 jobs:
   exclude:
+    - node_js: '14'
+      env: GIT_VERSION=edge
     - node_js: '12'
       env: GIT_VERSION=edge
     - node_js: '10'
@@ -66,7 +69,7 @@ deploy:
   file_glob: true
   file: dist/*.zip
   overwrite: true
-  skip_cleanup: true
+  edge: true
   release_notes: "[Changelog](https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md#${TRAVIS_TAG//[v\\.]})"
   on:
     tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ skip_branch_with_pr: true
 environment:
   matrix:
     - nodejs_version: '' # latest
+    - nodejs_version: '14'
     - nodejs_version: '12'
     - nodejs_version: '10'
 


### PR DESCRIPTION
Run tests also on node 14 (lts) as node 15 is (will be) the new latest version.
[Travis already has node 15](https://travis-ci.org/github/FredrikNoren/ungit/jobs/739090853#L867), Appveyor and GitHub need more time.