### PR TITLE
Types: add support for VSCode IntelliSense

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "endOfLine": "lf",
+  "jsdocUseInlineCommentForASingleTagBlock": true,
+  "plugins": ["./node_modules/@homer0/prettier-plugin-jsdoc"],
   "printWidth": 100,
   "singleQuote": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ungit",
       "version": "1.5.18",
       "license": "MIT",
       "dependencies": {
@@ -55,6 +54,8 @@
         "ungit": "bin/ungit"
       },
       "devDependencies": {
+        "@homer0/prettier-plugin-jsdoc": "~4.0.6",
+        "@types/mocha": "~9.1.0",
         "archiver": "~5.3.0",
         "browserify": "~17.0.0",
         "dedent": "~0.7.0",
@@ -621,6 +622,21 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/@homer0/prettier-plugin-jsdoc": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@homer0/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-4.0.6.tgz",
+      "integrity": "sha512-56dJNpRUIVrbd+1c4jgZCXIp9Gj4dSyIdUXzQBMU+fPhYJJI3YLIrcJ+WYw0Q6+JK7XFRvqDAujVr73ep3BQxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-parser": "^1.2.4",
+        "prettier": "^2.4.1",
+        "ramda": "0.27.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -992,6 +1008,13 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "14.14.44",
@@ -2536,6 +2559,15 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/commondir": {
@@ -12760,6 +12792,17 @@
         }
       }
     },
+    "@homer0/prettier-plugin-jsdoc": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@homer0/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-4.0.6.tgz",
+      "integrity": "sha512-56dJNpRUIVrbd+1c4jgZCXIp9Gj4dSyIdUXzQBMU+fPhYJJI3YLIrcJ+WYw0Q6+JK7XFRvqDAujVr73ep3BQxg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^1.2.4",
+        "prettier": "^2.4.1",
+        "ramda": "0.27.1"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -13061,9 +13104,9 @@
       "optional": true
     },
     "@types/mocha": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.1.tgz",
-      "integrity": "sha512-NysN+bNqj6E0Hv4CTGWSlPzMW6vTKjDpOteycDkV4IWBsO+PU48JonrPzV9ODjiI2XrjmA05KInLgF5ivZ/YGQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "dev": true
     },
     "@types/node": {
@@ -14352,6 +14395,12 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
       "dev": true
     },
     "commondir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13060,6 +13060,12 @@
       "dev": true,
       "optional": true
     },
