### PR TITLE
Fix exit code on wrong config

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -330,7 +330,7 @@ const argvConfig = argv.argv;
 // When ungit is started normally, $0 == ungit, and non-hyphenated options exists, show help and exit.
 if (argvConfig.$0.endsWith('ungit') && argvConfig._ && argvConfig._.length > 0) {
   yargs.showHelp();
-  process.exit(0);
+  process.exit(1);
 }
 
 let rcConfig = {};
@@ -342,7 +342,7 @@ if (!argvConfig.cliconfigonly) {
     delete rcConfig['configs'];
   } catch (err) {
     console.error(`Stop at reading ~/.ungitrc because ${err}`);
-    process.exit(0);
+    process.exit(1);
   }
 }
 

--- a/source/server.js
+++ b/source/server.js
@@ -107,7 +107,7 @@ if (config.autoShutdownTimeout) {
       logger.info(
         `Shutting down ungit due to inactivity. (autoShutdownTimeout is set to ${config.autoShutdownTimeout} ms`
       );
-      process.exit(0);
+      process.exit();
     }, config.autoShutdownTimeout);
   };
   app.use((req, res, next) => {
@@ -346,7 +346,7 @@ const readUserConfig = () => {
         })
         .catch((err) => {
           logger.error(`Stop at reading ~/.ungitrc because ${err}`);
-          process.exit(0);
+          process.exit(1);
         });
     })
     .catch(() => {


### PR DESCRIPTION
Return exit-code 1 instead of 0 when passing to ungit wrong arguments

Fixes #1548 