### PR TITLE
node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['10', '12', '14', '15']
+        node-version: ['12', '14', '16']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 #    env:
@@ -59,14 +59,14 @@ jobs:
 
       # publish artifacts
       - run: npm pack
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
       - run: npm run electronpackage -- --all
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
       - run: npm run electronzip
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
 
       - name: Upload npm pack
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit
@@ -74,7 +74,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-darwin-arm64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-darwin-arm64
@@ -82,7 +82,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-darwin-x64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-darwin-x64
@@ -90,7 +90,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-linux-arm64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-linux-arm64
@@ -98,7 +98,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-linux-armv7l
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-linux-armv7l
@@ -106,7 +106,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-linux-ia32
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-linux-ia32
@@ -114,7 +114,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-linux-x64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-linux-x64
@@ -122,7 +122,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-win32-arm64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-win32-arm64
@@ -130,7 +130,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-win32-ia32
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-win32-ia32
@@ -138,7 +138,7 @@ jobs:
           retention-days: 7
 
       - name: Upload ungit-win32-x64
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12'
         uses: actions/upload-artifact@v2
         with:
           name: ungit-win32-x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ os:
 language: node_js
 node_js:
   - node
+  - '16'
   - '14'
   - '12'
-  - '10'
 branches:
   only:
     - master
@@ -18,11 +18,11 @@ env:
     - GIT_VERSION=default
 jobs:
   exclude:
+    - node_js: '16'
+      env: GIT_VERSION=edge
     - node_js: '14'
       env: GIT_VERSION=edge
     - node_js: '12'
-      env: GIT_VERSION=edge
-    - node_js: '10'
       env: GIT_VERSION=edge
     - os: windows
       env: GIT_VERSION=edge
@@ -73,4 +73,4 @@ deploy:
   release_notes: "[Changelog](https://github.com/FredrikNoren/ungit/blob/master/CHANGELOG.md#${TRAVIS_TAG//[v\\.]})"
   on:
     tags: true
-    condition: $TRAVIS_OS_NAME = "linux" && $TRAVIS_NODE_VERSION = "10"
+    condition: $TRAVIS_OS_NAME = "linux" && $TRAVIS_NODE_VERSION = "12"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Quick intro to ungit: [https://youtu.be/hkBVAi3oKvo](https://youtu.be/hkBVAi3oKv
 
 Installing
 ----------
-Requires [node.js](https://nodejs.org) (≥ 10.18.0), [npm](https://www.npmjs.com/) (≥ 6.13.4, comes with node.js) and [git](https://git-scm.com/) (≥ 1.8.x). To install ungit just type:
+Requires [node.js](https://nodejs.org) (≥ 12), [npm](https://www.npmjs.com/) (≥ 6.14.12, comes with node.js) and [git](https://git-scm.com/) (≥ 1.8.x). To install ungit just type:
 
 	npm install -g ungit
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,16 +3,21 @@ skip_branch_with_pr: true
 environment:
   matrix:
     - nodejs_version: '' # latest
+    - nodejs_version: '16'
     - nodejs_version: '14'
     - nodejs_version: '12'
-    - nodejs_version: '10'
 
 branches:
   only:
     - master
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: |
+      try {
+        Install-Product node $env:nodejs_version
+      } catch {
+        Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+      }
   - node --version
   - npm --version
   - npm ci


### PR DESCRIPTION
Update CI to use node 16 and drop node 10.
Minimum supported node version is now 12.

Since it takes some time for new node versions to be supported by appveyor I have updated the script so we can use newer versions earlier: https://github.com/appveyor/ci/issues/2921#issuecomment-501016533

See https://nodejs.org/about/releases/