+    "@types/mocha": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.1.tgz",
+      "integrity": "sha512-NysN+bNqj6E0Hv4CTGWSlPzMW6vTKjDpOteycDkV4IWBsO+PU48JonrPzV9ODjiI2XrjmA05KInLgF5ivZ/YGQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.14.44",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.44.tgz",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "yargs": "~17.2.1"
   },
   "devDependencies": {
-    "@homer0/prettier-plugin-jsdoc": "^2.0.0",
-    "@types/mocha": "^8.2.1",
+    "@homer0/prettier-plugin-jsdoc": "~4.0.6",
+    "@types/mocha": "~9.1.0",
     "archiver": "~5.3.0",
     "browserify": "~17.0.0",
     "dedent": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@homer0/prettier-plugin-jsdoc": "^2.0.0",
+    "@types/mocha": "^8.2.1",
     "archiver": "~5.3.0",
     "browserify": "~17.0.0",
     "dedent": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "yargs": "~17.2.1"
   },
   "devDependencies": {
+    "@homer0/prettier-plugin-jsdoc": "^2.0.0",
     "archiver": "~5.3.0",
     "browserify": "~17.0.0",
     "dedent": "~0.7.0",

--- a/public/source/bootstrap.js
+++ b/public/source/bootstrap.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Import the Bootstrap components individually.
  */
 

--- a/public/source/jquery-ui.js
+++ b/public/source/jquery-ui.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Import the autocomplete widget and its dependencies.
  * The current order of the imports is required.
  */

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -124,17 +124,27 @@ const gitExecutorProm = (args, retryCount) => {
 };
 
 /**
- * Returns a promise that executes git command with given arguments
+ * Returns a promise that executes git command with given arguments.
+ *
  * @function
- * @param {obj|array} commands - An object that represents all parameters or first parameter only, which is an array of commands
- * @param {string} repoPath - path to the git repository
- * @param {boolean=} allowError - true if return code of 1 is acceptable as some cases errors are acceptable
- * @param {stream=} outPipe - if this argument exists, stdout is piped to this object
- * @param {stream=} inPipe - if this argument exists, data is piped to stdin process on start
- * @param {timeout=} timeout - execution timeout, default is 2 mins
- * @returns {promise} execution promise
- * @example getGitExecuteTask({ commands: ['show'], repoPath: '/tmp' });
- * @example getGitExecuteTask(['show'], '/tmp');
+ * @param {obj | Array} commands    - An object that represents all parameters or first parameter
+ *                                  only, which is an array of commands.
+ * @param {string}      repoPath    - path to the git repository.
+ * @param {boolean=}    allowError  - true if return code of 1 is acceptable as some cases errors
+ *                                  are acceptable.
+ * @param {stream=}     outPipe     - if this argument exists, stdout is piped to this object.
+ * @param {stream=}     inPipe      - if this argument exists, data is piped to stdin process on
+ *                                  start.
+ * @param {timeout=}    timeout     - execution timeout, default is 2 mins.
+ * @returns {promise} Execution promise.
+ * @example
+ *
+ *   getGitExecuteTask({ commands: ['show'], repoPath: '/tmp' });
+ *
+ * @example
+ *
+ *   getGitExecuteTask(['show'], '/tmp');
+ *
  */
 const git = (commands, repoPath, allowError, outPipe, inPipe, timeout) => {
   let args = {};

--- a/source/git-promise.js
+++ b/source/git-promise.js
@@ -127,15 +127,15 @@ const gitExecutorProm = (args, retryCount) => {
  * Returns a promise that executes git command with given arguments.
  *
  * @function
- * @param {obj | Array} commands    - An object that represents all parameters or first parameter
- *                                  only, which is an array of commands.
- * @param {string}      repoPath    - path to the git repository.
- * @param {boolean=}    allowError  - true if return code of 1 is acceptable as some cases errors
- *                                  are acceptable.
- * @param {stream=}     outPipe     - if this argument exists, stdout is piped to this object.
- * @param {stream=}     inPipe      - if this argument exists, data is piped to stdin process on
- *                                  start.
- * @param {timeout=}    timeout     - execution timeout, default is 2 mins.
+ * @param {Object | Array} commands    - An object that represents all parameters or first parameter
+ *                                     only, which is an array of commands.
+ * @param {string}         repoPath    - path to the git repository.
+ * @param {boolean=}       allowError  - true if return code of 1 is acceptable as some cases errors
+ *                                     are acceptable.
+ * @param {any=}           outPipe     - if this argument exists, stdout is piped to this object.
+ * @param {any=}           inPipe      - if this argument exists, data is piped to stdin process on
+ *                                     start.
+ * @param {number=}        timeout     - execution timeout, default is 2 mins.
  * @returns {promise} Execution promise.
  * @example
  *
@@ -154,6 +154,7 @@ const git = (commands, repoPath, allowError, outPipe, inPipe, timeout) => {
     args.outPipe = outPipe;
     args.inPipe = inPipe;
     args.allowError = allowError;
+    args.timeout = timeout;
   } else {
     args = commands;
   }

--- a/source/utils/cache.js
+++ b/source/utils/cache.js
@@ -1,93 +1,94 @@
 const NodeCache = require('node-cache');
-const cache = new NodeCache({ stdTTL: 0 });
 const md5 = require('blueimp-md5');
 const funcMap = {}; // Will there ever be a use case where this is a cache with TTL? func registration with TTL?
 
-/**
- * Get cached result associated with the key or execute a function to get the result.
- *
- * @function resolveFunc
- * @param {string} [key]  - A key associated with a function to be executed.
- * @returns {Promise} - Promise either resolved with cached result of the function or rejected with
- *                    function not found.
- */
-cache.resolveFunc = (key) => {
-  let result = cache.get(key);
-  if (result !== undefined) {
-    return Promise.resolve(result);
-  }
-  result = funcMap[key];
-  if (result === undefined) {
-    return Promise.reject(new Error(`Cache entry ${key} not found`));
-  }
-  try {
-    result = result.func();
-  } catch (err) {
-    return Promise.reject(err);
-  }
-  return Promise.resolve(result) // func is found, resolve, set with TTL and return result
-    .then((r) => {
-      cache.set(key, r, funcMap[key].ttl);
-      return r;
-    });
-};
-
-/**
- * Register a function to cache it's result. If same key exists, key is deregistered and registered
- * again.
- *
- * @function registerFunc
- * @param {ttl}      [ttl=0]            - Ttl in seconds to be used for the cached result of
- *                                      function. Default is `0`.
- * @param {string}   [key=md5 of func]  - Key to retrieve cached function result. Default is `md5 of
- *                                      func`.
- * @param {function} [func]             - Function to be executed to get the result.
- * @returns {string} - Key to retrieve cached function result.
- */
-cache.registerFunc = (...args) => {
-  const func = args.pop();
-  const key = args.pop() || md5(func);
-  const ttl = args.pop() || cache.options.stdTTL;
-
-  if (typeof func !== 'function') {
-    throw new Error('no function was passed in.');
+class OurCache extends NodeCache {
+  constructor() {
+    super({ stdTTL: 0 });
   }
 
-  if (isNaN(ttl) || ttl < 0) {
-    throw new Error('ttl value is not valid.');
+  /**
+   * Get cached result associated with the key or execute a function to get the result.
+   *
+   * @param {string} [key]  - A key associated with a function to be executed.
+   * @returns {Promise} - Promise either resolved with cached result of the function or rejected
+   *                    with function not found.
+   */
+  resolveFunc(key) {
+    let result = this.get(key);
+    if (result !== undefined) {
+      return Promise.resolve(result);
+    }
+    result = funcMap[key];
+    if (result === undefined) {
+      return Promise.reject(new Error(`Cache entry ${key} not found`));
+    }
+    try {
+      result = result.func();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.resolve(result) // func is found, resolve, set with TTL and return result
+      .then((r) => {
+        this.set(key, r, funcMap[key].ttl);
+        return r;
+      });
   }
 
-  if (funcMap[key]) {
-    cache.deregisterFunc(key);
+  /**
+   * Register a function to cache it's result. If same key exists, key is deregistered and
+   * registered again.
+   *
+   * @param {ttl}      [ttl=0]            - Ttl in seconds to be used for the cached result of
+   *                                      function. Default is `0`.
+   * @param {string}   [key=md5 of func]  - Key to retrieve cached function result. Default is `md5
+   *                                      of func`.
+   * @param {function} [func]             - Function to be executed to get the result.
+   * @returns {string} - Key to retrieve cached function result.
+   */
+  registerFunc(...args) {
+    const func = args.pop();
+    const key = args.pop() || md5(func);
+    const ttl = args.pop() || this.options.stdTTL;
+
+    if (typeof func !== 'function') {
+      throw new Error('no function was passed in.');
+    }
+
+    if (isNaN(ttl) || ttl < 0) {
+      throw new Error('ttl value is not valid.');
+    }
+
+    if (funcMap[key]) {
+      this.deregisterFunc(key);
+    }
+
+    funcMap[key] = {
+      func: func,
+      ttl: ttl,
+    };
+
+    return key;
   }
 
-  funcMap[key] = {
-    func: func,
-    ttl: ttl,
-  };
+  /**
+   * Immediately invalidate cached function result despite ttl value.
+   *
+   * @param {string} [key]  - A key associated with a function to be executed.
+   */
+  invalidateFunc(key) {
+    this.del(key);
+  }
 
-  return key;
-};
+  /**
+   * Remove function registration and invalidate it's cached value.
+   *
+   * @param {string} [key]  - A key associated with a function to be executed.
+   */
+  deregisterFunc(key) {
+    this.invalidateFunc(key);
+    delete funcMap[key];
+  }
+}
 
-/**
- * Immediately invalidate cached function result despite ttl value.
- *
- * @function invalidateFunc
- * @param {string} [key]  - A key associated with a function to be executed.
- */
-cache.invalidateFunc = (key) => {
-  cache.del(key);
-};
-
-/**
- * Remove function registration and invalidate it's cached value.
- *
- * @function deregisterFunc
- * @param {string} [key]  - A key associated with a function to be executed.
- */
-cache.deregisterFunc = (key) => {
-  cache.invalidateFunc(key);
-  delete funcMap[key];
-};
-
-module.exports = cache;
+module.exports = new OurCache();

--- a/source/utils/cache.js
+++ b/source/utils/cache.js
@@ -39,21 +39,20 @@ class OurCache extends NodeCache {
    * Register a function to cache it's result. If same key exists, key is deregistered and
    * registered again.
    *
-   * @param {ttl}      [ttl=0]            - Ttl in seconds to be used for the cached result of
-   *                                      function. Default is `0`.
-   * @param {string}   [key=md5 of func]  - Key to retrieve cached function result. Default is `md5
-   *                                      of func`.
-   * @param {function} [func]             - Function to be executed to get the result.
+   * @param {function} [func]           - Function to be executed to get the result.
+   * @param {string}   [key=md5(func)]  - Key to retrieve cached function result. Default is
+   *                                    `md5(func)`.
+   * @param {number}   [ttl=0]          - Ttl in seconds to be used for the cached result of
+   *                                    function. Default is `0`.
    * @returns {string} - Key to retrieve cached function result.
    */
-  registerFunc(...args) {
-    const func = args.pop();
-    const key = args.pop() || md5(func);
-    const ttl = args.pop() || this.options.stdTTL;
-
+  registerFunc(func, key, ttl) {
     if (typeof func !== 'function') {
       throw new Error('no function was passed in.');
     }
+
+    key = key || md5(func);
+    ttl = ttl || this.options.stdTTL;
 
     if (isNaN(ttl) || ttl < 0) {
       throw new Error('ttl value is not valid.');

--- a/source/utils/cache.js
+++ b/source/utils/cache.js
@@ -4,10 +4,12 @@ const md5 = require('blueimp-md5');
 const funcMap = {}; // Will there ever be a use case where this is a cache with TTL? func registration with TTL?
 
 /**
+ * Get cached result associated with the key or execute a function to get the result.
+ *
  * @function resolveFunc
- * @description Get cached result associated with the key or execute a function to get the result
- * @param {string} [key] - A key associated with a function to be executed.
- * @return {Promise} - Promise either resolved with cached result of the function or rejected with function not found.
+ * @param {string} [key]  - A key associated with a function to be executed.
+ * @returns {Promise} - Promise either resolved with cached result of the function or rejected with
+ *                    function not found.
  */
 cache.resolveFunc = (key) => {
   let result = cache.get(key);
@@ -31,12 +33,16 @@ cache.resolveFunc = (key) => {
 };
 
 /**
+ * Register a function to cache it's result. If same key exists, key is deregistered and registered
+ * again.
+ *
  * @function registerFunc
- * @description Register a function to cache it's result. If same key exists, key is deregistered and registered again.
- * @param {ttl} [ttl=0] - ttl in seconds to be used for the cached result of function.
- * @param {string} [key=md5 of func] - Key to retrieve cached function result.
- * @param {function} [func] - Function to be executed to get the result.
- * @return {string} - key to retrieve cached function result.
+ * @param {ttl}      [ttl=0]            - Ttl in seconds to be used for the cached result of
+ *                                      function. Default is `0`.
+ * @param {string}   [key=md5 of func]  - Key to retrieve cached function result. Default is `md5 of
+ *                                      func`.
+ * @param {function} [func]             - Function to be executed to get the result.
+ * @returns {string} - Key to retrieve cached function result.
  */
 cache.registerFunc = (...args) => {
   const func = args.pop();
@@ -64,18 +70,20 @@ cache.registerFunc = (...args) => {
 };
 
 /**
+ * Immediately invalidate cached function result despite ttl value.
+ *
  * @function invalidateFunc
- * @description Immediately invalidate cached function result despite ttl value
- * @param {string} [key] - A key associated with a function to be executed.
+ * @param {string} [key]  - A key associated with a function to be executed.
  */
 cache.invalidateFunc = (key) => {
   cache.del(key);
 };
 
 /**
+ * Remove function registration and invalidate it's cached value.
+ *
  * @function deregisterFunc
- * @description Remove function registration and invalidate it's cached value.
- * @param {string} [key] - A key associated with a function to be executed.
+ * @param {string} [key]  - A key associated with a function to be executed.
  */
 cache.deregisterFunc = (key) => {
   cache.invalidateFunc(key);

--- a/test/spec.cache.js
+++ b/test/spec.cache.js
@@ -68,8 +68,8 @@ describe('cache', () => {
     const key1 = 'func1';
     const key2 = 'func2';
     const func = () => i++;
-    cache.registerFunc(key1, func);
-    cache.registerFunc(key2, func);
+    cache.registerFunc(func, key1);
+    cache.registerFunc(func, key2);
 
     return cache
       .resolveFunc(key1)
@@ -100,7 +100,7 @@ describe('cache', () => {
   it('Testing ttl', function () {
     let i = 0;
     const func = () => i++;
-    const key = cache.registerFunc(1, null, func);
+    const key = cache.registerFunc(func, null, 1);
     this.timeout(3000);
 
     return cache

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "downlevelIteration": true,
+    "jsx": "preserve",
+    // Check JS files too
+    "allowJs": true,
+    "checkJs": true,
+    // Used for temp builds
+    "outDir": "build",
+    "paths": {
+      "mina": ["./node_modules/snapsvg/src/mina"],
+      "octicons": ["./node_modules/@primer/octicons"],
+      "ungit-address-parser": ["./source/address-parser"],
+      "ungit-components": ["./public/source/components"],
+      "ungit-main": ["./public/source/main"],
+      "ungit-navigation": ["./public/source/navigation"],
+      "ungit-program-events": ["./public/source/program-events"],
+      "ungit-storage": ["./public/source/storage"]
+    }
+  },
+  "exclude": ["node_modules", "build", "coverage", "public/js", "**/*.min.js", "**/*.bundle.js"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true,
     "resolveJsonModule": true,
     "downlevelIteration": true,
-    "jsx": "preserve",
     // Check JS files too
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
this adds some non-commital TypeScript support, by adding JSDoc comment parsing to Prettier (allows checking for mistakes) and enabling error highlighting in VS Code and any others that might run TypeScript checking.

Note that no compiling is needed, this just adds static configuration to help out VSCode.