### PR TITLE
fix patch checkbox html

### DIFF
--- a/components/staging/staging.less
+++ b/components/staging/staging.less
@@ -100,7 +100,7 @@
 
   .d2h-code-line-prefix input[type='checkbox'] {
     margin: 0;
-    margin-right: -6px;
+    margin-right: -5px;
     vertical-align: sub;
   }
 

--- a/components/textdiff/textdiff.js
+++ b/components/textdiff/textdiff.js
@@ -173,7 +173,7 @@ class TextDiffViewModel {
       // data bind at getPatchCheckBox that is rendered with "html" binding.
       // which is reason why manually updating the html content and refreshing kobinding to have it render...
       if (this.patchLineList) {
-        html = html.replace(/<span class="d2h-code-line-[a-z]+">(\+|-)/g, (match, capture) => {
+        html = html.replace(/<span class="d2h-code-line-prefix">(\+|-)/g, (match, capture) => {
           if (this.patchLineList()[index] === undefined) {
             this.patchLineList()[index] = true;
           }
@@ -200,9 +200,9 @@ class TextDiffViewModel {
     if (isActive) {
       this.numberOfSelectedPatchLines++;
     }
-    return `<div class="d2h-code-line-prefix"><span data-bind="visible: editState() !== 'patched'">${symbol}</span><input ${
+    return `<span class="d2h-code-line-prefix"><span data-bind="visible: editState() !== 'patched'">${symbol}</span><input ${
       isActive ? 'checked' : ''
-    } type="checkbox" data-bind="visible: editState() === 'patched', click: togglePatchLine.bind($data, ${index})"></input></div>`;
+    } type="checkbox" data-bind="visible: editState() === 'patched', click: togglePatchLine.bind($data, ${index})">`;
   }
 
   togglePatchLine(index) {


### PR DESCRIPTION
The closing tag isn't needed as it isn't replaced.
Ignore unchanged lines which start with `-` or `+`.

![image](https://user-images.githubusercontent.com/4009570/166112913-ed8d8603-6dee-4407-b07f-381968d26d63.png)
