### PR TITLE
Use io directly instead of using io.connect

### DIFF
--- a/public/source/server.js
+++ b/public/source/server.js
@@ -25,7 +25,7 @@ module.exports = Server;
 
 Server.prototype.initSocket = function () {
   var self = this;
-  this.socket = io.connect('', {
+  this.socket = io('', {
     path: rootPath + '/socket.io',
   });
   this.socket.on('connect_error', function (err) {


### PR DESCRIPTION
With https://github.com/socketio/socket.io-client/releases/tag/4.3.0 the `io.connect` alias got removed and broke the dependency bump. It got added back in https://github.com/socketio/socket.io-client/releases/tag/4.3.1 but let's just use `io` directly.