### PR TITLE
Fix archiver ESM compatibility in electronzip.js

### DIFF
--- a/scripts/electronzip.js
+++ b/scripts/electronzip.js
@@ -37,7 +37,7 @@ const distDir = path.join(baseDir, 'dist');
 async function zipDirectory(source, destination) {
   console.log(`start zip ${path.relative(baseDir, destination)}`);
   await new Promise((resolve, reject) => {
-    const archive = archiver.create('zip', {
+    const archive = new archiver.ZipArchive({
       zlib: { level: 9 },
     });
     const stream = fsSync.createWriteStream(destination);

--- a/scripts/electronzip.js
+++ b/scripts/electronzip.js
@@ -37,7 +37,9 @@ const distDir = path.join(baseDir, 'dist');
 async function zipDirectory(source, destination) {
   console.log(`start zip ${path.relative(baseDir, destination)}`);
   await new Promise((resolve, reject) => {
-    const archive = archiver('zip');
+    const archive = archiver.create('zip', {
+      zlib: { level: 9 },
+    });
     const stream = fsSync.createWriteStream(destination);
 
     archive


### PR DESCRIPTION
Update archiver usage to be compatible with archiver 8.0.0+ (ESM module).
Changed from archiver('zip') to new archiver.ZipArchive() with compression
level settings to properly instantiate the archiver.