### PR TITLE
Kill server when ungit gets killed

### DIFF
--- a/bin/ungit
+++ b/bin/ungit
@@ -16,8 +16,9 @@ const net = require('net');
 const server = net.createServer();
 let child;
 const cleanExit = () => {
-  if (child != undefined)
+  if (child) {
     child.kill('SIGINT');
+  }
   process.exit();
 };
 

--- a/bin/ungit
+++ b/bin/ungit
@@ -16,7 +16,8 @@ const net = require('net');
 const server = net.createServer();
 let child;
 const cleanExit = () => {
-  child.kill('SIGINT');
+  if (child != undefined)
+    child.kill('SIGINT');
   process.exit();
 };
 

--- a/bin/ungit
+++ b/bin/ungit
@@ -14,7 +14,11 @@ const bugtracker = new BugTracker('launcher');
 // Fastest way to find out if a port is used or not/i.e. if ungit is running
 const net = require('net');
 const server = net.createServer();
-const cleanExit = () => process.exit();
+let child;
+const cleanExit = () => {
+  child.kill('SIGINT');
+  process.exit();
+};
 
 process.on('SIGINT', cleanExit); // catch ctrl-c
 process.on('SIGTERM', cleanExit); // catch kill
@@ -58,7 +62,7 @@ const navigate = () => {
 };
 
 const launch = () => {
-  const child = child_process.fork(
+  child = child_process.fork(
     path.join(__dirname, '..', 'source', 'server.js'),
     process.argv.slice(2),
     { cwd: path.join(process.cwd(), '..'), silent: true }


### PR DESCRIPTION
This makes sure the child process `server.js` is killed when the parent `ungit` gets killed

Fixes #1552 