### PR TITLE
Add `--` before potential user provided input to make it disambiguating

### DIFF
--- a/source/git-api.js
+++ b/source/git-api.js
@@ -292,9 +292,10 @@ exports.registerApi = (env) => {
       const task = gitPromise({
         commands: credentialsOption(req.body.socketId, req.body.remote).concat([
           'fetch',
+          config.autoPruneOnFetch ? '--prune' : '',
+          '--',
           req.body.remote,
           req.body.ref ? req.body.ref : '',
-          config.autoPruneOnFetch ? '--prune' : '',
         ]),
         repoPath: req.body.path,
         timeout: tenMinTimeoutMs,


### PR DESCRIPTION
> When writing a script that is expected to handle random user-input, it is a good practice to make it explicit which arguments are which by placing disambiguating -- at appropriate places.

https://git-scm.com/docs/gitcli/2.25.0#_description