### PR TITLE
Add Tab Size Configuration

### DIFF
--- a/components/repository/repository.html
+++ b/components/repository/repository.html
@@ -1,4 +1,4 @@
-<div class="repository-view animated fadeInLeft" data-bind="attr: { style: 'tab-size: ' + ungit.config.diffTabSize }">
+<div class="repository-view animated fadeInLeft" data-bind="attr: { style: 'tab-size: ' + ungit.config.tabSize }">
   <!-- ko component: gitErrors --><!-- /ko -->
 
   <!-- ko if: isSubmodule -->

--- a/components/repository/repository.html
+++ b/components/repository/repository.html
@@ -1,4 +1,4 @@
-<div class="repository-view animated fadeInLeft" data-bind="style: { tabSize: ungit.config.diffTabSize }">
+<div class="repository-view animated fadeInLeft" data-bind="attr: { style: 'tab-size: ' + ungit.config.diffTabSize }">
   <!-- ko component: gitErrors --><!-- /ko -->
 
   <!-- ko if: isSubmodule -->

--- a/components/repository/repository.html
+++ b/components/repository/repository.html
@@ -1,4 +1,4 @@
-<div class="repository-view animated fadeInLeft">
+<div class="repository-view animated fadeInLeft" data-bind="style: { tabSize: ungit.config.diffTabSize }">
   <!-- ko component: gitErrors --><!-- /ko -->
 
   <!-- ko if: isSubmodule -->

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -179,7 +179,10 @@ class TextDiffViewModel {
       }
 
       if (ungit.config.diffTabSize) {
-        html = html.replace(/<span class="d2h-code-line-ctn">/g, `<span class="d2h-code-line-ctn" style="tab-size: ${ungit.config.diffTabSize};">`)
+        html = html.replace(
+          /<span class="d2h-code-line-ctn">/g,
+          `<span class="d2h-code-line-ctn" style="tab-size: ${ungit.config.diffTabSize};">`
+        );
       }
 
       if (html !== this.htmlSrc) {

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -178,6 +178,10 @@ class TextDiffViewModel {
         });
       }
 
+      if (ungit.config.diffTabSize) {
+        html = html.replace(/<span class="d2h-code-line-ctn">/g, `<span class="d2h-code-line-ctn" style="tab-size: ${ungit.config.diffTabSize};">`)
+      }
+
       if (html !== this.htmlSrc) {
         // diff has changed since last we displayed and need refresh
         this.htmlSrc = html;

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -178,13 +178,6 @@ class TextDiffViewModel {
         });
       }
 
-      if (ungit.config.diffTabSize) {
-        html = html.replace(
-          /<span class="d2h-code-line-ctn">/g,
-          `<span class="d2h-code-line-ctn" style="tab-size: ${ungit.config.diffTabSize};">`
-        );
-      }
-
       if (html !== this.htmlSrc) {
         // diff has changed since last we displayed and need refresh
         this.htmlSrc = html;

--- a/source/config.js
+++ b/source/config.js
@@ -141,8 +141,8 @@ const defaultConfig = {
   // Specify whether to Ignore or Show white space diff
   ignoreWhiteSpaceDiff: false,
 
-  // Specify tab size for diff
-  diffTabSize: null,
+  // Specify tab size as number of spaces
+  tabSize: null,
 
   // Number of refs to show on git commit bubbles to limit too many refs to appear.
   numRefsToShow: 5,
@@ -302,7 +302,7 @@ const argv = yargs
     'numRefsToShow',
     'Number of refs to show on git commit bubbles to limit too many refs to appear.'
   )
-  .describe('diffTabSize', 'Specify tab size for diff')
+  .describe('tabSize', 'Specify tab size as number of spaces')
   .describe('isForceGPGSign', 'Force gpg sign for tags and commits.')
   .boolean('isForceGPGSign')
   .describe(

--- a/source/config.js
+++ b/source/config.js
@@ -141,6 +141,9 @@ const defaultConfig = {
   // Specify whether to Ignore or Show white space diff
   ignoreWhiteSpaceDiff: false,
 
+  // Specify tab size for diff
+  diffTabSize: null,
+
   // Number of refs to show on git commit bubbles to limit too many refs to appear.
   numRefsToShow: 5,
 
@@ -299,6 +302,7 @@ const argv = yargs
     'numRefsToShow',
     'Number of refs to show on git commit bubbles to limit too many refs to appear.'
   )
+  .describe('diffTabSize', 'Specify tab size for diff')
   .describe('isForceGPGSign', 'Force gpg sign for tags and commits.')
   .boolean('isForceGPGSign')
   .describe(


### PR DESCRIPTION
This PR will allow the user to specify `tab-size` for the diff view.

Using tabs looks awful without this configuration (specially in `side-by-side` view) as it cause the text to be over indented as the default `tab-size` value is 8. 

Before (Tab size default to 8):
![before](https://user-images.githubusercontent.com/39461857/148648579-2a1da251-f033-4a72-a626-1ae56aa0b0c1.png)

After (Tab size set to 2):
![after](https://user-images.githubusercontent.com/39461857/148648586-308fc7d8-fc15-4c48-981d-58aee0de9e51.png)
