### PR TITLE
Adding Git worktree support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ We are following the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased](https://github.com/FredrikNoren/ungit/compare/v1.5.29...master)
 
+### Added
+- Git worktree support in the repository view
+  - List repository worktrees from a new Worktrees dropdown, including branch name, current-worktree marker, and clean/dirty/conflict status
+  - Create/remove a worktree
+  - Switch the current ungit view to another worktree or open it in a new browser tab
+  - Mark graph branch labels when a branch is checked out in another worktree
+  - Refresh graph and worktree UI when Git worktree metadata changes
+
 ## [1.5.29](https://github.com/FredrikNoren/ungit/compare/v1.5.28...v1.5.29)
 
 ### Changed

--- a/components/graph/git-node.js
+++ b/components/graph/git-node.js
@@ -250,6 +250,14 @@ class GitNodeViewModel extends Animateable {
       });
   }
 
+  createWorktree() {
+    if (!this.canCreateRef()) return;
+    const branchName = this.newBranchName();
+    this.branchingFormVisible(false);
+    this.newBranchName('');
+    programEvents.dispatch({ event: 'create-worktree', branch: branchName });
+  }
+
   toggleSelected() {
     this.selected(!this.selected());
     if (this.selected()) {

--- a/components/graph/git-ref.js
+++ b/components/graph/git-ref.js
@@ -3,6 +3,8 @@ const md5 = require('blueimp-md5');
 const octicons = require('octicons');
 const programEvents = require('ungit-program-events');
 const components = require('ungit-components');
+const navigation = require('ungit-navigation');
+const { encodePath } = require('ungit-address-parser');
 const Selectable = require('./selectable');
 
 class RefViewModel extends Selectable {
@@ -49,6 +51,7 @@ class RefViewModel extends Selectable {
     this.show = true;
     this.server = this.graph.server;
     this.isDragging = ko.observable(false);
+    this.worktree = ko.observable();
     this.current = ko.computed(
       () => this.isLocalBranch && this.graph.checkedOutBranch() == this.refName
     );
@@ -80,8 +83,43 @@ class RefViewModel extends Selectable {
       } else if (this.isTag) {
         prefix += `<span>${octicons.tag.toSVG({ height: size })}</span> `;
       }
-      return prefix + this.localRefName;
+      return prefix + this.localRefName + this.worktreeMarkerHtml();
     };
+  }
+
+  worktreeMarkerHtml() {
+    const worktree = this.worktree();
+    if (!worktree || this.isCurrentWorktreePath(worktree.path)) return '';
+    const status = this.sanitizeCssClass(worktree.status || 'unknown');
+    const title = this.escapeHtml(`Checked out in ${worktree.path}`);
+    const label = this.escapeHtml(this.worktreeLabel(worktree.path));
+    return ` <span class="worktree-ref-marker status-${status}" title="${title}">${label}</span>`;
+  }
+
+  worktreeLabel(path) {
+    const normalizedPath = this.normalizePath(path);
+    const slashIndex = normalizedPath.lastIndexOf('/');
+    return slashIndex >= 0 ? normalizedPath.slice(slashIndex + 1) : normalizedPath;
+  }
+
+  isCurrentWorktreePath(path) {
+    return this.normalizePath(path) === this.normalizePath(this.graph.repoPath());
+  }
+
+  normalizePath(path) {
+    return (path || '').replace(/\\/g, '/').replace(/\/+$/, '');
+  }
+
+  sanitizeCssClass(value) {
+    return `${value}`.replace(/[^a-z0-9_-]/gi, '-').toLowerCase();
+  }
+
+  escapeHtml(value) {
+    return `${value}`
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
   }
 
   _colorFromHashOfString(string) {
@@ -243,6 +281,12 @@ class RefViewModel extends Selectable {
   }
 
   checkout() {
+    const worktree = this.worktree();
+    if (worktree && !this.isCurrentWorktreePath(worktree.path)) {
+      navigation.browseTo(`repository?path=${encodePath(worktree.path)}`);
+      return Promise.resolve();
+    }
+
     const isRemote = this.isRemoteBranch;
     const isLocalCurrent = this.getLocalRef() && this.getLocalRef().current();
 

--- a/components/graph/graph.html
+++ b/components/graph/graph.html
@@ -94,6 +94,13 @@
             >
               Tag
             </button>
+            <button
+              class="btn btn-default"
+              type="button"
+              data-bind="click: createWorktree, enable: canCreateRef"
+            >
+              Worktree
+            </button>
           </form>
           <!-- /ko -->
         </span>

--- a/components/graph/graph.js
+++ b/components/graph/graph.js
@@ -16,6 +16,7 @@ class GraphViewModel extends ComponentRoot {
     super();
     this._isLoadNodesFromApiRunning = false;
     this.updateBranches = _.debounce(this._updateBranches, 250, this.defaultDebounceOption);
+    this.updateWorktrees = _.debounce(this._updateWorktrees, 250, this.defaultDebounceOption);
     this.loadNodesFromApi = _.debounce(this._loadNodesFromApi, 250, this.defaultDebounceOption);
     this._markIdeologicalStamp = 0;
     this.repoPath = repoPath;
@@ -26,6 +27,7 @@ class GraphViewModel extends ComponentRoot {
     this.nodes = ko.observableArray();
     this.edges = ko.observableArray();
     this.refs = ko.observableArray();
+    this.worktrees = ko.observableArray();
     this.nodesById = {};
     this.edgesById = {};
     this.refsByRefName = {};
@@ -80,6 +82,7 @@ class GraphViewModel extends ComponentRoot {
 
     this.loadNodesFromApi();
     this.updateBranches();
+    this.updateWorktrees();
     this.graphWidth = ko.observable();
     this.graphHeight = ko.observable(800);
     this.searchIcon = octicons.search.toSVG({ height: 18 });
@@ -107,6 +110,7 @@ class GraphViewModel extends ComponentRoot {
         this.HEADref(refViewModel);
       }
     }
+    if (refViewModel) this.attachWorktreeToRef(refViewModel);
     return refViewModel;
   }
 
@@ -277,6 +281,7 @@ class GraphViewModel extends ComponentRoot {
     if (event.event == 'git-directory-changed' || event.event === 'working-tree-changed') {
       this.loadNodesFromApi();
       this.updateBranches();
+      this.updateWorktrees();
     } else if (event.event == 'request-app-content-refresh') {
       this.loadNodesFromApi();
     } else if (event.event == 'remote-tags-update') {
@@ -309,6 +314,32 @@ class GraphViewModel extends ComponentRoot {
         ungit.logger.warn('updateBranches failed', err);
       }
     }
+  }
+
+  async _updateWorktrees() {
+    try {
+      const worktrees = await this.server.getPromise('/worktrees', { path: this.repoPath() });
+      this.setWorktrees(worktrees || []);
+    } catch (err) {
+      if (err.errorCode != 'not-a-repository') {
+        this.server.unhandledRejection(err);
+      } else {
+        ungit.logger.warn('updateWorktrees failed', err);
+      }
+    }
+  }
+
+  setWorktrees(worktrees) {
+    this.worktrees(worktrees);
+    this.refs().forEach((ref) => {
+      if (ref.worktree) ref.worktree(null);
+    });
+    this.refs().forEach((ref) => this.attachWorktreeToRef(ref));
+  }
+
+  attachWorktreeToRef(ref) {
+    if (!ref.worktree || !ref.isLocalBranch) return;
+    ref.worktree(this.worktrees().find((worktree) => worktree.branch === ref.refName));
   }
 
   setRemoteTags(remoteTags) {

--- a/components/graph/graph.less
+++ b/components/graph/graph.less
@@ -79,6 +79,30 @@
       &.tag {
         color: #eef266;
       }
+
+      .worktree-ref-marker {
+        border: 2px dashed rgba(255, 255, 255, 0.75);
+        border-radius: 8px;
+        display: inline-block;
+        font-size: 12px;
+        font-weight: normal;
+        line-height: 16px;
+        margin-left: 6px;
+        padding: 0 6px;
+        vertical-align: 2px;
+
+        &.status-dirty {
+          border-color: #f0ad4e;
+        }
+
+        &.status-conflicts {
+          border-color: #d9534f;
+        }
+
+        &.status-clean {
+          border-color: #5cb85c;
+        }
+      }
     }
 
     .graphAction {

--- a/components/modals/forms.ts
+++ b/components/modals/forms.ts
@@ -8,6 +8,7 @@ ungit.components.register(
 );
 ungit.components.register('addremotemodal', (arg: any) => new AddRemoteModalViewModel(arg.path));
 ungit.components.register('addsubmodulemodal', (arg: any) => new AddSubmoduleModalViewModel(arg.path));
+ungit.components.register('addworktreemodal', (arg: any) => new AddWorktreeModalViewModel(arg));
 
 /**
  * Form receives collection of user inputs, i.e. username, password and etc.
@@ -86,6 +87,35 @@ class AddSubmoduleModalViewModel extends FormModalViewModel {
         submoduleUrl: this.items[1].value(),
       });
       ungit.programEvents.dispatch({ event: 'submodule-fetch' });
+    } catch (e) {
+      ungit.server.unhandledRejection(e);
+    }
+  }
+}
+
+class AddWorktreeModalViewModel extends FormModalViewModel {
+  repoPath: string
+  createBranch: boolean
+  constructor(arg: any) {
+    super('Create worktree', 'add-worktree', true);
+    this.repoPath = arg.path;
+    this.createBranch = arg.createBranch !== false;
+    this.items.push(new FormItems('Branch', ko.observable(arg.branch || ''), 'text', true))
+    this.items.push(new FormItems('Path', ko.observable(arg.worktreePath || ''), 'text', false))
+  }
+
+  async submit() {
+    super.submit();
+    try {
+      await ungit.server.postPromise('/worktrees', {
+        path: this.repoPath,
+        worktreePath: this.items[1].value(),
+        branch: this.items[0].value(),
+        createBranch: this.createBranch,
+      });
+      ungit.programEvents.dispatch({ event: 'branch-updated' });
+      ungit.programEvents.dispatch({ event: 'request-app-content-refresh' });
+      ungit.programEvents.dispatch({ event: 'worktree-changed' });
     } catch (e) {
       ungit.server.unhandledRejection(e);
     }

--- a/components/repository/repository.html
+++ b/components/repository/repository.html
@@ -27,6 +27,7 @@
     <!-- /ko -->
     <!-- ko component: remotes --><!-- /ko -->
     <!-- ko component: submodules --><!-- /ko -->
+    <!-- ko component: worktrees --><!-- /ko -->
     <!-- ko component: branches --><!-- /ko -->
 
     <div class="btn-group branch">

--- a/components/repository/repository.js
+++ b/components/repository/repository.js
@@ -15,6 +15,7 @@ class RepositoryViewModel {
     this.graph = components.create('graph', { server, repoPath: this.repoPath });
     this.remotes = components.create('remotes', { server, repoPath: this.repoPath });
     this.submodules = components.create('submodules', { server, repoPath: this.repoPath });
+    this.worktrees = components.create('worktrees', { server, repoPath: this.repoPath });
     this.stash = this.isBareDir
       ? {}
       : components.create('stash', { server, repoPath: this.repoPath });
@@ -54,6 +55,7 @@ class RepositoryViewModel {
     if (this.stash.onProgramEvent) this.stash.onProgramEvent(event);
     if (this.remotes.onProgramEvent) this.remotes.onProgramEvent(event);
     if (this.submodules.onProgramEvent) this.submodules.onProgramEvent(event);
+    if (this.worktrees.onProgramEvent) this.worktrees.onProgramEvent(event);
     if (this.branches.onProgramEvent) this.branches.onProgramEvent(event);
     if (event.event == 'connected') this.server.watchRepository(this.repoPath());
 

--- a/components/worktrees/ungit-plugin.json
+++ b/components/worktrees/ungit-plugin.json
@@ -1,0 +1,9 @@
+{
+  "exports": {
+    "knockoutTemplates": {
+      "worktrees": "worktrees.html"
+    },
+    "javascript": "worktrees.bundle.js",
+    "css": "worktrees.css"
+  }
+}

--- a/components/worktrees/worktrees.html
+++ b/components/worktrees/worktrees.html
@@ -1,0 +1,74 @@
+<div class="worktrees-component">
+  <div class="btn-group worktrees-button">
+    <button type="button" class="btn btn-default btn-main" data-bind="click: loadWorktrees">
+      <span>Worktrees</span>
+      <!-- ko if: worktreeCount() > 0 -->
+      <span class="badge" data-bind="text: worktreeCount"></span>
+      <!-- /ko -->
+    </button>
+    <button
+      type="button"
+      class="btn btn-default dropdown-toggle"
+      data-bind="click: loadWorktrees"
+      data-toggle="dropdown"
+      aria-haspopup="true"
+      aria-expanded="false"
+    >
+      <span class="caret"></span>
+      <span class="sr-only">Toggle Worktree List</span>
+    </button>
+
+    <ul class="dropdown-menu dropdown-menu-right worktrees-menu" role="menu">
+      <!-- ko if: error -->
+      <li class="dropdown-header worktree-error" data-bind="text: error"></li>
+      <li class="divider" role="separator"></li>
+      <!-- /ko -->
+
+      <!-- ko if: isLoading -->
+      <li class="dropdown-header">Loading worktrees...</li>
+      <!-- /ko -->
+
+      <!-- ko if: !isLoading() && !hasWorktrees() -->
+      <li class="dropdown-header">No worktrees found.</li>
+      <!-- /ko -->
+
+      <!-- ko foreach: worktrees -->
+      <li data-bind="css: { active: $parent.isCurrentWorktree($data) }">
+        <a
+          class="linked-url worktree-link"
+          href="#"
+          data-bind="click: $parent.switchToWorktree.bind($parent), attr: { title: path }"
+        >
+          <span data-bind="html: $parent.branchIcon"></span>
+          <span data-bind="text: $parent.branchLabel($data)"></span>
+          <!-- ko if: $parent.isCurrentWorktree($data) -->
+          <span class="worktree-current-label">Current</span>
+          <!-- /ko -->
+          <span
+            class="worktree-status"
+            data-bind="text: $parent.statusLabel($data), css: status"
+          ></span>
+        </a>
+        <a
+          class="list-link list-url worktree-open"
+          href="#"
+          data-bind="html: $parent.linkIcon, click: $parent.openInNewTab.bind($parent), attr: { title: 'Open ' + path + ' in a new tab' }"
+        ></a>
+        <a
+          class="list-link list-remove worktree-remove"
+          href="#"
+          data-bind="html: $parent.closeIcon, click: $parent.removeWorktree.bind($parent), attr: { title: 'Remove ' + path }"
+        ></a>
+      </li>
+      <!-- /ko -->
+      <!-- ko if: hasWorktrees -->
+      <li class="divider" role="separator"></li>
+      <!-- /ko -->
+      <li>
+        <a href="#" class="add-worktree" data-bind="click: function() { openCreateForm(); }">
+          Create worktree
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/components/worktrees/worktrees.js
+++ b/components/worktrees/worktrees.js
@@ -1,0 +1,128 @@
+const ko = require('knockout');
+const octicons = require('octicons');
+const components = require('ungit-components');
+const navigation = require('ungit-navigation');
+const { encodePath } = require('ungit-address-parser');
+
+class WorktreesViewModel {
+  constructor(server, repoPath) {
+    this.server = server;
+    this.repoPath = repoPath;
+    this.worktrees = ko.observableArray([]);
+    this.isLoading = ko.observable(false);
+    this.error = ko.observable();
+    this.worktreeCount = ko.computed(() => (this.worktrees() || []).length);
+    this.hasWorktrees = ko.computed(() => this.worktreeCount() > 0);
+    this.branchIcon = octicons['git-branch'].toSVG({ height: 18 });
+    this.linkIcon = octicons['link-external'].toSVG({ height: 18 });
+    this.closeIcon = octicons.x.toSVG({ height: 18 });
+  }
+
+  loadWorktrees() {
+    this.isLoading(true);
+    this.error(null);
+    return this.server
+      .getPromise('/worktrees', { path: this.repoPath() })
+      .then((worktrees) => {
+        this.worktrees(worktrees || []);
+      })
+      .catch((e) => {
+        this.error(e.errorSummary || e.message || 'Unable to load worktrees');
+      })
+      .finally(() => {
+        this.isLoading(false);
+      });
+  }
+
+  onProgramEvent(event) {
+    if (event.event === 'create-worktree') {
+      this.openCreateForm(event.branch);
+    } else if (event.event === 'worktree-changed' || event.event === 'git-directory-changed') {
+      this.loadWorktrees();
+    }
+  }
+
+  openCreateForm(branch) {
+    const branchName = branch || '';
+    components.showModal('addworktreemodal', {
+      path: this.repoPath(),
+      branch: branchName,
+      worktreePath: this.defaultWorktreePath(branchName || 'worktree'),
+      createBranch: true,
+    });
+  }
+
+  defaultWorktreePath(branch) {
+    const repoPath = this.repoPath();
+    const separator = (ungit.config && ungit.config.fileSeparator) || '/';
+    const normalizedPath = repoPath.replace(/\\/g, '/');
+    const slashIndex = normalizedPath.lastIndexOf('/');
+    const parentPath = slashIndex >= 0 ? repoPath.slice(0, slashIndex) : '.';
+    const repoName = slashIndex >= 0 ? normalizedPath.slice(slashIndex + 1) : normalizedPath;
+    const safeBranchName = branch.replace(/[\\/\s]+/g, '-');
+    return `${parentPath}${separator}${repoName}-${safeBranchName}`;
+  }
+
+  switchToWorktree(worktree) {
+    navigation.browseTo(`repository?path=${encodePath(worktree.path)}`);
+  }
+
+  openInNewTab(worktree) {
+    const rootPath = (ungit.config && ungit.config.rootPath) || '';
+    window.open(`${rootPath}/#/repository?path=${encodePath(worktree.path)}`, '_blank');
+  }
+
+  toggleLock(worktree) {
+    return this.server
+      .postPromise('/worktrees/lock', {
+        path: this.repoPath(),
+        worktreePath: worktree.path,
+        lock: !worktree.locked,
+      })
+      .then(() => this.loadWorktrees())
+      .catch((e) => {
+        this.error(e.errorSummary || e.message || 'Unable to update worktree lock');
+      });
+  }
+
+  removeWorktree(worktree) {
+    components.showModal('yesnomodal', {
+      title: 'Are you sure?',
+      details: `Removing ${worktree.path} worktree cannot be undone with ungit.`,
+      closeFunc: (isYes) => {
+        if (!isYes) return Promise.resolve();
+        return this.server
+          .delPromise('/worktrees', {
+            path: this.repoPath(),
+            worktreePath: worktree.path,
+          })
+          .then(() => this.loadWorktrees())
+          .catch((e) => {
+            this.error(e.errorSummary || e.message || 'Unable to remove worktree');
+          });
+      },
+    });
+  }
+
+  statusLabel(worktree) {
+    return worktree.status || 'unknown';
+  }
+
+  branchLabel(worktree) {
+    return worktree.branch || 'detached';
+  }
+
+  isCurrentWorktree(worktree) {
+    return this.normalizePath(worktree.path) === this.normalizePath(this.repoPath());
+  }
+
+  normalizePath(path) {
+    return (path || '').replace(/\\/g, '/').replace(/\/+$/, '');
+  }
+
+  updateNode(parentElement) {
+    ko.renderTemplate('worktrees', this, {}, parentElement);
+  }
+}
+
+components.register('worktrees', (args) => new WorktreesViewModel(args.server, args.repoPath));

--- a/components/worktrees/worktrees.less
+++ b/components/worktrees/worktrees.less
@@ -1,0 +1,84 @@
+.worktrees-component {
+  display: inline-block;
+  vertical-align: middle;
+
+  .worktrees-button {
+    .btn {
+      .badge {
+        margin-left: 6px;
+        background: #1976d2;
+        color: white;
+        border-radius: 10px;
+        padding: 2px 7px;
+        font-size: 11px;
+      }
+    }
+  }
+}
+
+.worktrees-menu {
+  min-width: 360px;
+  max-width: 480px;
+
+  .worktree-error {
+    color: #b54848;
+    white-space: normal;
+  }
+
+  > li {
+    &.active {
+      > a {
+        background: #eef4fb;
+        color: #222;
+      }
+    }
+  }
+
+  .worktree-link {
+    overflow: hidden;
+    padding-right: 92px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .worktree-current-label,
+  .worktree-status {
+    border-radius: 3px;
+    display: inline-block;
+    font-size: 11px;
+    margin-left: 6px;
+    padding: 1px 5px;
+    text-transform: capitalize;
+    vertical-align: middle;
+  }
+
+  .worktree-current-label {
+    background: #1976d2;
+    color: #fff;
+  }
+
+  .worktree-open {
+    margin-right: 40px;
+  }
+
+  .worktree-status {
+    &.clean {
+      background: #dff0d8;
+      color: #3c763d;
+    }
+
+    &.dirty {
+      background: #fcf8e3;
+      color: #8a6d3b;
+    }
+
+    &.conflicts {
+      background: #f2dede;
+      color: #a94442;
+    }
+  }
+
+  .worktree-remove {
+    color: #b54848;
+  }
+}

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -1016,64 +1016,81 @@ exports.registerApi = (env) => {
     );
   });
 
-  app.post(`${exports.pathPrefix}/worktrees`, ensureAuthenticated, ensurePathExists, async (req, res) => {
-    const { worktreePath, branch, createBranch } = req.body;
-    const repoPath = req.body.path || req.query.path;
+  app.post(
+    `${exports.pathPrefix}/worktrees`,
+    ensureAuthenticated,
+    ensurePathExists,
+    async (req, res) => {
+      const { worktreePath, branch, createBranch } = req.body;
+      const repoPath = req.body.path || req.query.path;
 
-    if (!worktreePath || !branch) {
-      return res.status(400).json({ error: 'path and branch are required' });
+      if (!worktreePath || !branch) {
+        return res.status(400).json({ error: 'path and branch are required' });
+      }
+
+      try {
+        await fs.access(worktreePath);
+        return res.status(400).json({ error: 'path already exists' });
+      } catch {
+        // path does not exist, continue
+      }
+
+      const args = ['worktree', 'add'];
+      if (createBranch) {
+        args.push('-b', branch, worktreePath);
+      } else {
+        args.push(worktreePath, branch);
+      }
+
+      jsonResultOrFailProm(
+        res,
+        gitPromise(args, repoPath).then(() =>
+          gitPromise(['worktree', 'list', '--porcelain'], repoPath)
+            .then(gitParser.parseWorktreeList)
+            .then((worktrees) => worktrees.find((w) => w.path === worktreePath))
+        )
+      );
     }
+  );
 
-    try {
-      await fs.access(worktreePath);
-      return res.status(400).json({ error: 'path already exists' });
-    } catch {}
+  app.delete(
+    `${exports.pathPrefix}/worktrees`,
+    ensureAuthenticated,
+    ensurePathExists,
+    (req, res) => {
+      const { worktreePath, force } = req.query;
+      const repoPath = req.query.path;
 
-    const args = ['worktree', 'add'];
-    if (createBranch) {
-      args.push('-b', branch, worktreePath);
-    } else {
-      args.push(worktreePath, branch);
+      if (!worktreePath) {
+        return res.status(400).json({ error: 'path is required' });
+      }
+
+      const args = ['worktree', 'remove'];
+      if (force === 'true') {
+        args.push('--force');
+      }
+      args.push(worktreePath);
+
+      jsonResultOrFailProm(res, gitPromise(args, repoPath));
     }
+  );
 
-    jsonResultOrFailProm(
-      res,
-      gitPromise(args, repoPath).then(() =>
-        gitPromise(['worktree', 'list', '--porcelain'], repoPath)
-          .then(gitParser.parseWorktreeList)
-          .then((worktrees) => worktrees.find((w) => w.path === worktreePath))
-      )
-    );
-  });
+  app.post(
+    `${exports.pathPrefix}/worktrees/lock`,
+    ensureAuthenticated,
+    ensurePathExists,
+    (req, res) => {
+      const { worktreePath, lock } = req.body;
+      const repoPath = req.body.path || req.query.path;
 
-  app.delete(`${exports.pathPrefix}/worktrees`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const { worktreePath, force } = req.query;
-    const repoPath = req.query.path;
+      if (!worktreePath) {
+        return res.status(400).json({ error: 'path is required' });
+      }
 
-    if (!worktreePath) {
-      return res.status(400).json({ error: 'path is required' });
+      const args = ['worktree', lock ? 'lock' : 'unlock', worktreePath];
+      jsonResultOrFailProm(res, gitPromise(args, repoPath));
     }
-
-    const args = ['worktree', 'remove'];
-    if (force === 'true') {
-      args.push('--force');
-    }
-    args.push(worktreePath);
-
-    jsonResultOrFailProm(res, gitPromise(args, repoPath));
-  });
-
-  app.post(`${exports.pathPrefix}/worktrees/lock`, ensureAuthenticated, ensurePathExists, (req, res) => {
-    const { worktreePath, lock } = req.body;
-    const repoPath = req.body.path || req.query.path;
-
-    if (!worktreePath) {
-      return res.status(400).json({ error: 'path is required' });
-    }
-
-    const args = ['worktree', lock ? 'lock' : 'unlock', worktreePath];
-    jsonResultOrFailProm(res, gitPromise(args, repoPath));
-  });
+  );
 
   app.get(`${exports.pathPrefix}/gitconfig`, ensureAuthenticated, (req, res) => {
     jsonResultOrFailProm(res, gitPromise(['config', '--list']).then(gitParser.parseGitConfig));

--- a/source/git-api.js
+++ b/source/git-api.js
@@ -146,6 +146,7 @@ exports.registerApi = (env) => {
     });
     await watcher.addGit(path.join(repoPath, 'HEAD'));
     await watcher.addGit(path.join(repoPath, 'index'));
+    await watcher.addGit(path.join(repoPath, 'worktrees'));
 
     return watcher;
   };
@@ -989,6 +990,90 @@ exports.registerApi = (env) => {
         .finally(emitWorkingTreeChanged.bind(null, req.query.path));
     }
   );
+
+  app.get(`${exports.pathPrefix}/worktrees`, ensureAuthenticated, ensurePathExists, (req, res) => {
+    jsonResultOrFailProm(
+      res,
+      gitPromise(['worktree', 'list', '--porcelain'], req.query.path)
+        .then(gitParser.parseWorktreeList)
+        .then(async (worktrees) => {
+          for (const worktree of worktrees) {
+            try {
+              const status = await gitPromise(['status', '--porcelain'], worktree.path);
+              if (!status || status.trim() === '') {
+                worktree.status = 'clean';
+              } else if (status.includes('UU ') || status.includes('AA ')) {
+                worktree.status = 'conflicts';
+              } else {
+                worktree.status = 'dirty';
+              }
+            } catch {
+              worktree.status = 'unknown';
+            }
+          }
+          return worktrees;
+        })
+    );
+  });
+
+  app.post(`${exports.pathPrefix}/worktrees`, ensureAuthenticated, ensurePathExists, async (req, res) => {
+    const { worktreePath, branch, createBranch } = req.body;
+    const repoPath = req.body.path || req.query.path;
+
+    if (!worktreePath || !branch) {
+      return res.status(400).json({ error: 'path and branch are required' });
+    }
+
+    try {
+      await fs.access(worktreePath);
+      return res.status(400).json({ error: 'path already exists' });
+    } catch {}
+
+    const args = ['worktree', 'add'];
+    if (createBranch) {
+      args.push('-b', branch, worktreePath);
+    } else {
+      args.push(worktreePath, branch);
+    }
+
+    jsonResultOrFailProm(
+      res,
+      gitPromise(args, repoPath).then(() =>
+        gitPromise(['worktree', 'list', '--porcelain'], repoPath)
+          .then(gitParser.parseWorktreeList)
+          .then((worktrees) => worktrees.find((w) => w.path === worktreePath))
+      )
+    );
+  });
+
+  app.delete(`${exports.pathPrefix}/worktrees`, ensureAuthenticated, ensurePathExists, (req, res) => {
+    const { worktreePath, force } = req.query;
+    const repoPath = req.query.path;
+
+    if (!worktreePath) {
+      return res.status(400).json({ error: 'path is required' });
+    }
+
+    const args = ['worktree', 'remove'];
+    if (force === 'true') {
+      args.push('--force');
+    }
+    args.push(worktreePath);
+
+    jsonResultOrFailProm(res, gitPromise(args, repoPath));
+  });
+
+  app.post(`${exports.pathPrefix}/worktrees/lock`, ensureAuthenticated, ensurePathExists, (req, res) => {
+    const { worktreePath, lock } = req.body;
+    const repoPath = req.body.path || req.query.path;
+
+    if (!worktreePath) {
+      return res.status(400).json({ error: 'path is required' });
+    }
+
+    const args = ['worktree', lock ? 'lock' : 'unlock', worktreePath];
+    jsonResultOrFailProm(res, gitPromise(args, repoPath));
+  });
 
   app.get(`${exports.pathPrefix}/gitconfig`, ensureAuthenticated, (req, res) => {
     jsonResultOrFailProm(res, gitPromise(['config', '--list']).then(gitParser.parseGitConfig));

--- a/source/git-parser.js
+++ b/source/git-parser.js
@@ -430,3 +430,31 @@ exports.parsePatchDiffResult = (patchLineList, text) => {
     return null;
   }
 };
+
+exports.parseWorktreeList = (text) => {
+  if (!text || !text.trim()) return [];
+
+  const worktrees = [];
+  const lines = text.trim().split('\n');
+  let current = null;
+
+  for (const line of lines) {
+    if (line.startsWith('worktree ')) {
+      if (current) worktrees.push(current);
+      current = { path: line.slice(9) };
+    } else if (current) {
+      if (line.startsWith('HEAD ')) {
+        current.head = line.slice(5);
+      } else if (line.startsWith('branch ')) {
+        current.branch = line.slice(7).replace('refs/heads/', '');
+      } else if (line.startsWith('locked ')) {
+        current.locked = line.slice(7) || true;
+      } else if (line.startsWith('prunable ')) {
+        current.prunable = line.slice(9) || true;
+      }
+    }
+  }
+
+  if (current) worktrees.push(current);
+  return worktrees;
+};

--- a/test/spec.graph-worktrees.js
+++ b/test/spec.graph-worktrees.js
@@ -1,0 +1,227 @@
+const expect = require('expect.js');
+const fs = require('fs');
+const ko = require('knockout');
+const path = require('path');
+const vm = require('vm');
+
+describe('graph worktree refs', () => {
+  function createRefViewModelClass(args = {}) {
+    const source = fs.readFileSync(path.join(__dirname, '../components/graph/git-ref.js'), {
+      encoding: 'utf8',
+    });
+    const navigation = args.navigation || { browseTo: () => {} };
+    const sandbox = {
+      module: { exports: {} },
+      exports: {},
+      ungit: {
+        logger: {
+          warn: () => {},
+        },
+      },
+      require: (name) => {
+        if (name === 'knockout') return ko;
+        if (name === 'blueimp-md5') return () => ({ toString: () => '1234567890' });
+        if (name === 'octicons') {
+          return {
+            globe: { toSVG: () => '<svg class="globe"></svg>' },
+            'git-branch': { toSVG: () => '<svg class="branch"></svg>' },
+            tag: { toSVG: () => '<svg class="tag"></svg>' },
+          };
+        }
+        if (name === 'ungit-program-events') return { dispatch: () => {} };
+        if (name === 'ungit-components') return { showModal: () => {} };
+        if (name === 'ungit-navigation') return navigation;
+        if (name === 'ungit-address-parser') return { encodePath: encodeURIComponent };
+        if (name === './selectable') {
+          return class Selectable {
+            constructor(graph) {
+              this.selected = ko.computed({
+                read() {
+                  return graph.currentActionContext() == this;
+                },
+                write(value) {
+                  graph.currentActionContext(value ? this : null);
+                },
+                owner: this,
+              });
+            }
+          };
+        }
+        throw new Error(`Unexpected require: ${name}`);
+      },
+    };
+    vm.runInNewContext(source, sandbox);
+    return sandbox.module.exports;
+  }
+
+  function createGraph(path = '/repos/current', branch = 'main') {
+    const posts = [];
+    return {
+      posts,
+      currentActionContext: ko.observable(),
+      checkedOutBranch: ko.observable(branch),
+      HEADref: () => ({ node: () => {} }),
+      repoPath: () => path,
+      getRef: () => null,
+      server: {
+        postPromise: (url, body) => {
+          posts.push({ url, body });
+          return Promise.resolve({});
+        },
+        unhandledRejection: () => {},
+      },
+    };
+  }
+
+  function createGraphViewModel(args = {}) {
+    const source = fs.readFileSync(path.join(__dirname, '../components/graph/graph.js'), {
+      encoding: 'utf8',
+    });
+    const registered = {};
+    const sandbox = {
+      window: { innerHeight: 800 },
+      ungit: {
+        config: {
+          numberOfNodesPerLoad: 100,
+          numRefsToShow: 10,
+        },
+        logger: {
+          debug: () => {},
+        },
+      },
+      require: (name) => {
+        if (name === 'knockout') return ko;
+        if (name === 'lodash') {
+          return {
+            debounce: (fn) => fn,
+          };
+        }
+        if (name === 'moment') return () => ({ valueOf: () => 1 });
+        if (name === 'octicons') {
+          return {
+            search: { toSVG: () => '<svg></svg>' },
+            plus: { toSVG: () => '<svg></svg>' },
+          };
+        }
+        if (name === 'ungit-components') {
+          return {
+            register: (componentName, creator) => {
+              registered[componentName] = creator;
+            },
+          };
+        }
+        if (name === './git-node') {
+          return class GitNodeViewModel {};
+        }
+        if (name === './git-ref') return createRefViewModelClass();
+        if (name === './edge') return class EdgeViewModel {};
+        if (name === '../ComponentRoot') {
+          return {
+            ComponentRoot: class ComponentRoot {
+              constructor() {
+                this.defaultDebounceOption = {};
+              }
+
+              isSamePayload() {
+                return false;
+              }
+            },
+          };
+        }
+        throw new Error(`Unexpected require: ${name}`);
+      },
+    };
+    vm.runInNewContext(source, sandbox);
+
+    const calls = [];
+    const server = args.server || {
+      getPromise: (url) => {
+        calls.push(url);
+        if (url === '/gitlog') return Promise.resolve({ nodes: [] });
+        if (url === '/checkout') return Promise.resolve('main');
+        if (url === '/worktrees') {
+          return Promise.resolve([
+            { path: '/repos/current', branch: 'main', status: 'clean' },
+            { path: '/repos/current-feature-demo', branch: 'feature/demo', status: 'dirty' },
+          ]);
+        }
+        return Promise.resolve({});
+      },
+      unhandledRejection: () => {},
+    };
+    const repoPath = args.repoPath || (() => '/repos/current');
+
+    return {
+      calls,
+      viewModel: registered.graph({ server, repoPath }),
+    };
+  }
+
+  it('renders a marker for a branch checked out in another worktree', () => {
+    const RefViewModel = createRefViewModelClass();
+    const ref = new RefViewModel('refs/heads/feature/demo', createGraph());
+
+    ref.worktree({
+      path: '/repos/current-feature-demo',
+      branch: 'feature/demo',
+      status: 'dirty',
+    });
+
+    const html = ref.displayHtml();
+
+    expect(html).to.contain('feature/demo');
+    expect(html).to.contain('worktree-ref-marker');
+    expect(html).to.contain('>current-feature-demo</span>');
+    expect(html).to.contain('status-dirty');
+    expect(html).to.contain('Checked out in /repos/current-feature-demo');
+  });
+
+  it('does not render the other-worktree marker for the current repo path', () => {
+    const RefViewModel = createRefViewModelClass();
+    const ref = new RefViewModel('refs/heads/main', createGraph('/repos/current', 'main'));
+
+    ref.worktree({
+      path: '/repos/current',
+      branch: 'main',
+      status: 'clean',
+    });
+
+    expect(ref.displayHtml()).to.not.contain('worktree-ref-marker');
+  });
+
+  it('loads worktrees into matching graph branch refs', async () => {
+    const { viewModel } = createGraphViewModel();
+    const currentRef = viewModel.getRef('refs/heads/main');
+    const featureRef = viewModel.getRef('refs/heads/feature/demo');
+
+    await viewModel._updateWorktrees();
+
+    expect(currentRef.worktree().path).to.be('/repos/current');
+    expect(featureRef.worktree().path).to.be('/repos/current-feature-demo');
+    expect(featureRef.displayHtml()).to.contain('worktree-ref-marker');
+  });
+
+  it('switches to another worktree instead of checking out its branch in the current path', async () => {
+    const browsedTo = [];
+    const RefViewModel = createRefViewModelClass({
+      navigation: {
+        browseTo(path) {
+          browsedTo.push(path);
+        },
+      },
+    });
+    const graph = createGraph('/repos/current', 'main');
+    const ref = new RefViewModel('refs/heads/bugfix/hotfix', graph);
+
+    ref.worktree({
+      path: '/repos/current-hotfix',
+      branch: 'bugfix/hotfix',
+      status: 'clean',
+    });
+
+    await ref.checkout();
+
+    expect(browsedTo).to.eql(['repository?path=%2Frepos%2Fcurrent-hotfix']);
+    expect(graph.posts).to.eql([]);
+  });
+});

--- a/test/spec.worktrees.js
+++ b/test/spec.worktrees.js
@@ -1,0 +1,260 @@
+const expect = require('expect.js');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('worktrees component', () => {
+  function createObservable(initialValue) {
+    let value = initialValue;
+    const observable = function (nextValue) {
+      if (arguments.length) value = nextValue;
+      return value;
+    };
+    observable.subscribe = () => {};
+    return observable;
+  }
+
+  function createWorktreesViewModel(args = {}) {
+    const source = fs.readFileSync(path.join(__dirname, '../components/worktrees/worktrees.js'), {
+      encoding: 'utf8',
+    });
+    const registered = {};
+    const renderCalls = [];
+    const shownModals = [];
+    const programEvents = {
+      dispatched: [],
+      dispatch(event) {
+        this.dispatched.push(event);
+      },
+    };
+    const navigation = {
+      browsedTo: [],
+      browseTo(path) {
+        this.browsedTo.push(path);
+      },
+    };
+    const sandbox = {
+      window: {
+        opened: [],
+        confirm: () => true,
+        open(url) {
+          this.opened.push(url);
+        },
+      },
+      ungit: {
+        config: {
+          fileSeparator: '/',
+        },
+      },
+      require: (name) => {
+        if (name === 'knockout') {
+          return {
+            observable: createObservable,
+            observableArray: (initialValue) => createObservable(initialValue),
+            computed: (fn) => fn,
+            renderTemplate: (...renderArgs) => renderCalls.push(renderArgs),
+          };
+        }
+        if (name === 'ungit-components') {
+          return {
+            register: (componentName, creator) => {
+              registered[componentName] = creator;
+            },
+            showModal: (modalName, modalArgs) => {
+              shownModals.push({ modalName, modalArgs });
+            },
+          };
+        }
+        if (name === 'octicons') {
+          return {
+            'git-branch': {
+              toSVG: () => '<svg></svg>',
+            },
+            'link-external': {
+              toSVG: () => '<svg class="link"></svg>',
+            },
+            x: {
+              toSVG: () => '<svg class="x"></svg>',
+            },
+          };
+        }
+        if (name === 'ungit-program-events') return programEvents;
+        if (name === 'ungit-navigation') return navigation;
+        if (name === 'ungit-address-parser') {
+          return {
+            encodePath: encodeURIComponent,
+          };
+        }
+        throw new Error(`Unexpected require: ${name}`);
+      },
+    };
+
+    vm.runInNewContext(source, sandbox);
+    const server = args.server || {
+      getPromise: () => Promise.resolve([]),
+      postPromise: () => Promise.resolve({}),
+      delPromise: () => Promise.resolve({}),
+      unhandledRejection: () => {},
+    };
+    const repoPath = args.repoPath || (() => '/repos/SleepyCats');
+
+    return {
+      viewModel: registered.worktrees({ server, repoPath }),
+      renderCalls,
+      shownModals,
+      programEvents,
+      navigation,
+      window: sandbox.window,
+    };
+  }
+
+  it('is exported as an ungit plugin', () => {
+    const manifestPath = path.join(__dirname, '../components/worktrees/ungit-plugin.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, { encoding: 'utf8' }));
+
+    expect(manifest.exports.javascript).to.be('worktrees.bundle.js');
+    expect(manifest.exports.css).to.be('worktrees.css');
+    expect(manifest.exports.knockoutTemplates.worktrees).to.be('worktrees.html');
+  });
+
+  it('registers a renderable component view model', () => {
+    const { viewModel, renderCalls } = createWorktreesViewModel();
+
+    expect(viewModel.updateNode).to.be.a('function');
+    viewModel.updateNode('parent');
+    expect(renderCalls[0][0]).to.be('worktrees');
+    expect(renderCalls[0][1]).to.be(viewModel);
+    expect(renderCalls[0][3]).to.be('parent');
+  });
+
+  it('uses the shared bootstrap dropdown behavior', () => {
+    const template = fs.readFileSync(
+      path.join(__dirname, '../components/worktrees/worktrees.html'),
+      {
+        encoding: 'utf8',
+      }
+    );
+
+    expect(template).to.contain('data-toggle="dropdown"');
+    expect(template).to.not.contain('css: { open: isOpen }');
+    expect(template).to.not.contain('click: toggle');
+    expect(template).to.not.contain('event.stopPropagation()');
+    expect(template).to.not.contain('worktree-lock');
+    expect(template).to.contain('html: $parent.linkIcon');
+    expect(template).to.contain('html: $parent.closeIcon');
+  });
+
+  it('loads worktrees', async () => {
+    const calls = [];
+    const { viewModel } = createWorktreesViewModel({
+      server: {
+        getPromise: (url, args) => {
+          calls.push({ url, args });
+          return Promise.resolve([{ path: '/repos/SleepyCats', branch: 'main' }]);
+        },
+      },
+    });
+
+    await viewModel.loadWorktrees();
+
+    expect(viewModel.worktrees()).to.eql([{ path: '/repos/SleepyCats', branch: 'main' }]);
+    expect(calls).to.eql([{ url: '/worktrees', args: { path: '/repos/SleepyCats' } }]);
+  });
+
+  it('identifies the current worktree', () => {
+    const { viewModel } = createWorktreesViewModel();
+
+    expect(viewModel.isCurrentWorktree({ path: '/repos/SleepyCats' })).to.be(true);
+    expect(viewModel.isCurrentWorktree({ path: '/repos/SleepyCats-feature' })).to.be(false);
+  });
+
+  it('treats absent locked values as unlocked', async () => {
+    const calls = [];
+    const { viewModel } = createWorktreesViewModel({
+      server: {
+        getPromise: () => Promise.resolve([]),
+        postPromise: (url, body) => {
+          calls.push({ url, body });
+          return Promise.resolve({});
+        },
+      },
+    });
+
+    await viewModel.toggleLock({ path: '/repos/SleepyCats-feature' });
+
+    expect(calls).to.eql([
+      {
+        url: '/worktrees/lock',
+        body: {
+          path: '/repos/SleepyCats',
+          worktreePath: '/repos/SleepyCats-feature',
+          lock: true,
+        },
+      },
+    ]);
+  });
+
+  it('confirms worktree removal with the shared modal', async () => {
+    const calls = [];
+    const { viewModel, shownModals } = createWorktreesViewModel({
+      server: {
+        getPromise: (url, args) => {
+          calls.push({ method: 'get', url, args });
+          return Promise.resolve([]);
+        },
+        delPromise: (url, args) => {
+          calls.push({ method: 'del', url, args });
+          return Promise.resolve({});
+        },
+      },
+    });
+
+    viewModel.removeWorktree({ path: '/repos/SleepyCats-feature' });
+
+    expect(calls).to.eql([]);
+    expect(shownModals.length).to.be(1);
+    expect(shownModals[0].modalName).to.be('yesnomodal');
+    expect(shownModals[0].modalArgs.title).to.be('Are you sure?');
+    expect(shownModals[0].modalArgs.details).to.be(
+      'Removing /repos/SleepyCats-feature worktree cannot be undone with ungit.'
+    );
+
+    shownModals[0].modalArgs.closeFunc(false);
+    expect(calls).to.eql([]);
+
+    await shownModals[0].modalArgs.closeFunc(true);
+    expect(calls).to.eql([
+      {
+        method: 'del',
+        url: '/worktrees',
+        args: {
+          path: '/repos/SleepyCats',
+          worktreePath: '/repos/SleepyCats-feature',
+        },
+      },
+      {
+        method: 'get',
+        url: '/worktrees',
+        args: { path: '/repos/SleepyCats' },
+      },
+    ]);
+  });
+
+  it('opens the worktree create modal from graph create-worktree events', () => {
+    const { viewModel, shownModals } = createWorktreesViewModel();
+
+    viewModel.onProgramEvent({ event: 'create-worktree', branch: 'feature/demo' });
+
+    expect(shownModals).to.eql([
+      {
+        modalName: 'addworktreemodal',
+        modalArgs: {
+          path: '/repos/SleepyCats',
+          branch: 'feature/demo',
+          worktreePath: '/repos/SleepyCats-feature-demo',
+          createBranch: true,
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
This PR adds support for git worktree:
  - List repository worktrees from a new Worktrees dropdown, including branch name, current-worktree marker, and clean/dirty/conflict status
  - Create/remove a worktree
  - Switch the current ungit view to another worktree or open it in a new browser tab
  - Mark graph branch labels when a branch is checked out in another worktree
  - Merging from different worktree seamlessly.
  - Refresh graph and worktree UI when Git worktree metadata changes
  - 
<img width="1488" height="1171" alt="Screenshot 2026-05-08 at 17 42 51" src="https://github.com/user-attachments/assets/5561a0f4-a351-4cd2-abcf-c9a79fb6b472" />
