### PR TITLE
Fallback for font if bundled font dont support glyphs

### DIFF
--- a/public/less/d2h.less
+++ b/public/less/d2h.less
@@ -10,7 +10,7 @@
 }
 
 .d2h-diff-table {
-  font-family: 'Source Code Pro';
+  font-family: 'Source Code Pro', monospace;
   font-size: 12px;
 
   tbody > tr > td {

--- a/public/less/variables.less
+++ b/public/less/variables.less
@@ -16,8 +16,8 @@
 @link-hover-color: lighten(@link-color, 15%);
 
 // Typography
-@font-family-sans-serif: 'Open Sans';
-@font-family-monospace: 'Source Code Pro';
+@font-family-sans-serif: 'Open Sans', sans-serif;
+@font-family-monospace: 'Source Code Pro', monospace;
 
 // Buttons
 @btn-default-color: @text-color;


### PR DESCRIPTION
Example of problem:
Browser select to render local font because bundled OpenSans.woff but from but from the wrong font style because it wasn't specified.
![image](https://github.com/FredrikNoren/ungit/assets/2046529/231d87a4-8c7b-442c-97a7-3a5373e1868f)

Fixed version:
![image](https://github.com/FredrikNoren/ungit/assets/2046529/99b11d0f-6b0a-4df0-8814-b282f457fa97)


