### PR TITLE
Prepare version 1.5.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.13...master)
+## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.14...master)
+
+## [1.5.14](https://github.com/FredrikNoren/ungit/compare/v1.5.13...v1.5.14)
 
 ### Changed
 - Update socket.io to version 3.0.0 [#1443](https://github.com/FredrikNoren/ungit/pull/1443)
-- Bump Dependencies [#1442](https://github.com/FredrikNoren/ungit/pull/1442), [#1444](https://github.com/FredrikNoren/ungit/pull/1444)
+- Bump Dependencies [#1442](https://github.com/FredrikNoren/ungit/pull/1442), [#1444](https://github.com/FredrikNoren/ungit/pull/1444), [#1448](https://github.com/FredrikNoren/ungit/pull/1448), [#1449](https://github.com/FredrikNoren/ungit/pull/1449)
 
 ## [1.5.13](https://github.com/FredrikNoren/ungit/compare/v1.5.12...v1.5.13)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ungit",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ungit",
   "author": "Fredrik Norén <fredrik.jw.noren@gmail.com>",
   "description": "Git made easy",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "ungitPluginApiVersion": "0.2.0",
   "scripts": {
     "start": "node ./bin/ungit",


### PR DESCRIPTION
### Changed
- Update socket.io to version 3.0.0 [#1443](https://github.com/FredrikNoren/ungit/pull/1443)
- Bump Dependencies [#1442](https://github.com/FredrikNoren/ungit/pull/1442), [#1444](https://github.com/FredrikNoren/ungit/pull/1444), [#1448](https://github.com/FredrikNoren/ungit/pull/1448), [#1449](https://github.com/FredrikNoren/ungit/pull/1449)

Since electron got bumped to 11.x.x we now also support darwin-arm64 electron builds.