### PR TITLE
Use fork to spawn a new node process

### DIFF
--- a/bin/ungit
+++ b/bin/ungit
@@ -58,10 +58,10 @@ const navigate = () => {
 };
 
 const launch = () => {
-  const child = child_process.spawn(
-    process.argv[0], // because it's `nodejs` in some OS
-    [path.join(__dirname, '..', 'source', 'server.js')].concat(process.argv.slice(2)),
-    { cwd: path.join(process.cwd(), '..') }
+  const child = child_process.fork(
+    path.join(__dirname, '..', 'source', 'server.js'),
+    process.argv.slice(2),
+    { cwd: path.join(process.cwd(), '..'), silent: true }
   );
 
   child.on('exit', (res) => {


### PR DESCRIPTION
Changes `child_process.spawn` to `child_process.fork` to create new node process to run `server.js`.

Currently `bin/ungit` creates a new child process using `spawn` with the first argument of `process`, which is expected to be `"node"` or in some OS (apparently) `"nodejs"`. When running this script from other programs, for example as part of a [VSCode extension](https://github.com/Hirse/vscode-ungit), this expectation does not hold and the first argument is actually `"Code.exe"`. Trying to spawn the ungit server there fails for obvious reasons.

Since the goal is to create a new node process (with the same one that is already running), we can shorthand it by using [`fork`](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options):
> The child_process.fork() method is a special case of [child_process.spawn()](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) used specifically to spawn new Node.js processes.

Adding the `silent` option is necessary to keep the event handlers the same.