### PR TITLE
Use monospace font-family in commit body

### DIFF
--- a/components/commit/commit.less
+++ b/components/commit/commit.less
@@ -80,6 +80,7 @@
 
     .details {
       .body {
+        font-family: 'Source Code Pro', monospace;
         white-space: pre-wrap;
         word-wrap: break-word;
         color: #8f9fa6;


### PR DESCRIPTION

| Before | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/d9724e3f-c139-4178-8bb5-7e631ca49a93) | ![image](https://github.com/user-attachments/assets/93716bd1-1c26-46bb-b48a-5766c7cc907c) |